### PR TITLE
Remove unused accordion props

### DIFF
--- a/src/components/dashboard/StateTable.tsx
+++ b/src/components/dashboard/StateTable.tsx
@@ -12,7 +12,7 @@ interface StateTableProps {
 export default function StateTable({ data, selectedState, onSelectState }: StateTableProps) {
   return (
     <Card className="p-2">
-      <Accordion type="single" collapsible value={selectedState || undefined} onValueChange={onSelectState}>
+      <Accordion value={selectedState || undefined} onValueChange={onSelectState}>
         {data
           .filter((d) => d.visited)
           .map((d) => (


### PR DESCRIPTION
## Summary
- use default Accordion props in `StateTable`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688b5eba3d148324917777302df06705