### PR TITLE
Add stats tab and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Layout from "@/components/layout/Layout";
 import Dashboard from "@/pages/Dashboard";
 import Examples from "@/pages/Examples";
+import StatsExamples from "@/pages/StatsExamples";
 
 function App() {
   const [tab, setTab] = useState("dashboard");
@@ -11,6 +12,7 @@ function App() {
       {tab === "trends" && <p>Trends coming soon...</p>}
       {tab === "map" && <p>Map coming soon...</p>}
       {tab === "examples" && <Examples />}
+      {tab === "stats" && <StatsExamples />}
     </Layout>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -33,6 +33,9 @@ export default function Layout({
           <TabsTrigger value="examples" onClick={() => setActiveTab("examples")}>
             Examples
           </TabsTrigger>
+          <TabsTrigger value="stats" onClick={() => setActiveTab("stats")}>
+            Stats
+          </TabsTrigger>
         </TabsList>
       </Tabs>
       <div className="mt-2">{children}</div>


### PR DESCRIPTION
## Summary
- expose new StatsExamples page in UI
- render `StatsExamples` for the `"stats"` tab

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bb08ed0288324ade238b6b29741c4