### PR TITLE
Fix MapChart typings and add module stub

### DIFF
--- a/src/components/dashboard/MapChart.tsx
+++ b/src/components/dashboard/MapChart.tsx
@@ -14,8 +14,8 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
   return (
     <ComposableMap projection="geoAlbersUsa" width={800} height={400}>
       <Geographies geography="/us-states.json">
-        {({ geographies }) =>
-          geographies.map((geo) => {
+        {({ geographies }: { geographies: any[] }) =>
+          geographies.map((geo: any) => {
             const code = fipsToAbbr[geo.id as string];
             const isVisited = code ? visited.has(code) : false;
             return (

--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -4,6 +4,7 @@ import {
   Bar,
   XAxis,
   YAxis,
+  Tooltip,
 } from '@/components/ui/chart'
 
 export interface DistanceBucket {

--- a/src/components/dashboard/StateTable.tsx
+++ b/src/components/dashboard/StateTable.tsx
@@ -12,7 +12,7 @@ interface StateTableProps {
 export default function StateTable({ data, selectedState, onSelectState }: StateTableProps) {
   return (
     <Card className="p-2">
-      <Accordion type="single" collapsible value={selectedState || undefined} onValueChange={onSelectState}>
+      <Accordion value={selectedState || undefined} onValueChange={onSelectState}>
         {data
           .filter((d) => d.visited)
           .map((d) => (

--- a/src/types/react-simple-maps.d.ts
+++ b/src/types/react-simple-maps.d.ts
@@ -1,0 +1,1 @@
+declare module "react-simple-maps";


### PR DESCRIPTION
## Summary
- add missing module declaration for `react-simple-maps`
- provide explicit any typings in `MapChart`
- fix chart tooltip import
- drop unsupported props from `StateTable`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688b5ebeb9208324880f962b66c72533