### PR TITLE
use Shadcn chart wrapper

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -4,9 +4,13 @@ import {
   ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
-import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
 import { useGarminData } from "@/hooks/useGarminData";
 
 const chartConfig = {

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -3,9 +3,13 @@ import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
 } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
 
 import type { GarminDay } from "@/lib/api";
 import { useDailySteps } from "@/hooks/useGarminData";

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,6 +1,20 @@
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
+export {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  Line,
+  LineChart,
+  CartesianGrid,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+} from "recharts"
+
 import { cn } from "@/lib/utils"
 
 // Format: { THEME_NAME: CSS_SELECTOR }


### PR DESCRIPTION
## Summary
- re-export Recharts primitives from the Shadcn chart wrapper
- switch dashboard charts to import primitives from the wrapper

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688af9fee37483249d6d4512ca0282eb