### PR TITLE
Add label prop to ProgressRing

### DIFF
--- a/src/components/dashboard/ProgressRing.tsx
+++ b/src/components/dashboard/ProgressRing.tsx
@@ -1,20 +1,34 @@
 import React from "react";
 
+export interface ProgressRingProps {
+  /** Progress percentage from 0-100 */
+  value: number;
+  /** Outer dimension of the ring */
+  size?: number;
+  /** Stroke width of the ring */
+  strokeWidth?: number;
+  /** Accessible label describing the metric */
+  label: string;
+}
+
 export function ProgressRing({
   value,
   size = 80,
   strokeWidth = 8,
-}: {
-  value: number;
-  size?: number;
-  strokeWidth?: number;
-}) {
+  label,
+}: ProgressRingProps) {
   const radius = size / 2 - strokeWidth / 2;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (value / 100) * circumference;
 
   return (
-    <svg width={size} height={size} className="rotate-[-90deg]">
+    <svg
+      width={size}
+      height={size}
+      role="img"
+      aria-label={label}
+      className="rotate-[-90deg]"
+    >
       <circle
         cx={size / 2}
         cy={size / 2}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -46,7 +46,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Steps</h2>
-          <ProgressRing value={(data.steps / 10000) * 100} />
+          <ProgressRing label="Steps progress" value={(data.steps / 10000) * 100} />
           <span className="mt-2 text-lg font-bold">{data.steps}</span>
         </Card>
 
@@ -58,7 +58,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Sleep (hrs)</h2>
-          <ProgressRing value={(data.sleep / 8) * 100} />
+          <ProgressRing label="Sleep progress" value={(data.sleep / 8) * 100} />
           <span className="mt-2 text-lg font-bold">{data.sleep}</span>
         </Card>
 
@@ -70,7 +70,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Heart Rate</h2>
-          <ProgressRing value={(data.heartRate / 200) * 100} />
+          <ProgressRing label="Heart rate progress" value={(data.heartRate / 200) * 100} />
           <span className="mt-2 text-lg font-bold">{data.heartRate}</span>
         </Card>
 
@@ -82,7 +82,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Calories</h2>
-          <ProgressRing value={(data.calories / 3000) * 100} />
+          <ProgressRing label="Calories progress" value={(data.calories / 3000) * 100} />
           <span className="mt-2 text-lg font-bold">{data.calories}</span>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- make `ProgressRing` accept an accessible `label` prop
- wire `role="img"` and `aria-label` to the SVG
- pass labels from Dashboard cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bc3f9087883248f6b4e19423389d9