### PR TITLE
Add statistics charts

### DIFF
--- a/src/components/statistics/ActivityByTime.tsx
+++ b/src/components/statistics/ActivityByTime.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import {
+  ChartContainer,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const activityByTimeData = [
+  { time: "12am", value: 2 },
+  { time: "2am", value: 1 },
+  { time: "4am", value: 0 },
+  { time: "6am", value: 8 },
+  { time: "8am", value: 12 },
+  { time: "10am", value: 4 },
+  { time: "12pm", value: 5 },
+  { time: "2pm", value: 1 },
+  { time: "4pm", value: 2 },
+  { time: "6pm", value: 6 },
+  { time: "8pm", value: 3 },
+  { time: "10pm", value: 2 },
+]
+
+const config = {
+  value: { label: "Sessions", color: "var(--chart-2)" },
+} satisfies Record<string, unknown>
+
+export default function ActivityByTime() {
+  return (
+    <ChartContainer config={config} className="h-64" title="Workout Activity by Time">
+      <RadarChart data={activityByTimeData}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="time" />
+        <PolarRadiusAxis />
+        <ChartTooltip />
+        <Radar
+          name="Activity"
+          dataKey="value"
+          stroke="var(--chart-2)"
+          fill="var(--chart-2)"
+          fillOpacity={0.6}
+        />
+      </RadarChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/AnnualMileage.tsx
+++ b/src/components/statistics/AnnualMileage.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const annualData = [
+  { month: "1", miles: 1200 },
+  { month: "2", miles: 1100 },
+  { month: "3", miles: 950 },
+  { month: "4", miles: 1500 },
+  { month: "5", miles: 1600 },
+  { month: "6", miles: 800 },
+  { month: "7", miles: 1400 },
+  { month: "8", miles: 1800 },
+  { month: "9", miles: 1300 },
+  { month: "10", miles: 1000 },
+  { month: "11", miles: 500 },
+]
+
+const config = {
+  miles: { label: "Mileage", color: "var(--chart-1)" },
+} satisfies Record<string, unknown>
+
+export default function AnnualMileage() {
+  return (
+    <ChartContainer config={config} className="h-64" title="Annual Mileage">
+      <BarChart data={annualData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <ChartTooltip />
+        <Bar dataKey="miles" fill="var(--chart-1)" radius={2} />
+      </BarChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/AvgDailyMileageRadar.tsx
+++ b/src/components/statistics/AvgDailyMileageRadar.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import {
+  ChartContainer,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const dailyMileage = [
+  { day: "Mon", miles: 5 },
+  { day: "Tue", miles: 6 },
+  { day: "Wed", miles: 4 },
+  { day: "Thu", miles: 5.5 },
+  { day: "Fri", miles: 3 },
+  { day: "Sat", miles: 8 },
+  { day: "Sun", miles: 7 },
+]
+
+const config = {
+  miles: { label: "Miles", color: "var(--chart-3)" },
+} satisfies Record<string, unknown>
+
+export default function AvgDailyMileageRadar() {
+  return (
+    <ChartContainer config={config} className="h-64" title="Average Daily Mileage">
+      <RadarChart data={dailyMileage}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="day" />
+        <PolarRadiusAxis />
+        <ChartTooltip />
+        <Radar
+          name="Mileage"
+          dataKey="miles"
+          stroke="var(--chart-3)"
+          fill="var(--chart-3)"
+          fillOpacity={0.4}
+        />
+      </RadarChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/HeartRateZones.tsx
+++ b/src/components/statistics/HeartRateZones.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const hrZoneData = [
+  { zone: "Recovery", bpm: 120 },
+  { zone: "Easy", bpm: 137 },
+  { zone: "Tempo", bpm: 161 },
+  { zone: "Threshold", bpm: 180 },
+]
+
+const config = {
+  bpm: { label: "Heart Rate", color: "var(--chart-8)" },
+} satisfies Record<string, unknown>
+
+export default function HeartRateZones() {
+  return (
+    <ChartContainer config={config} className="h-60" title="Heart Rate Zones">
+      <BarChart data={hrZoneData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="zone" tickLine={false} axisLine={false} />
+        <ChartTooltip />
+        <Bar dataKey="bpm" fill="var(--chart-8)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/PaceDistribution.tsx
+++ b/src/components/statistics/PaceDistribution.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import {
+  ChartContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const violinData = [
+  { pace: "5:00", density: 0.1 },
+  { pace: "5:30", density: 0.3 },
+  { pace: "6:00", density: 0.6 },
+  { pace: "6:30", density: 0.9 },
+  { pace: "7:00", density: 0.6 },
+  { pace: "7:30", density: 0.3 },
+  { pace: "8:00", density: 0.1 },
+]
+
+const config = {
+  density: { label: "Density", color: "var(--chart-7)" },
+} satisfies Record<string, unknown>
+
+export default function PaceDistribution() {
+  return (
+    <ChartContainer config={config} className="h-64" title="Pace Distribution">
+      <AreaChart data={violinData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="pace" tickLine={false} axisLine={false} />
+        <ChartTooltip />
+        <Area
+          type="monotone"
+          dataKey="density"
+          stroke="var(--chart-7)"
+          fill="var(--chart-7)"
+          fillOpacity={0.4}
+          dot={false}
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/PaceVsHR.tsx
+++ b/src/components/statistics/PaceVsHR.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import {
+  ChartContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const scatterData = Array.from({ length: 200 }, () => ({
+  pace: 6 + Math.random() * 2,
+  hr: 120 + Math.random() * 40,
+}))
+
+const config = {
+  pace: { label: "Pace", color: "var(--chart-9)" },
+  hr: { label: "Heart Rate", color: "var(--chart-10)" },
+} satisfies Record<string, unknown>
+
+export default function PaceVsHR() {
+  return (
+    <ChartContainer config={config} className="h-64" title="Pace vs Heart Rate">
+      <ScatterChart>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="pace" name="Pace (min/mi)" />
+        <YAxis dataKey="hr" name="Heart Rate (bpm)" />
+        <ChartTooltip />
+        <Scatter data={scatterData} fill="var(--chart-9)" />
+      </ScatterChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/RunDistances.tsx
+++ b/src/components/statistics/RunDistances.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const runDistanceData = [
+  { range: "1mi", count: 1125 },
+  { range: "2mi", count: 739 },
+  { range: "3mi", count: 459 },
+  { range: "4mi", count: 472 },
+  { range: "5-6mi", count: 596 },
+  { range: "7-8mi", count: 157 },
+  { range: "9-10mi", count: 51 },
+  { range: "11-12mi", count: 53 },
+  { range: "13-14mi", count: 26 },
+  { range: "15+mi", count: 4 },
+]
+
+const config = {
+  count: { label: "Count", color: "var(--chart-4)" },
+} satisfies Record<string, unknown>
+
+export default function RunDistances() {
+  return (
+    <ChartContainer config={config} className="h-60" title="Run Distances">
+      <BarChart layout="vertical" data={runDistanceData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis type="number" tickLine={false} axisLine={false} />
+        <ChartTooltip />
+        <Bar dataKey="count" fill="var(--chart-4)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/TreadmillVsOutdoor.tsx
+++ b/src/components/statistics/TreadmillVsOutdoor.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import {
+  ChartContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip as ChartTooltip,
+  Legend,
+} from "@/components/ui/chart"
+
+const treadmillData = [
+  { name: "Outdoor", value: 1254 },
+  { name: "Treadmill", value: 477 },
+]
+
+const config = {
+  Outdoor: { label: "Outdoor", color: "var(--chart-5)" },
+  Treadmill: { label: "Treadmill", color: "var(--chart-6)" },
+} satisfies Record<string, unknown>
+
+export default function TreadmillVsOutdoor() {
+  return (
+    <ChartContainer config={config} className="h-60" title="Treadmill vs Outdoor">
+      <PieChart width={200} height={160}>
+        <ChartTooltip />
+        <Legend verticalAlign="bottom" height={24} />
+        <Pie
+          data={treadmillData}
+          dataKey="value"
+          nameKey="name"
+          innerRadius={50}
+          outerRadius={70}
+          paddingAngle={4}
+          cornerRadius={8}
+          label={({ percent }) => `${Math.round(percent * 100)}%`}
+        >
+          {treadmillData.map((entry, idx) => (
+            <Cell
+              key={entry.name}
+              fill={idx === 0 ? "var(--chart-5)" : "var(--chart-6)"}
+            />
+          ))}
+        </Pie>
+      </PieChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -1,0 +1,8 @@
+export { default as AnnualMileage } from "./AnnualMileage";
+export { default as ActivityByTime } from "./ActivityByTime";
+export { default as AvgDailyMileageRadar } from "./AvgDailyMileageRadar";
+export { default as RunDistances } from "./RunDistances";
+export { default as TreadmillVsOutdoor } from "./TreadmillVsOutdoor";
+export { default as PaceDistribution } from "./PaceDistribution";
+export { default as HeartRateZones } from "./HeartRateZones";
+export { default as PaceVsHR } from "./PaceVsHR";

--- a/src/pages/StatisticsExamplesPage.tsx
+++ b/src/pages/StatisticsExamplesPage.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import AnnualMileage from "@/components/statistics/AnnualMileage"
+import ActivityByTime from "@/components/statistics/ActivityByTime"
+import AvgDailyMileageRadar from "@/components/statistics/AvgDailyMileageRadar"
+import RunDistances from "@/components/statistics/RunDistances"
+import TreadmillVsOutdoor from "@/components/statistics/TreadmillVsOutdoor"
+import PaceDistribution from "@/components/statistics/PaceDistribution"
+import HeartRateZones from "@/components/statistics/HeartRateZones"
+import PaceVsHR from "@/components/statistics/PaceVsHR"
+// import TemperatureBreakdown from "./TemperatureBreakdown"
+// import WeatherConditions from "./WeatherConditions"
+
+export default function StatisticsExamplesPage() {
+  return (
+    <div className="space-y-12 px-6 py-8 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold">Statistics</h1>
+      <div className="grid gap-8 md:grid-cols-3">
+        <AnnualMileage />
+        <ActivityByTime />
+        <AvgDailyMileageRadar />
+      </div>
+      <div className="grid gap-8 md:grid-cols-2">
+        <RunDistances />
+        <TreadmillVsOutdoor />
+      </div>
+      <div className="grid gap-8 md:grid-cols-3">
+        <PaceDistribution />
+        <HeartRateZones />
+        <PaceVsHR />
+      </div>
+      {/* add TemperatureBreakdown and WeatherConditions similarly */}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create statistics chart components with mock data
- compose a `StatisticsExamplesPage` showcasing multiple chart types

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bc5cb3cbc8324b287063ba5cc300c