### PR TITLE
Add acute:chronic load ratio chart

### DIFF
--- a/src/components/statistics/TrainingLoadRatio.tsx
+++ b/src/components/statistics/TrainingLoadRatio.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import {
+  ChartContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+
+const loadData = Array.from({ length: 28 }, (_, i) => {
+  const date = new Date()
+  date.setDate(date.getDate() - (27 - i))
+  const acute = Math.round(50 + Math.random() * 20)
+  const chronic = Math.round(40 + Math.random() * 25)
+  const ratio = +(acute / chronic).toFixed(2)
+  return {
+    date: date.toISOString().slice(0, 10),
+    ratio,
+  }
+})
+
+const config = {
+  ratio: { label: "AC Ratio", color: "var(--chart-4)" },
+} satisfies Record<string, unknown>
+
+export default function TrainingLoadRatio() {
+  return (
+    <ChartContainer
+      config={config}
+      className="h-64"
+      title="Acute vs Chronic Load Ratio"
+    >
+      <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickFormatter={(d) => new Date(d).toLocaleDateString()}
+        />
+        <YAxis domain={[0, 2]} />
+        <ChartTooltip />
+        <Area
+          type="monotone"
+          dataKey="ratio"
+          stroke="var(--chart-4)"
+          fill="var(--chart-4)"
+          fillOpacity={0.3}
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -6,3 +6,4 @@ export { default as TreadmillVsOutdoor } from "./TreadmillVsOutdoor";
 export { default as PaceDistribution } from "./PaceDistribution";
 export { default as HeartRateZones } from "./HeartRateZones";
 export { default as PaceVsHR } from "./PaceVsHR";
+export { default as TrainingLoadRatio } from "./TrainingLoadRatio";

--- a/src/pages/StatisticsExamplesPage.tsx
+++ b/src/pages/StatisticsExamplesPage.tsx
@@ -8,6 +8,7 @@ import TreadmillVsOutdoor from "@/components/statistics/TreadmillVsOutdoor"
 import PaceDistribution from "@/components/statistics/PaceDistribution"
 import HeartRateZones from "@/components/statistics/HeartRateZones"
 import PaceVsHR from "@/components/statistics/PaceVsHR"
+import TrainingLoadRatio from "@/components/statistics/TrainingLoadRatio"
 // import TemperatureBreakdown from "./TemperatureBreakdown"
 // import WeatherConditions from "./WeatherConditions"
 
@@ -24,10 +25,11 @@ export default function StatisticsExamplesPage() {
         <RunDistances />
         <TreadmillVsOutdoor />
       </div>
-      <div className="grid gap-8 md:grid-cols-3">
+      <div className="grid gap-8 md:grid-cols-4">
         <PaceDistribution />
         <HeartRateZones />
         <PaceVsHR />
+        <TrainingLoadRatio />
       </div>
       {/* add TemperatureBreakdown and WeatherConditions similarly */}
     </div>


### PR DESCRIPTION
## Summary
- add TrainingLoadRatio chart demo
- export new chart from statistics index
- showcase the chart on StatisticsExamples page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bc93ce70c832487cfb74f7ce55ef3