### PR TITLE
Fix warning by using CommonJS in PostCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- use `module.exports` syntax in `postcss.config.js` to avoid Node's moduless config warning

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688afbec7f48832484e3f374132ffe11