### PR TITLE
Fix chart color tokens and improve usage

### DIFF
--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -22,7 +22,7 @@ export interface DailyStepsChartProps {
 const chartConfig = {
   steps: {
     label: "Steps",
-    color: "var(--chart-primary)",
+    color: "hsl(var(--chart-primary))",
   },
 } satisfies ChartConfig;
 
@@ -140,7 +140,7 @@ export function DailyStepsChart({
         <Bar
           dataKey="steps"
           name="Steps"
-          fill="var(--chart-primary)"
+          fill="hsl(var(--chart-primary))"
           radius={[4, 4, 0, 0]}
           barSize={22}
           aria-label="Bar chart of daily steps"

--- a/src/components/dashboard/PaceDistributionChart.tsx
+++ b/src/components/dashboard/PaceDistributionChart.tsx
@@ -20,8 +20,8 @@ interface PaceDistributionChartProps {
 
 export function PaceDistributionChart({ data }: PaceDistributionChartProps) {
   const config = {
-    upper: { color: 'var(--chart-primary)' },
-    lower: { color: 'var(--chart-primary)' },
+    upper: { color: 'hsl(var(--chart-primary))' },
+    lower: { color: 'hsl(var(--chart-primary))' },
   }
   return (
     <ChartContainer
@@ -39,8 +39,8 @@ export function PaceDistributionChart({ data }: PaceDistributionChartProps) {
         />
         <YAxis hide />
         <ReferenceLine y={0} strokeDasharray='3 3' stroke='var(--axis-line)' />
-        <Area dataKey='upper' fill='var(--chart-primary)' stroke='none' />
-        <Area dataKey='lower' fill='var(--chart-primary)' stroke='none' />
+        <Area dataKey='upper' fill='hsl(var(--chart-primary))' stroke='none' />
+        <Area dataKey='lower' fill='hsl(var(--chart-primary))' stroke='none' />
       </AreaChart>
     </ChartContainer>
   )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,8 +14,8 @@
     --muted: 210 40% 96%;
     --muted-foreground: 215 16% 47%;
 
-    /* chart palette (OKLCH samples) */
-    --chart-1: oklch(0.646 0.222 41.116);
+    /* chart palette */
+    --chart-1: 217 91% 60%;
     --chart-2: oklch(0.6 0.118 184.704);
     --chart-3: oklch(0.398 0.07 227.392);
     --chart-4: oklch(0.828 0.189 84.429);
@@ -27,8 +27,8 @@
     --chart-10: oklch(0.57 0.12 200);
 
     /* semantic chart tokens */
-    --chart-primary: hsl(var(--primary)); /* fallback to primary */
-    --axis-line: rgba(0, 0, 0, 0.1); /* light subtle line for light mode */
+    --chart-primary: 217 91% 60%;
+    --axis-line: 215 16% 47%;
     --grid-line: rgba(0, 0, 0, 0.08);
     --legend-text: hsl(var(--muted-foreground));
     --tick-text: hsl(var(--muted-foreground));
@@ -47,8 +47,8 @@
     --muted-foreground: 215 20% 65%;
 
     /* chart palette still accessible; adjust semantic overrides */
-    --chart-primary: hsl(var(--primary));
-    --axis-line: rgba(255, 255, 255, 0.06);
+    --chart-primary: 217 91% 60%;
+    --axis-line: 215 20% 65%;
     --grid-line: rgba(255, 255, 255, 0.04);
     --legend-text: hsl(var(--muted-foreground));
     --tick-text: hsl(var(--muted-foreground));


### PR DESCRIPTION
## Summary
- correct color tokens and use hsl triplets
- update chart components to use the new tokens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b86bd2fe8832497e746f0ed654821