### PR TITLE
Apply card styles to dashboard charts

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
   CartesianGrid,
 } from "@/components/ui/chart";
+import ChartCard from "./ChartCard";
 import type { ChartConfig } from "@/components/ui/chart";
 import { useGarminData } from "@/hooks/useGarminData";
 
@@ -30,17 +31,17 @@ export function ActivitiesChart() {
   const activities = data.activities;
 
   return (
-    <ChartContainer
-      config={chartConfig}
-      className="h-60 md:col-span-2"
+    <ChartCard
       title="Activities"
-      subtitle="Distance vs Duration"
+      description="Distance vs Duration"
+      className="md:col-span-2"
     >
-      <LineChart data={activities} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
-        <YAxis yAxisId="left" orientation="left" />
-        <YAxis yAxisId="right" orientation="right" />
+      <ChartContainer config={chartConfig} className="h-60">
+        <LineChart data={activities} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <YAxis yAxisId="left" orientation="left" />
+          <YAxis yAxisId="right" orientation="right" />
         <ChartTooltip
           content={<ChartTooltipContent labelFormatter={(d) => new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })} />}
         />
@@ -48,6 +49,7 @@ export function ActivitiesChart() {
         <Line yAxisId="left" type="monotone" dataKey="distance" stroke={chartConfig.distance.color} />
         <Line yAxisId="right" type="monotone" dataKey="duration" stroke={chartConfig.duration.color} />
       </LineChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   );
 }

