### PR TITLE
Add charts to dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Card } from "@/components/ui/card";
 import { ProgressRing } from "@/components/dashboard/ProgressRing";
+import { ActivitiesChart } from "@/components/dashboard/ActivitiesChart";
+import { StepsChart } from "@/components/dashboard/StepsChart";
 import { useGarminData } from "@/hooks/useGarminData";
 
 export default function Dashboard() {
@@ -11,29 +13,39 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-      <Card className="flex flex-col items-center">
-        <h2 className="text-sm mb-2">Steps</h2>
-        <ProgressRing value={(data.steps / 10000) * 100} />
-        <span className="mt-2 text-lg font-bold">{data.steps}</span>
+    <div className="grid gap-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card className="flex flex-col items-center">
+          <h2 className="text-sm mb-2">Steps</h2>
+          <ProgressRing value={(data.steps / 10000) * 100} />
+          <span className="mt-2 text-lg font-bold">{data.steps}</span>
+        </Card>
+
+        <Card className="flex flex-col items-center">
+          <h2 className="text-sm mb-2">Sleep (hrs)</h2>
+          <ProgressRing value={(data.sleep / 8) * 100} />
+          <span className="mt-2 text-lg font-bold">{data.sleep}</span>
+        </Card>
+
+        <Card className="flex flex-col items-center">
+          <h2 className="text-sm mb-2">Heart Rate</h2>
+          <ProgressRing value={(data.heartRate / 200) * 100} />
+          <span className="mt-2 text-lg font-bold">{data.heartRate}</span>
+        </Card>
+
+        <Card className="flex flex-col items-center">
+          <h2 className="text-sm mb-2">Calories</h2>
+          <ProgressRing value={(data.calories / 3000) * 100} />
+          <span className="mt-2 text-lg font-bold">{data.calories}</span>
+        </Card>
+      </div>
+
+      <Card className="md:col-span-2 p-4">
+        <StepsChart />
       </Card>
 
-      <Card className="flex flex-col items-center">
-        <h2 className="text-sm mb-2">Sleep (hrs)</h2>
-        <ProgressRing value={(data.sleep / 8) * 100} />
-        <span className="mt-2 text-lg font-bold">{data.sleep}</span>
-      </Card>
-
-      <Card className="flex flex-col items-center">
-        <h2 className="text-sm mb-2">Heart Rate</h2>
-        <ProgressRing value={(data.heartRate / 200) * 100} />
-        <span className="mt-2 text-lg font-bold">{data.heartRate}</span>
-      </Card>
-
-      <Card className="flex flex-col items-center">
-        <h2 className="text-sm mb-2">Calories</h2>
-        <ProgressRing value={(data.calories / 3000) * 100} />
-        <span className="mt-2 text-lg font-bold">{data.calories}</span>
+      <Card className="md:col-span-2 p-4">
+        <ActivitiesChart />
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- import StepsChart and ActivitiesChart
- display activity and step charts beneath metrics cards on the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688af7d9dd608324813bd555d0fe43a5