### PR TITLE
Remove bar charts from examples page

### DIFF
--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -1,12 +1,10 @@
 import React from "react";
-import BarChartExamples from "@/components/examples/BarChartExamples";
 import AreaChartInteractive from "@/components/examples/AreaChartInteractive";
 
 export default function Examples() {
   return (
     <div className="grid gap-6">
       <AreaChartInteractive />
-      <BarChartExamples />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove BarChartExamples from the Examples page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ba400e42c832498089f3070ab09df