### PR TITLE
Add accessible labels to StepsChart

### DIFF
--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -9,6 +9,7 @@ import {
   YAxis,
   CartesianGrid,
 } from "@/components/ui/chart";
+import { Cell, type TooltipProps } from "recharts";
 import type { ChartConfig } from "@/components/ui/chart";
 
 import type { GarminDay } from "@/lib/api";
@@ -22,17 +23,47 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
+function StepsTooltip(props: TooltipProps<number, string>) {
+  const { active, payload } = props;
+  let summary: string | null = null;
+  if (
+    active &&
+    payload &&
+    payload.length &&
+    payload[0].payload &&
+    payload[0].value !== undefined
+  ) {
+    const day = payload[0].payload as GarminDay;
+    summary = `${payload[0].value.toLocaleString()} steps on ${new Date(
+      day.date,
+    ).toLocaleDateString()}`;
+  }
+
+  return (
+    <div aria-live="polite">
+      <ChartTooltipContent
+        active={active}
+        payload={payload}
+        nameKey="steps"
+        labelFormatter={(d) =>
+          new Date(d).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+          })
+        }
+      />
+      {summary && <p className="sr-only">{summary}</p>}
+    </div>
+  );
+}
+
 export function StepsChart() {
   const data = useDailySteps();
   if (!data) return <Skeleton className="h-60 w-full" />;
 
   if (!data.length) {
     return (
-      <ChartContainer
-        config={chartConfig}
-        className="h-60"
-        title="Daily Steps"
-      >
+      <ChartContainer config={chartConfig} className="h-60" title="Daily Steps">
         <div className="flex h-full items-center justify-center text-muted-foreground">
           No data
         </div>
@@ -42,26 +73,26 @@ export function StepsChart() {
 
   // assume data is an array like [{ date: "2025-07-01", steps: 8000 }, …]
   return (
-    <ChartContainer
-      config={chartConfig}
-      className="h-60"
-      title="Daily Steps"
-    >
-      <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+    <ChartContainer config={chartConfig} className="h-60" title="Daily Steps">
+      <BarChart
+        data={data}
+        margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
+      >
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
-        <YAxis />
-        <ChartTooltip
-          content={
-            <ChartTooltipContent
-              nameKey="steps"
-              labelFormatter={(d) =>
-                new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })
-              }
-            />
-          }
+        <XAxis
+          dataKey="date"
+          tickFormatter={(d) => new Date(d).toLocaleDateString()}
         />
-        <Bar dataKey="steps" fill={chartConfig.steps.color} />
+        <YAxis />
+        <ChartTooltip content={<StepsTooltip />} />
+        <Bar dataKey="steps" fill={chartConfig.steps.color}>
+          {data.map((day) => (
+            <Cell
+              key={day.date}
+              aria-label={`${day.steps.toLocaleString()} steps on ${new Date(day.date).toLocaleDateString()}`}
+            />
+          ))}
+        </Bar>
       </BarChart>
     </ChartContainer>
   );


### PR DESCRIPTION
## Summary
- expose accessible info on steps bars
- add screen reader text in custom tooltip

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688b6c34a810832490b796f3b6134d88