### PR TITLE
Add sample activities chart

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -1,0 +1,44 @@
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
+import { useGarminData } from "@/hooks/useGarminData";
+
+const chartConfig = {
+  distance: {
+    label: "Distance (km)",
+    color: "var(--chart-1)",
+  },
+  duration: {
+    label: "Duration (min)",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+export function ActivitiesChart() {
+  const data = useGarminData();
+  if (!data) return null;
+  const activities = data.activities;
+
+  return (
+    <ChartContainer config={chartConfig} className="h-60">
+      <LineChart data={activities} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+        <YAxis yAxisId="left" orientation="left" />
+        <YAxis yAxisId="right" orientation="right" />
+        <ChartTooltip
+          content={<ChartTooltipContent labelFormatter={(d) => new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })} />}
+        />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Line yAxisId="left" type="monotone" dataKey="distance" stroke={chartConfig.distance.color} />
+        <Line yAxisId="right" type="monotone" dataKey="duration" stroke={chartConfig.duration.color} />
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -4,10 +4,11 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
 
 import type { GarminDay } from "@/lib/api";
-import { useGarminData } from "@/hooks/useGarminData";
+import { useDailySteps } from "@/hooks/useGarminData";
 
 const chartConfig = {
   steps: {
@@ -17,7 +18,7 @@ const chartConfig = {
 } satisfies ChartConfig;
 
 export function StepsChart() {
-  const { data } = useGarminData<GarminDay[]>();
+  const data = useDailySteps();
   if (!data) return null;
 
   // assume data is an array like [{ date: "2025-07-01", steps: 8000 }, …]

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -207,13 +207,11 @@ const ChartTooltipContent = React.forwardRef<
                         <div
                           className={cn(
                             "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
-                            {
-                              "h-2.5 w-2.5": indicator === "dot",
-                              "w-1": indicator === "line",
-                              "w-0 border-[1.5px] border-dashed bg-transparent":
-                                indicator === "dashed",
-                              "my-0.5": nestLabel && indicator === "dashed",
-                            }
+                            indicator === "dot" && "h-2.5 w-2.5",
+                            indicator === "line" && "w-1",
+                            indicator === "dashed" &&
+                              "w-0 border-[1.5px] border-dashed bg-transparent",
+                            nestLabel && indicator === "dashed" && "my-0.5"
                           )}
                           style={
                             {

--- a/src/hooks/useGarminData.ts
+++ b/src/hooks/useGarminData.ts
@@ -1,10 +1,18 @@
 import { useState, useEffect } from "react";
-import { getGarminData, GarminData } from "@/lib/api";
+import { getGarminData, getDailySteps, GarminData, GarminDay } from "@/lib/api";
 
 export function useGarminData(): GarminData | null {
   const [data, setData] = useState<GarminData | null>(null);
   useEffect(() => {
     getGarminData().then(setData);
+  }, []);
+  return data;
+}
+
+export function useDailySteps(): GarminDay[] | null {
+  const [data, setData] = useState<GarminDay[] | null>(null);
+  useEffect(() => {
+    getDailySteps().then(setData);
   }, []);
   return data;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,6 +14,21 @@ export type GarminData = {
   activities: Activity[];
 };
 
+export type GarminDay = {
+  date: string;
+  steps: number;
+};
+
+export const mockDailySteps: GarminDay[] = [
+  { date: "2025-07-24", steps: 7500 },
+  { date: "2025-07-25", steps: 8200 },
+  { date: "2025-07-26", steps: 6100 },
+  { date: "2025-07-27", steps: 9450 },
+  { date: "2025-07-28", steps: 10020 },
+  { date: "2025-07-29", steps: 8456 },
+  { date: "2025-07-30", steps: 10342 },
+];
+
 export const mockGarminData: GarminData = {
   steps: 10342,
   sleep: 7.4,
@@ -28,5 +43,11 @@ export const mockGarminData: GarminData = {
 export async function getGarminData(): Promise<GarminData> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(mockGarminData), 500);
+  });
+}
+
+export async function getDailySteps(): Promise<GarminDay[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockDailySteps), 300);
   });
 }


### PR DESCRIPTION
## Summary
- support daily steps data in API and expose via `useDailySteps` hook
- tweak chart tooltip indicator class merging
- update `StepsChart` to use new hook
- add `ActivitiesChart` as an example chart

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688af4b7592c832488685c95cf610e04