### PR TITLE
Add chart primary and axis line tokens

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,6 +12,8 @@
     --primary-foreground: 210 40% 98%;
     --muted: 210 40% 96%;
     --muted-foreground: 215 16% 47%;
+    --chart-primary: var(--chart-1);
+    --axis-line: var(--muted-foreground);
   }
   :root {
     --chart-1: oklch(0.646 0.222 41.116);
@@ -35,6 +37,8 @@
     --primary-foreground: 222 47% 11%;
     --muted: 217 33% 20%;
     --muted-foreground: 215 20% 65%;
+    --chart-primary: var(--chart-1);
+    --axis-line: var(--muted-foreground);
   }
 
   html, body {


### PR DESCRIPTION
## Summary
- expose `--chart-primary` and `--axis-line` design tokens
- map them to existing palette colours in both light and dark themes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b6a18ec948324b6904e7379222448