### PR TITLE
Add workout activity by time chart example

### DIFF
--- a/src/components/examples/RadarChartWorkoutByTime.tsx
+++ b/src/components/examples/RadarChartWorkoutByTime.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import { PolarAngleAxis, PolarGrid, Radar, RadarChart, PolarRadiusAxis } from 'recharts'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+
+export const description = 'A radar chart of workout activity by time'
+
+const chartData = [
+  { time: '12am', sessions: 2 },
+  { time: '2am', sessions: 1 },
+  { time: '4am', sessions: 0 },
+  { time: '6am', sessions: 8 },
+  { time: '8am', sessions: 12 },
+  { time: '10am', sessions: 4 },
+  { time: '12pm', sessions: 5 },
+  { time: '2pm', sessions: 1 },
+  { time: '4pm', sessions: 2 },
+  { time: '6pm', sessions: 6 },
+  { time: '8pm', sessions: 3 },
+  { time: '10pm', sessions: 2 },
+]
+
+const chartConfig = {
+  sessions: {
+    label: 'Sessions',
+    color: 'hsl(var(--chart-2))',
+  },
+} satisfies ChartConfig
+
+export default function RadarChartWorkoutByTime() {
+  return (
+    <Card>
+      <CardHeader className='items-center pb-4'>
+        <CardTitle>Workout Activity by Time</CardTitle>
+        <CardDescription>Session counts in two hour intervals</CardDescription>
+      </CardHeader>
+      <CardContent className='pb-0'>
+        <ChartContainer
+          config={chartConfig}
+          className='mx-auto aspect-square max-h-[250px]'
+        >
+          <RadarChart data={chartData}>
+            <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+            <PolarAngleAxis dataKey='time' />
+            <PolarRadiusAxis />
+            <PolarGrid />
+            <Radar
+              dataKey='sessions'
+              fill='var(--color-sessions)'
+              fillOpacity={0.6}
+            />
+          </RadarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex-col gap-2 text-sm'>
+        <div className='flex items-center gap-2 leading-none font-medium'>
+          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground flex items-center gap-2 leading-none'>
+          Activity over a typical day
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -12,6 +12,7 @@ import ChartRadialGrid from "@/components/examples/RadialChartGrid";
 import ChartBarHorizontal from "@/components/examples/BarChartHorizontal";
 import ChartPieDonut from "@/components/examples/PieChartDonut";
 import ChartRadarDots from "@/components/examples/RadarChartDots";
+import RadarChartWorkoutByTime from "@/components/examples/RadarChartWorkoutByTime";
 import ChartBarMixed from "@/components/examples/BarChartMixed";
 import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
 import { mockDailySteps } from "@/lib/api";
@@ -30,6 +31,7 @@ export default function Examples() {
       <LineChartInteractive />
 
       <ChartRadarDefault />
+      <RadarChartWorkoutByTime />
 
       <ChartRadialSimple />
 


### PR DESCRIPTION
## Summary
- add a radar chart example showing workout activity by time of day
- display the new chart on the examples page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bcb92ea54832480133656e3c2887e