### PR TITLE
Fix horizontal bar chart height

### DIFF
--- a/src/components/examples/BarChartHorizontal.tsx
+++ b/src/components/examples/BarChartHorizontal.tsx
@@ -44,7 +44,7 @@ export default function ChartBarHorizontal() {
         <CardDescription>January - June 2024</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig} className='h-60'>
           <BarChart
             accessibilityLayer
             data={chartData}


### PR DESCRIPTION
## Summary
- fix layout for BarChartHorizontal example so it renders with height

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bc1c54e188324920c48eaedc64687