--- a/src/components/dashboard/AnnualMileageChart.tsx
+++ b/src/components/dashboard/AnnualMileageChart.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip,
   CartesianGrid,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface AnnualMileage {
   year: number
@@ -20,11 +21,8 @@ interface AnnualMileageChartProps {
 export function AnnualMileageChart({ data }: AnnualMileageChartProps) {
   const config = { totalMiles: { color: 'hsl(var(--chart-7))' } }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Annual Mileage'
-    >
+    <ChartCard title='Annual Mileage' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray='3 3' />
         <XAxis dataKey='year' />
@@ -32,6 +30,7 @@ export function AnnualMileageChart({ data }: AnnualMileageChartProps) {
         <Tooltip />
         <Bar dataKey='totalMiles' fill='hsl(var(--chart-7))' />
       </BarChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/ChartCard.tsx
+++ b/src/components/dashboard/ChartCard.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ChartCardProps {
+  title?: string;
+  description?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+export function ChartCard({ title, description, className, children }: ChartCardProps) {
+  return (
+    <Card className={cn(className)}>
+      {(title || description) && (
+        <CardHeader>
+          {title && <CardTitle>{title}</CardTitle>}
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent className="pt-0">{children}</CardContent>
+    </Card>
+  );
+}
+
+export default ChartCard;

--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -8,6 +8,7 @@ import {
   YAxis,
   CartesianGrid,
 } from "@/components/ui/chart";
+import ChartCard from "./ChartCard";
 import type { ChartConfig } from "@/components/ui/chart";
 import type { GarminDay } from "@/lib/api";
 import { Cell } from "recharts";
@@ -25,11 +26,8 @@ const chartConfig = {
 
 export function DailyStepsChart({ data }: DailyStepsChartProps) {
   return (
-    <ChartContainer
-      config={chartConfig}
-      className="h-60 md:col-span-2"
-      title="Daily Steps"
-    >
+    <ChartCard title="Daily Steps" className="md:col-span-2">
+      <ChartContainer config={chartConfig} className="h-60">
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis
@@ -61,6 +59,7 @@ export function DailyStepsChart({ data }: DailyStepsChartProps) {
           ))}
         </Bar>
       </BarChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   );
 }

--- a/src/components/dashboard/HeartRateZonesChart.tsx
+++ b/src/components/dashboard/HeartRateZonesChart.tsx
@@ -7,6 +7,7 @@ import {
   CartesianGrid,
   Tooltip,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface HeartRateZoneData {
   zone: string
@@ -22,18 +23,16 @@ export function HeartRateZonesChart({ data }: HeartRateZonesChartProps) {
     count: { color: 'hsl(var(--chart-2))' },
   }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Heart Rate Zones'
-    >
-      <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-        <CartesianGrid stroke='hsl(var(--muted))' />
-        <XAxis dataKey='zone' />
-        <YAxis />
-        <Tooltip />
-        <Bar dataKey='count' fill='hsl(var(--chart-2))' radius={[4,4,0,0]} />
-      </BarChart>
-    </ChartContainer>
+    <ChartCard title='Heart Rate Zones' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
+        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid stroke='hsl(var(--muted))' />
+          <XAxis dataKey='zone' />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey='count' fill='hsl(var(--chart-2))' radius={[4,4,0,0]} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/MapChart.tsx
+++ b/src/components/dashboard/MapChart.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 import type { StateVisit } from "@/lib/types";
 import { fipsToAbbr } from "@/lib/stateCodes";
-import { ChartHeader } from "@/components/ui/chart-header";
+
+import ChartCard from "./ChartCard";
 
 interface MapChartProps {
   data: StateVisit[];
@@ -13,8 +14,7 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
   const visited = new Set(data.filter((d) => d.visited).map((d) => d.stateCode));
 
   return (
-    <div className="space-y-2">
-      <ChartHeader title="Visited States" />
+    <ChartCard title="Visited States">
       <ComposableMap projection="geoAlbersUsa" width={800} height={400}>
         <Geographies geography="/us-states.json">
           {({ geographies }: { geographies: any[] }) =>
@@ -44,6 +44,6 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
         }
       </Geographies>
       </ComposableMap>
-    </div>
+    </ChartCard>
   );
 }

--- a/src/components/dashboard/PaceDistributionChart.tsx
+++ b/src/components/dashboard/PaceDistributionChart.tsx
@@ -7,6 +7,7 @@ import {
   CartesianGrid,
   ReferenceLine,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface PaceDistributionBin {
   bin: string
@@ -24,19 +25,17 @@ export function PaceDistributionChart({ data }: PaceDistributionChartProps) {
     lower: { color: 'hsl(var(--muted-foreground))' },
   }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Pace Distribution'
-    >
-      <AreaChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-        <CartesianGrid strokeDasharray='3 3' />
-        <XAxis dataKey='bin' />
-        <YAxis hide />
-        <ReferenceLine y={0} strokeDasharray='3 3' stroke='hsl(var(--muted))' />
-        <Area dataKey='upper' fill='hsl(var(--muted-foreground))' stroke='none' />
-        <Area dataKey='lower' fill='hsl(var(--muted-foreground))' stroke='none' />
-      </AreaChart>
-    </ChartContainer>
+    <ChartCard title='Pace Distribution' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
+        <AreaChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray='3 3' />
+          <XAxis dataKey='bin' />
+          <YAxis hide />
+          <ReferenceLine y={0} strokeDasharray='3 3' stroke='hsl(var(--muted))' />
+          <Area dataKey='upper' fill='hsl(var(--muted-foreground))' stroke='none' />
+          <Area dataKey='lower' fill='hsl(var(--muted-foreground))' stroke='none' />
+        </AreaChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/PaceVsHeartChart.tsx
+++ b/src/components/dashboard/PaceVsHeartChart.tsx
@@ -7,6 +7,7 @@ import {
   CartesianGrid,
   Tooltip,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface PaceHeartPoint {
   pace: number
@@ -22,18 +23,16 @@ export function PaceVsHeartChart({ data }: PaceVsHeartChartProps) {
     value: { color: 'hsl(var(--chart-4))' },
   }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Pace vs Heart Rate'
-    >
-      <ScatterChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-        <CartesianGrid stroke='hsl(var(--muted))' />
-        <XAxis dataKey='pace' type='number' reversed />
-        <YAxis dataKey='heartRate' type='number' />
-        <Tooltip />
-        <Scatter fill='hsl(var(--chart-4))' />
-      </ScatterChart>
-    </ChartContainer>
+    <ChartCard title='Pace vs Heart Rate' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
+        <ScatterChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid stroke='hsl(var(--muted))' />
+          <XAxis dataKey='pace' type='number' reversed />
+          <YAxis dataKey='heartRate' type='number' />
+          <Tooltip />
+          <Scatter fill='hsl(var(--chart-4))' />
+        </ScatterChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/RunDistancesChart.tsx
+++ b/src/components/dashboard/RunDistancesChart.tsx
@@ -6,6 +6,7 @@ import {
   YAxis,
   Tooltip,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface DistanceBucket {
   label: string
@@ -19,17 +20,15 @@ interface RunDistancesChartProps {
 export function RunDistancesChart({ data }: RunDistancesChartProps) {
   const config = { count: { color: 'hsl(var(--chart-10))' } }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Run Distances'
-    >
+    <ChartCard title='Run Distances' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis type='number' hide />
         <YAxis dataKey='label' type='category' />
         <Tooltip />
         <Bar dataKey='count' fill='hsl(var(--chart-10))' radius={[0,4,4,0]} />
       </BarChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/StateTable.tsx
+++ b/src/components/dashboard/StateTable.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 import type { StateVisit } from "@/lib/types";
-import { Card } from "@/components/ui/card";
-import { ChartHeader } from "@/components/ui/chart-header";
+import ChartCard from "./ChartCard";
 
 interface StateTableProps {
   data: StateVisit[];
@@ -12,8 +11,7 @@ interface StateTableProps {
 
 export default function StateTable({ data, selectedState, onSelectState }: StateTableProps) {
   return (
-    <Card className="p-2 space-y-2">
-      <ChartHeader title="Visited States" subtitle="Details" />
+    <ChartCard title="Visited States" description="Details" className="p-2 space-y-2">
       <Accordion value={selectedState || undefined} onValueChange={onSelectState}>
         {data
           .filter((d) => d.visited)
@@ -40,6 +38,6 @@ export default function StateTable({ data, selectedState, onSelectState }: State
             </AccordionItem>
           ))}
       </Accordion>
-    </Card>
+    </ChartCard>
   );
 }

--- a/src/components/dashboard/TemperatureChart.tsx
+++ b/src/components/dashboard/TemperatureChart.tsx
@@ -6,6 +6,7 @@ import {
   YAxis,
   Tooltip,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface TempBucket {
   label: string
@@ -19,17 +20,15 @@ interface TemperatureChartProps {
 export function TemperatureChart({ data }: TemperatureChartProps) {
   const config = { count: { color: 'hsl(var(--chart-5))' } }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Temperature'
-    >
+    <ChartCard title='Temperature' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
       <BarChart layout='vertical' data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis type='number' hide />
         <YAxis dataKey='label' type='category' />
         <Tooltip />
         <Bar dataKey='count' fill='hsl(var(--chart-5))' radius={[0,4,4,0]} />
       </BarChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/TreadmillOutdoorChart.tsx
+++ b/src/components/dashboard/TreadmillOutdoorChart.tsx
@@ -4,6 +4,7 @@ import {
   Pie,
   Tooltip,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface TreadmillOutdoor {
   outdoor: number
@@ -21,11 +22,8 @@ export function TreadmillOutdoorChart({ data }: TreadmillOutdoorChartProps) {
     { name: 'treadmill', value: data.treadmill, fill: 'hsl(var(--chart-1))' },
   ]
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Treadmill vs Outdoor'
-    >
+    <ChartCard title='Treadmill vs Outdoor' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
       <PieChart>
         <Pie
           data={chartData}
@@ -38,6 +36,7 @@ export function TreadmillOutdoorChart({ data }: TreadmillOutdoorChartProps) {
         />
         <Tooltip />
       </PieChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/WorkoutTimeChart.tsx
+++ b/src/components/dashboard/WorkoutTimeChart.tsx
@@ -6,6 +6,7 @@ import {
   PolarRadiusAxis,
   Radar,
 } from '@/components/ui/chart'
+import ChartCard from './ChartCard'
 
 export interface HourActivity {
   hour: number
@@ -20,17 +21,15 @@ interface WorkoutTimeChartProps {
 export function WorkoutTimeChart({ data, maxPct }: WorkoutTimeChartProps) {
   const config = { pct: { color: 'hsl(var(--chart-8))' } }
   return (
-    <ChartContainer
-      config={config}
-      className='h-60 md:col-span-2'
-      title='Workout Activity by Time'
-    >
+    <ChartCard title='Workout Activity by Time' className='md:col-span-2'>
+      <ChartContainer config={config} className='h-60'>
       <RadarChart data={data}>
         <PolarGrid stroke='hsl(var(--muted))' />
         <PolarAngleAxis dataKey='hour' />
         <PolarRadiusAxis angle={90} domain={[0, maxPct]} />
         <Radar dataKey='pct' fill='hsl(var(--chart-8))' fillOpacity={0.6} />
       </RadarChart>
-    </ChartContainer>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,5 +1,6 @@
 export { default as MapChart } from "./MapChart";
 export { default as StateTable } from "./StateTable";
+export { default as ChartCard } from "./ChartCard";
 export * from "./ProgressRing";
 export * from "./ActivitiesChart";
 export * from "./StepsChart";


### PR DESCRIPTION
## Summary
- unify dashboard charts with new `ChartCard` component
- wrap all charts and tables in dashboard cards for consistent styling
- export the new component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ba9e7fb188324bc603ee7f1817c65