### PR TITLE
Fix example bar charts

### DIFF
--- a/src/components/examples/BarChartDefault.tsx
+++ b/src/components/examples/BarChartDefault.tsx
@@ -44,7 +44,7 @@ export default function ChartBarDefault() {
         <CardDescription>January - June 2024</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig} className='h-60'>
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis

--- a/src/components/examples/BarChartHorizontal.tsx
+++ b/src/components/examples/BarChartHorizontal.tsx
@@ -44,7 +44,7 @@ export default function ChartBarHorizontal() {
         <CardDescription>January - June 2024</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig} className='h-60'>
           <BarChart
             accessibilityLayer
             data={chartData}

--- a/src/components/examples/BarChartLabelCustom.tsx
+++ b/src/components/examples/BarChartLabelCustom.tsx
@@ -43,7 +43,7 @@ export default function ChartBarLabelCustom() {
         <CardDescription>January - June 2024</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig} className='h-60'>
           <BarChart accessibilityLayer data={chartData} layout='vertical' margin={{ right: 16 }}>
             <CartesianGrid horizontal={false} />
             <YAxis

--- a/src/components/examples/BarChartMixed.tsx
+++ b/src/components/examples/BarChartMixed.tsx
@@ -45,7 +45,7 @@ export default function ChartBarMixed() {
         <CardDescription>January - June 2024</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer config={chartConfig} className='h-60'>
           <BarChart accessibilityLayer data={chartData} layout='vertical' margin={{ left: 0 }}>
             <YAxis
               dataKey='browser'


### PR DESCRIPTION
## Summary
- give example bar charts a fixed height so they render

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bc19b5a58832483fe537206bd608b