### PR TITLE
Add radial charts to examples

### DIFF
--- a/src/components/examples/RadialChartLabel.tsx
+++ b/src/components/examples/RadialChartLabel.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import { LabelList, RadialBar, RadialBarChart } from 'recharts'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+
+export const description = 'A radial chart with a label'
+
+const chartData = [
+  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
+  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
+  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
+  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+]
+
+const chartConfig = {
+  visitors: {
+    label: 'Visitors',
+  },
+  chrome: {
+    label: 'Chrome',
+    color: 'var(--chart-1)',
+  },
+  safari: {
+    label: 'Safari',
+    color: 'var(--chart-2)',
+  },
+  firefox: {
+    label: 'Firefox',
+    color: 'var(--chart-3)',
+  },
+  edge: {
+    label: 'Edge',
+    color: 'var(--chart-4)',
+  },
+  other: {
+    label: 'Other',
+    color: 'var(--chart-5)',
+  },
+} satisfies ChartConfig
+
+export default function ChartRadialLabel() {
+  return (
+    <Card className='flex flex-col'>
+      <CardHeader className='items-center pb-0'>
+        <CardTitle>Radial Chart - Label</CardTitle>
+        <CardDescription>January - June 2024</CardDescription>
+      </CardHeader>
+      <CardContent className='flex-1 pb-0'>
+        <ChartContainer
+          config={chartConfig}
+          className='mx-auto aspect-square max-h-[250px]'
+        >
+          <RadialBarChart
+            data={chartData}
+            startAngle={-90}
+            endAngle={380}
+            innerRadius={30}
+            outerRadius={110}
+          >
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent hideLabel nameKey='browser' />}
+            />
+            <RadialBar dataKey='visitors' background>
+              <LabelList
+                position='insideStart'
+                dataKey='browser'
+                className='fill-white capitalize mix-blend-luminosity'
+                fontSize={11}
+              />
+            </RadialBar>
+          </RadialBarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex-col gap-2 text-sm'>
+        <div className='flex items-center gap-2 leading-none font-medium'>
+          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          Showing total visitors for the last 6 months
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/components/examples/RadialChartSimple.tsx
+++ b/src/components/examples/RadialChartSimple.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import { RadialBar, RadialBarChart } from 'recharts'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+
+export const description = 'A radial chart'
+
+const chartData = [
+  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
+  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
+  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
+  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+]
+
+const chartConfig = {
+  visitors: {
+    label: 'Visitors',
+  },
+  chrome: {
+    label: 'Chrome',
+    color: 'var(--chart-1)',
+  },
+  safari: {
+    label: 'Safari',
+    color: 'var(--chart-2)',
+  },
+  firefox: {
+    label: 'Firefox',
+    color: 'var(--chart-3)',
+  },
+  edge: {
+    label: 'Edge',
+    color: 'var(--chart-4)',
+  },
+  other: {
+    label: 'Other',
+    color: 'var(--chart-5)',
+  },
+} satisfies ChartConfig
+
+export default function ChartRadialSimple() {
+  return (
+    <Card className='flex flex-col'>
+      <CardHeader className='items-center pb-0'>
+        <CardTitle>Radial Chart</CardTitle>
+        <CardDescription>January - June 2024</CardDescription>
+      </CardHeader>
+      <CardContent className='flex-1 pb-0'>
+        <ChartContainer
+          config={chartConfig}
+          className='mx-auto aspect-square max-h-[250px]'
+        >
+          <RadialBarChart data={chartData} innerRadius={30} outerRadius={110}>
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent hideLabel nameKey='browser' />}
+            />
+            <RadialBar dataKey='visitors' background />
+          </RadialBarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex-col gap-2 text-sm'>
+        <div className='flex items-center gap-2 leading-none font-medium'>
+          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          Showing total visitors for the last 6 months
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/components/examples/RadialChartText.tsx
+++ b/src/components/examples/RadialChartText.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import {
+  Label,
+  PolarGrid,
+  PolarRadiusAxis,
+  RadialBar,
+  RadialBarChart,
+} from 'recharts'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ChartConfig, ChartContainer } from '@/components/ui/chart'
+
+export const description = 'A radial chart with text'
+
+const chartData = [
+  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+]
+
+const chartConfig = {
+  visitors: {
+    label: 'Visitors',
+  },
+  safari: {
+    label: 'Safari',
+    color: 'var(--chart-2)',
+  },
+} satisfies ChartConfig
+
+export default function ChartRadialText() {
+  return (
+    <Card className='flex flex-col'>
+      <CardHeader className='items-center pb-0'>
+        <CardTitle>Radial Chart - Text</CardTitle>
+        <CardDescription>January - June 2024</CardDescription>
+      </CardHeader>
+      <CardContent className='flex-1 pb-0'>
+        <ChartContainer
+          config={chartConfig}
+          className='mx-auto aspect-square max-h-[250px]'
+        >
+          <RadialBarChart
+            data={chartData}
+            startAngle={0}
+            endAngle={250}
+            innerRadius={80}
+            outerRadius={110}
+          >
+            <PolarGrid
+              gridType='circle'
+              radialLines={false}
+              stroke='none'
+              className='first:fill-muted last:fill-background'
+              polarRadius={[86, 74]}
+            />
+            <RadialBar dataKey='visitors' background cornerRadius={10} />
+            <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
+              <Label
+                content={({ viewBox }) => {
+                  if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+                    return (
+                      <text
+                        x={viewBox.cx}
+                        y={viewBox.cy}
+                        textAnchor='middle'
+                        dominantBaseline='middle'
+                      >
+                        <tspan
+                          x={viewBox.cx}
+                          y={viewBox.cy}
+                          className='fill-foreground text-4xl font-bold'
+                        >
+                          {chartData[0].visitors.toLocaleString()}
+                        </tspan>
+                        <tspan
+                          x={viewBox.cx}
+                          y={(viewBox.cy || 0) + 24}
+                          className='fill-muted-foreground'
+                        >
+                          Visitors
+                        </tspan>
+                      </text>
+                    )
+                  }
+                }}
+              />
+            </PolarRadiusAxis>
+          </RadialBarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex-col gap-2 text-sm'>
+        <div className='flex items-center gap-2 leading-none font-medium'>
+          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          Showing total visitors for the last 6 months
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -4,6 +4,9 @@ import LineChartInteractive from "@/components/examples/LineChartInteractive";
 import BarChartInteractive from "@/components/examples/BarChartInteractive";
 
 import ChartRadarDefault from "@/components/examples/RadarChartDefault";
+import ChartRadialSimple from "@/components/examples/RadialChartSimple";
+import ChartRadialLabel from "@/components/examples/RadialChartLabel";
+import ChartRadialText from "@/components/examples/RadialChartText";
 
 
 export default function Examples() {
@@ -16,6 +19,12 @@ export default function Examples() {
       <LineChartInteractive />
 
       <ChartRadarDefault />
+
+      <ChartRadialSimple />
+
+      <ChartRadialLabel />
+
+      <ChartRadialText />
 
     </div>
   );


### PR DESCRIPTION
## Summary
- add new radial chart components: simple, label, and text versions
- showcase these charts on the examples page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ba7d574008324945ecdac7713dbd9