### PR TITLE
Use shared ChartContainer

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from "@/components/ui/chart-container";
 import {
-  ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   ChartLegend,

--- a/src/components/dashboard/AnnualMileageChart.tsx
+++ b/src/components/dashboard/AnnualMileageChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   BarChart,
   Bar,
   XAxis,

--- a/src/components/dashboard/AverageDailyMileageChart.tsx
+++ b/src/components/dashboard/AverageDailyMileageChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   RadarChart,
   PolarGrid,
   PolarAngleAxis,

--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
+import { ChartContainer } from "@/components/ui/chart-container";
 import {
-  ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   BarChart,

--- a/src/components/dashboard/HeartRateZonesChart.tsx
+++ b/src/components/dashboard/HeartRateZonesChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   BarChart,
   Bar,
   XAxis,

--- a/src/components/dashboard/MapChart.tsx
+++ b/src/components/dashboard/MapChart.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 import type { StateVisit } from "@/lib/types";
 import { fipsToAbbr } from "@/lib/stateCodes";
-import { ChartHeader } from "@/components/ui/chart-header";
+import { ChartContainer } from "@/components/ui/chart-container";
 
 interface MapChartProps {
   data: StateVisit[];
@@ -13,8 +13,7 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
   const visited = new Set(data.filter((d) => d.visited).map((d) => d.stateCode));
 
   return (
-    <div className="space-y-2">
-      <ChartHeader title="Visited States" />
+    <ChartContainer title="Visited States" className="md:col-span-2">
       <ComposableMap projection="geoAlbersUsa" width={800} height={400}>
         <Geographies geography="/us-states.json">
           {({ geographies }: { geographies: any[] }) =>
@@ -44,6 +43,6 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
         }
       </Geographies>
       </ComposableMap>
-    </div>
+    </ChartContainer>
   );
 }

--- a/src/components/dashboard/PaceDistributionChart.tsx
+++ b/src/components/dashboard/PaceDistributionChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   AreaChart,
   Area,
   XAxis,

--- a/src/components/dashboard/PaceVsHeartChart.tsx
+++ b/src/components/dashboard/PaceVsHeartChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   ScatterChart,
   Scatter,
   XAxis,

--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   BarChart,
   Bar,
   XAxis,

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -1,6 +1,6 @@
 // src/components/dashboard/StepsChart.tsx
+import { ChartContainer } from "@/components/ui/chart-container";
 import {
-  ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   BarChart,

--- a/src/components/dashboard/TemperatureChart.tsx
+++ b/src/components/dashboard/TemperatureChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   BarChart,
   Bar,
   XAxis,

--- a/src/components/dashboard/TreadmillOutdoorChart.tsx
+++ b/src/components/dashboard/TreadmillOutdoorChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   PieChart,
   Pie,
   Tooltip,

--- a/src/components/dashboard/WeatherConditionsChart.tsx
+++ b/src/components/dashboard/WeatherConditionsChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   BarChart,
   Bar,
   XAxis,

--- a/src/components/dashboard/WorkoutTimeChart.tsx
+++ b/src/components/dashboard/WorkoutTimeChart.tsx
@@ -1,5 +1,5 @@
+import { ChartContainer } from '@/components/ui/chart-container'
 import {
-  ChartContainer,
   RadarChart,
   PolarGrid,
   PolarAngleAxis,

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -384,7 +384,6 @@ function getPayloadConfigFromPayload(
 }
 
 export {
-  ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   ChartLegend,


### PR DESCRIPTION
## Summary
- switch dashboard charts to ChartContainer from `ui/chart-container`
- wrap states map with ChartContainer for a consistent header
- drop unused `ChartContainer` export from `ui/chart`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b7d83e3d4832481409cb6295a2d0c