### PR TITLE
Add selected state highlight to map chart

### DIFF
--- a/src/components/dashboard/MapChart.tsx
+++ b/src/components/dashboard/MapChart.tsx
@@ -7,10 +7,11 @@ import ChartCard from "./ChartCard";
 
 interface MapChartProps {
   data: StateVisit[];
+  selectedState: string | null;
   onSelectState: (stateCode: string) => void;
 }
 
-export default function MapChart({ data, onSelectState }: MapChartProps) {
+export default function MapChart({ data, selectedState, onSelectState }: MapChartProps) {
   const visited = new Set(data.filter((d) => d.visited).map((d) => d.stateCode));
 
   return (
@@ -21,6 +22,7 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
             geographies.map((geo: any) => {
             const code = fipsToAbbr[geo.id as string];
             const isVisited = code ? visited.has(code) : false;
+            const isSelected = code === selectedState;
             return (
               <Geography
                 key={geo.rsmKey}
@@ -28,7 +30,12 @@ export default function MapChart({ data, onSelectState }: MapChartProps) {
                 onClick={() => isVisited && code && onSelectState(code)}
                 style={{
                   default: {
-                    fill: isVisited ? "hsl(var(--primary))" : "hsl(var(--muted))",
+                    fill: isSelected
+                      ? "hsl(var(--accent))"
+                      : isVisited
+                        ? "hsl(var(--primary))"
+                        : "hsl(var(--muted))",
+                    stroke: isSelected ? "hsl(var(--accent-foreground))" : "none",
                     outline: "none",
                   },
                   hover: {

--- a/src/pages/StatsExamples.tsx
+++ b/src/pages/StatsExamples.tsx
@@ -44,7 +44,11 @@ export default function StatsExamples() {
       <RunDistancesChart data={running.distanceBuckets} />
       <TreadmillOutdoorChart data={running.treadmillOutdoor} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 md:col-span-2">
-        <StatesMap data={visits} onSelectState={setSelected} />
+        <StatesMap
+          data={visits}
+          selectedState={selected}
+          onSelectState={setSelected}
+        />
         <StateTable data={visits} selectedState={selected} onSelectState={setSelected} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow `MapChart` to receive a `selectedState` prop
- highlight the selected state with accent colors
- forward the selected state on the stats examples page

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bb1dbcdcc8324b44637fadaaeb25d