### PR TITLE
Refine chart container styling

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -32,7 +32,7 @@ export function ActivitiesChart() {
   return (
     <ChartContainer
       config={chartConfig}
-      className="h-60"
+      className="h-60 md:col-span-2"
       title="Activities"
       subtitle="Distance vs Duration"
     >

--- a/src/components/dashboard/AnnualMileageChart.tsx
+++ b/src/components/dashboard/AnnualMileageChart.tsx
@@ -22,7 +22,7 @@ export function AnnualMileageChart({ data }: AnnualMileageChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Annual Mileage'
     >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/AverageDailyMileageChart.tsx
+++ b/src/components/dashboard/AverageDailyMileageChart.tsx
@@ -22,7 +22,7 @@ export function AverageDailyMileageChart({ data, maxPct }: AverageDailyMileageCh
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Daily Mileage by Day'
     >
       <RadarChart data={data}>

--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -27,7 +27,7 @@ export function DailyStepsChart({ data }: DailyStepsChartProps) {
   return (
     <ChartContainer
       config={chartConfig}
-      className="h-60"
+      className="h-60 md:col-span-2"
       title="Daily Steps"
     >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/HeartRateZonesChart.tsx
+++ b/src/components/dashboard/HeartRateZonesChart.tsx
@@ -24,7 +24,7 @@ export function HeartRateZonesChart({ data }: HeartRateZonesChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Heart Rate Zones'
     >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/PaceDistributionChart.tsx
+++ b/src/components/dashboard/PaceDistributionChart.tsx
@@ -26,7 +26,7 @@ export function PaceDistributionChart({ data }: PaceDistributionChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Pace Distribution'
     >
       <AreaChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/PaceVsHeartChart.tsx
+++ b/src/components/dashboard/PaceVsHeartChart.tsx
@@ -24,7 +24,7 @@ export function PaceVsHeartChart({ data }: PaceVsHeartChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Pace vs Heart Rate'
     >
       <ScatterChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -21,7 +21,7 @@ export function RunDistancesChart({ data }: RunDistancesChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Run Distances'
     >
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -30,7 +30,7 @@ export function StepsChart() {
     return (
       <ChartContainer
         config={chartConfig}
-        className="h-60"
+        className="h-60 md:col-span-2"
         title="Daily Steps"
       >
         <div className="flex h-full items-center justify-center text-muted-foreground">
@@ -44,7 +44,7 @@ export function StepsChart() {
   return (
     <ChartContainer
       config={chartConfig}
-      className="h-60"
+      className="h-60 md:col-span-2"
       title="Daily Steps"
     >
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/TemperatureChart.tsx
+++ b/src/components/dashboard/TemperatureChart.tsx
@@ -21,7 +21,7 @@ export function TemperatureChart({ data }: TemperatureChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Temperature'
     >
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>

--- a/src/components/dashboard/TreadmillOutdoorChart.tsx
+++ b/src/components/dashboard/TreadmillOutdoorChart.tsx
@@ -23,7 +23,7 @@ export function TreadmillOutdoorChart({ data }: TreadmillOutdoorChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Treadmill vs Outdoor'
     >
       <PieChart>

--- a/src/components/dashboard/WeatherConditionsChart.tsx
+++ b/src/components/dashboard/WeatherConditionsChart.tsx
@@ -42,7 +42,7 @@ export function WeatherConditionsChart({ data }: WeatherConditionsChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Weather Conditions'
     >
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>

--- a/src/components/dashboard/WorkoutTimeChart.tsx
+++ b/src/components/dashboard/WorkoutTimeChart.tsx
@@ -22,7 +22,7 @@ export function WorkoutTimeChart({ data, maxPct }: WorkoutTimeChartProps) {
   return (
     <ChartContainer
       config={config}
-      className='h-60'
+      className='h-60 md:col-span-2'
       title='Workout Activity by Time'
     >
       <RadarChart data={data}>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -77,7 +77,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex flex-col text-xs space-y-2 [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex flex-col text-xs space-y-2 rounded-md bg-card p-4 [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -58,45 +58,25 @@ export default function Dashboard() {
         </Card>
       </div>
 
-      <Card className="md:col-span-2 p-4">
-        <DailyStepsChart data={dailySteps} />
-      </Card>
+      <DailyStepsChart data={dailySteps} />
 
-      <Card className="md:col-span-2 p-4">
-        <ActivitiesChart />
-      </Card>
+      <ActivitiesChart />
 
-      <Card className="md:col-span-2 p-4">
-        <PaceDistributionChart data={running.paceDistribution} />
-      </Card>
+      <PaceDistributionChart data={running.paceDistribution} />
 
-      <Card className="md:col-span-2 p-4">
-        <HeartRateZonesChart data={running.heartRateZones} />
-      </Card>
+      <HeartRateZonesChart data={running.heartRateZones} />
 
-      <Card className="md:col-span-2 p-4">
-        <PaceVsHeartChart data={running.paceVsHeart} />
-      </Card>
+      <PaceVsHeartChart data={running.paceVsHeart} />
 
-      <Card className="md:col-span-2 p-4">
-        <TemperatureChart data={running.temperature} />
-      </Card>
+      <TemperatureChart data={running.temperature} />
 
-      <Card className="md:col-span-2 p-4">
-        <AnnualMileageChart data={running.annualMileage} />
-      </Card>
+      <AnnualMileageChart data={running.annualMileage} />
 
-      <Card className="md:col-span-2 p-4">
-        <WorkoutTimeChart data={running.byHour} maxPct={100} />
-      </Card>
+      <WorkoutTimeChart data={running.byHour} maxPct={100} />
 
-      <Card className="md:col-span-2 p-4">
-        <RunDistancesChart data={running.distanceBuckets} />
-      </Card>
+      <RunDistancesChart data={running.distanceBuckets} />
 
-      <Card className="md:col-span-2 p-4">
-        <TreadmillOutdoorChart data={running.treadmillOutdoor} />
-      </Card>
+      <TreadmillOutdoorChart data={running.treadmillOutdoor} />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 md:col-span-2">
         <MapChart data={visits} onSelectState={setSelected} />


### PR DESCRIPTION
## Summary
- embed card styling in `ChartContainer`
- drop redundant `<Card>` wrappers in dashboard
- apply responsive column span to chart components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b6c25359c8324ba30ceeff6e03844