### PR TITLE
Fix chart types and tooltip formatting

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from "@/components/ui/chart-container";
+import { ChartContainer } from "@/components/ui/chart";
 import {
   ChartTooltip,
   ChartTooltipContent,

--- a/src/components/dashboard/AnnualMileageChart.tsx
+++ b/src/components/dashboard/AnnualMileageChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   BarChart,
   Bar,

--- a/src/components/dashboard/AverageDailyMileageChart.tsx
+++ b/src/components/dashboard/AverageDailyMileageChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   RadarChart,
   PolarGrid,

--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChartContainer } from "@/components/ui/chart-container";
+import { ChartContainer } from "@/components/ui/chart";
 import {
   ChartTooltip,
   ChartTooltipContent,
@@ -80,8 +80,6 @@ export function DailyStepsChart({
       <BarChart
         data={last7}
         margin={{ top: 20, right: 20, bottom: 20, left: 0 }}
-        // enable animation for polish
-        isAnimationActive={true}
       >
         <CartesianGrid
           stroke="var(--grid-line)"
@@ -146,6 +144,7 @@ export function DailyStepsChart({
           radius={[4, 4, 0, 0]}
           barSize={22}
           aria-label="Bar chart of daily steps"
+          isAnimationActive
         >
           {last7.map((day) => (
             <Cell

--- a/src/components/dashboard/HeartRateZonesChart.tsx
+++ b/src/components/dashboard/HeartRateZonesChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   BarChart,
   Bar,

--- a/src/components/dashboard/PaceDistributionChart.tsx
+++ b/src/components/dashboard/PaceDistributionChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   AreaChart,
   Area,

--- a/src/components/dashboard/PaceVsHeartChart.tsx
+++ b/src/components/dashboard/PaceVsHeartChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   ScatterChart,
   Scatter,

--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   BarChart,
   Bar,

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -1,5 +1,5 @@
 // src/components/dashboard/StepsChart.tsx
-import { ChartContainer } from "@/components/ui/chart-container";
+import { ChartContainer } from "@/components/ui/chart";
 import {
   ChartTooltip,
   ChartTooltipContent,

--- a/src/components/dashboard/TemperatureChart.tsx
+++ b/src/components/dashboard/TemperatureChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   BarChart,
   Bar,

--- a/src/components/dashboard/TreadmillOutdoorChart.tsx
+++ b/src/components/dashboard/TreadmillOutdoorChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   PieChart,
   Pie,

--- a/src/components/dashboard/WeatherConditionsChart.tsx
+++ b/src/components/dashboard/WeatherConditionsChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   BarChart,
   Bar,

--- a/src/components/dashboard/WorkoutTimeChart.tsx
+++ b/src/components/dashboard/WorkoutTimeChart.tsx
@@ -1,4 +1,4 @@
-import { ChartContainer } from '@/components/ui/chart-container'
+import { ChartContainer } from '@/components/ui/chart'
 import {
   RadarChart,
   PolarGrid,

--- a/src/components/ui/chart-header.tsx
+++ b/src/components/ui/chart-header.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 interface ChartHeaderProps {
-  title: string;
+  title?: string;
   subtitle?: string;
   className?: string;
 }
@@ -11,7 +11,9 @@ interface ChartHeaderProps {
 export function ChartHeader({ title, subtitle, className }: ChartHeaderProps) {
   return (
     <div className={cn("flex flex-col items-center text-center space-y-1", className)}>
-      <div className="text-sm font-medium uppercase tracking-wide">{title}</div>
+      {title && (
+        <div className="text-sm font-medium uppercase tracking-wide">{title}</div>
+      )}
       {subtitle && (
         <div className="text-[10px] text-muted-foreground">{subtitle}</div>
       )}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -130,7 +130,19 @@ ${colorConfig
   )
 }
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+function ChartTooltip(
+  props: React.ComponentProps<typeof RechartsPrimitive.Tooltip> & {
+    children?: React.ReactNode
+  }
+) {
+  const { children, ...rest } = props
+  return (
+    <RechartsPrimitive.Tooltip
+      {...rest}
+      content={children as React.ReactElement}
+    />
+  )
+}
 
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
@@ -141,6 +153,7 @@ const ChartTooltipContent = React.forwardRef<
       indicator?: "line" | "dot" | "dashed"
       nameKey?: string
       labelKey?: string
+      valueFormatter?: (value: any) => React.ReactNode
     }
 >(
   (
@@ -155,6 +168,7 @@ const ChartTooltipContent = React.forwardRef<
       labelFormatter,
       labelClassName,
       formatter,
+      valueFormatter,
       color,
       nameKey,
       labelKey,
@@ -266,9 +280,13 @@ const ChartTooltipContent = React.forwardRef<
                           {itemConfig?.label || item.name}
                         </span>
                       </div>
-                      {item.value && (
+                      {item.value !== undefined && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {valueFormatter
+                            ? valueFormatter(item.value)
+                            : typeof item.value === "number"
+                            ? item.value.toLocaleString()
+                            : String(item.value)}
                         </span>
                       )}
                     </div>
@@ -384,6 +402,7 @@ function getPayloadConfigFromPayload(
 }
 
 export {
+  ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   ChartLegend,


### PR DESCRIPTION
## Summary
- allow optional title for `ChartHeader`
- export `ChartContainer` and add `valueFormatter` for tooltips
- adjust Tooltip wrapper to accept children
- use exported chart container in dashboard charts
- move animation flag to `Bar` element

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688b82e84a788324b9b42aeebaddd210