### PR TITLE
Add dark/light mode toggle

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ThemeToggle from "@/components/ui/theme-toggle";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -16,6 +17,7 @@ export default function Layout({
     <div className="min-h-screen p-4">
       <header className="flex justify-between items-center mb-4">
         <h1 className="text-xl font-bold">Garmin Dashboard</h1>
+        <ThemeToggle />
       </header>
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored || (prefersDark ? "dark" : "light");
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  function toggleTheme() {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("theme", next);
+  }
+
+  return (
+    <button
+      className="px-3 py-1 rounded bg-muted hover:bg-muted-foreground"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      🌮
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- support switching the `dark` class via a taco button
- mount `ThemeToggle` in the layout header

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ba41ca0d08324a7961e174293b5b9