### PR TITLE
Simplify chart theme variables

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,20 +24,11 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.65rem;
-    --chart-primary: var(--chart-1);
-    --axis-line: var(--muted-foreground);
-  }
-  :root {
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --chart-6: oklch(0.712 0.21 23);
-    --chart-7: oklch(0.653 0.167 344);
-    --chart-8: oklch(0.6 0.162 140);
-    --chart-9: oklch(0.723 0.104 262);
-    --chart-10: oklch(0.57 0.12 200);
   }
 
   .dark {
@@ -65,8 +56,6 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --chart-primary: var(--chart-1);
-    --axis-line: var(--muted-foreground);
   }
 
   html, body {


### PR DESCRIPTION
## Summary
- clean up theme variables in `globals.css`
- remove unused chart color variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688badf78808832495e9f90242895e46