### PR TITLE
Fix RunDistancesChart import

### DIFF
--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -4,6 +4,7 @@ import {
   Bar,
   XAxis,
   YAxis,
+  Tooltip,
 } from '@/components/ui/chart'
 
 export interface DistanceBucket {


### PR DESCRIPTION
## Summary
- include Tooltip in `RunDistancesChart`

## Testing
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'react-simple-maps' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b5eb356108324a17a3f6703af13b2