### PR TITLE
Add consistent chart headers and theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ create semi-random demo data each time the app loads. You can replace this
 function with real API calls for production data.
 
 ## Charts & maps
-All charts should be wrapped in Shadcn’s `<ChartContainer>` so they inherit CSS variables for colours and spacing.
+All charts should be wrapped in Shadcn’s `<ChartContainer>` so they inherit CSS variables for colours and spacing. Include a <ChartHeader> for titles so typography stays consistent.
 
 Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can reference shared styling from `ui/...`.
 

--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -30,7 +30,12 @@ export function ActivitiesChart() {
   const activities = data.activities;
 
   return (
-    <ChartContainer config={chartConfig} className="h-60">
+    <ChartContainer
+      config={chartConfig}
+      className="h-60"
+      title="Activities"
+      subtitle="Distance vs Duration"
+    >
       <LineChart data={activities} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/dashboard/AnnualMileageChart.tsx
+++ b/src/components/dashboard/AnnualMileageChart.tsx
@@ -20,7 +20,11 @@ interface AnnualMileageChartProps {
 export function AnnualMileageChart({ data }: AnnualMileageChartProps) {
   const config = { totalMiles: { color: 'hsl(var(--chart-7))' } }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Annual Mileage'
+    >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray='3 3' />
         <XAxis dataKey='year' />

--- a/src/components/dashboard/AverageDailyMileageChart.tsx
+++ b/src/components/dashboard/AverageDailyMileageChart.tsx
@@ -20,7 +20,11 @@ interface AverageDailyMileageChartProps {
 export function AverageDailyMileageChart({ data, maxPct }: AverageDailyMileageChartProps) {
   const config = { pct: { color: 'hsl(var(--chart-9))' } }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Daily Mileage by Day'
+    >
       <RadarChart data={data}>
         <PolarGrid stroke='hsl(var(--muted))' />
         <PolarAngleAxis dataKey='day' />

--- a/src/components/dashboard/HeartRateZonesChart.tsx
+++ b/src/components/dashboard/HeartRateZonesChart.tsx
@@ -22,7 +22,11 @@ export function HeartRateZonesChart({ data }: HeartRateZonesChartProps) {
     count: { color: 'hsl(var(--chart-2))' },
   }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Heart Rate Zones'
+    >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid stroke='hsl(var(--muted))' />
         <XAxis dataKey='zone' />

--- a/src/components/dashboard/MapChart.tsx
+++ b/src/components/dashboard/MapChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 import type { StateVisit } from "@/lib/types";
 import { fipsToAbbr } from "@/lib/stateCodes";
+import { ChartHeader } from "@/components/ui/chart-header";
 
 interface MapChartProps {
   data: StateVisit[];
@@ -12,10 +13,12 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
   const visited = new Set(data.filter((d) => d.visited).map((d) => d.stateCode));
 
   return (
-    <ComposableMap projection="geoAlbersUsa" width={800} height={400}>
-      <Geographies geography="/us-states.json">
-        {({ geographies }: { geographies: any[] }) =>
-          geographies.map((geo: any) => {
+    <div className="space-y-2">
+      <ChartHeader title="Visited States" />
+      <ComposableMap projection="geoAlbersUsa" width={800} height={400}>
+        <Geographies geography="/us-states.json">
+          {({ geographies }: { geographies: any[] }) =>
+            geographies.map((geo: any) => {
             const code = fipsToAbbr[geo.id as string];
             const isVisited = code ? visited.has(code) : false;
             return (
@@ -40,6 +43,7 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
           })
         }
       </Geographies>
-    </ComposableMap>
+      </ComposableMap>
+    </div>
   );
 }

--- a/src/components/dashboard/PaceDistributionChart.tsx
+++ b/src/components/dashboard/PaceDistributionChart.tsx
@@ -24,7 +24,11 @@ export function PaceDistributionChart({ data }: PaceDistributionChartProps) {
     lower: { color: 'hsl(var(--muted-foreground))' },
   }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Pace Distribution'
+    >
       <AreaChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray='3 3' />
         <XAxis dataKey='bin' />

--- a/src/components/dashboard/PaceVsHeartChart.tsx
+++ b/src/components/dashboard/PaceVsHeartChart.tsx
@@ -22,7 +22,11 @@ export function PaceVsHeartChart({ data }: PaceVsHeartChartProps) {
     value: { color: 'hsl(var(--chart-4))' },
   }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Pace vs Heart Rate'
+    >
       <ScatterChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid stroke='hsl(var(--muted))' />
         <XAxis dataKey='pace' type='number' reversed />

--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -19,7 +19,11 @@ interface RunDistancesChartProps {
 export function RunDistancesChart({ data }: RunDistancesChartProps) {
   const config = { count: { color: 'hsl(var(--chart-10))' } }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Run Distances'
+    >
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis type='number' hide />
         <YAxis dataKey='label' type='category' />

--- a/src/components/dashboard/StateTable.tsx
+++ b/src/components/dashboard/StateTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 import type { StateVisit } from "@/lib/types";
 import { Card } from "@/components/ui/card";
+import { ChartHeader } from "@/components/ui/chart-header";
 
 interface StateTableProps {
   data: StateVisit[];
@@ -11,7 +12,8 @@ interface StateTableProps {
 
 export default function StateTable({ data, selectedState, onSelectState }: StateTableProps) {
   return (
-    <Card className="p-2">
+    <Card className="p-2 space-y-2">
+      <ChartHeader title="Visited States" subtitle="Details" />
       <Accordion value={selectedState || undefined} onValueChange={onSelectState}>
         {data
           .filter((d) => d.visited)

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -27,7 +27,11 @@ export function StepsChart() {
 
   // assume data is an array like [{ date: "2025-07-01", steps: 8000 }, …]
   return (
-    <ChartContainer config={chartConfig} className="h-60">
+    <ChartContainer
+      config={chartConfig}
+      className="h-60"
+      title="Daily Steps"
+    >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/dashboard/TemperatureChart.tsx
+++ b/src/components/dashboard/TemperatureChart.tsx
@@ -19,7 +19,11 @@ interface TemperatureChartProps {
 export function TemperatureChart({ data }: TemperatureChartProps) {
   const config = { count: { color: 'hsl(var(--chart-5))' } }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Temperature'
+    >
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis type='number' hide />
         <YAxis dataKey='label' type='category' />

--- a/src/components/dashboard/TreadmillOutdoorChart.tsx
+++ b/src/components/dashboard/TreadmillOutdoorChart.tsx
@@ -21,7 +21,11 @@ export function TreadmillOutdoorChart({ data }: TreadmillOutdoorChartProps) {
     { name: 'treadmill', value: data.treadmill, fill: 'hsl(var(--chart-1))' },
   ]
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Treadmill vs Outdoor'
+    >
       <PieChart>
         <Pie
           data={chartData}

--- a/src/components/dashboard/WeatherConditionsChart.tsx
+++ b/src/components/dashboard/WeatherConditionsChart.tsx
@@ -40,7 +40,11 @@ interface WeatherConditionsChartProps {
 export function WeatherConditionsChart({ data }: WeatherConditionsChartProps) {
   const config = { count: { color: 'hsl(var(--chart-6))' } }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Weather Conditions'
+    >
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis type='number' hide />
         <YAxis dataKey='label' type='category' tick={<AxisTick />} />

--- a/src/components/dashboard/WorkoutTimeChart.tsx
+++ b/src/components/dashboard/WorkoutTimeChart.tsx
@@ -20,7 +20,11 @@ interface WorkoutTimeChartProps {
 export function WorkoutTimeChart({ data, maxPct }: WorkoutTimeChartProps) {
   const config = { pct: { color: 'hsl(var(--chart-8))' } }
   return (
-    <ChartContainer config={config} className='h-60'>
+    <ChartContainer
+      config={config}
+      className='h-60'
+      title='Workout Activity by Time'
+    >
       <RadarChart data={data}>
         <PolarGrid stroke='hsl(var(--muted))' />
         <PolarAngleAxis dataKey='hour' />

--- a/src/components/ui/chart-header.tsx
+++ b/src/components/ui/chart-header.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ChartHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  title?: string;
+  subtitle?: string;
+}
+
+export const ChartHeader = React.forwardRef<HTMLDivElement, ChartHeaderProps>(
+  ({ title, subtitle, className, ...props }, ref) => {
+    if (!title && !subtitle) return null;
+    return (
+      <div
+        ref={ref}
+        className={cn("text-center space-y-0.5", className)}
+        {...props}
+      >
+        {title && (
+          <h3 className="text-sm font-medium tracking-wide uppercase">
+            {title}
+          </h3>
+        )}
+        {subtitle && (
+          <p className="text-xs text-muted-foreground">{subtitle}</p>
+        )}
+      </div>
+    );
+  }
+);
+ChartHeader.displayName = "ChartHeader";
+

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -26,6 +26,7 @@ export {
 } from "recharts"
 
 import { cn } from "@/lib/utils"
+import { ChartHeader } from "./chart-header"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -63,8 +64,10 @@ const ChartContainer = React.forwardRef<
     children: React.ComponentProps<
       typeof RechartsPrimitive.ResponsiveContainer
     >["children"]
+    title?: string
+    subtitle?: string
   }
->(({ id, className, children, config, ...props }, ref) => {
+>(({ id, className, children, config, title, subtitle, ...props }, ref) => {
   const uniqueId = React.useId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
 
@@ -74,15 +77,20 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex flex-col text-xs space-y-2 [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}
       >
+        {(title || subtitle) && (
+          <ChartHeader title={title} subtitle={subtitle} />
+        )}
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
-          {children}
-        </RechartsPrimitive.ResponsiveContainer>
+        <div className="flex-1">
+          <RechartsPrimitive.ResponsiveContainer>
+            {children}
+          </RechartsPrimitive.ResponsiveContainer>
+        </div>
       </div>
     </ChartContext.Provider>
   )


### PR DESCRIPTION
## Summary
- add `ChartHeader` primitive
- update `ChartContainer` to support `title` and `subtitle`
- use `ChartHeader` across dashboard charts
- document header usage in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b614d21a88324ae649c5dd0960807