### PR TITLE
Apply card styling to statistics charts

### DIFF
--- a/src/components/statistics/ActivityByTime.tsx
+++ b/src/components/statistics/ActivityByTime.tsx
@@ -9,6 +9,7 @@ import {
   Radar,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const activityByTimeData = [
   { time: "12am", value: 2 },
@@ -31,20 +32,22 @@ const config = {
 
 export default function ActivityByTime() {
   return (
-    <ChartContainer config={config} className="h-64" title="Workout Activity by Time">
-      <RadarChart data={activityByTimeData}>
-        <PolarGrid />
-        <PolarAngleAxis dataKey="time" />
-        <PolarRadiusAxis />
-        <ChartTooltip />
-        <Radar
-          name="Activity"
-          dataKey="value"
-          stroke="var(--chart-2)"
-          fill="var(--chart-2)"
-          fillOpacity={0.6}
-        />
-      </RadarChart>
-    </ChartContainer>
+    <ChartCard title="Workout Activity by Time">
+      <ChartContainer config={config} className="h-64">
+        <RadarChart data={activityByTimeData}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="time" />
+          <PolarRadiusAxis />
+          <ChartTooltip />
+          <Radar
+            name="Activity"
+            dataKey="value"
+            stroke="var(--chart-2)"
+            fill="var(--chart-2)"
+            fillOpacity={0.6}
+          />
+        </RadarChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/AnnualMileage.tsx
+++ b/src/components/statistics/AnnualMileage.tsx
@@ -8,6 +8,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const annualData = [
   { month: "1", miles: 1200 },
@@ -29,13 +30,15 @@ const config = {
 
 export default function AnnualMileage() {
   return (
-    <ChartContainer config={config} className="h-64" title="Annual Mileage">
-      <BarChart data={annualData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="month" tickLine={false} axisLine={false} />
-        <ChartTooltip />
-        <Bar dataKey="miles" fill="var(--chart-1)" radius={2} />
-      </BarChart>
-    </ChartContainer>
+    <ChartCard title="Annual Mileage">
+      <ChartContainer config={config} className="h-64">
+        <BarChart data={annualData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" tickLine={false} axisLine={false} />
+          <ChartTooltip />
+          <Bar dataKey="miles" fill="var(--chart-1)" radius={2} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/AvgDailyMileageRadar.tsx
+++ b/src/components/statistics/AvgDailyMileageRadar.tsx
@@ -9,6 +9,7 @@ import {
   Radar,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const dailyMileage = [
   { day: "Mon", miles: 5 },
@@ -26,20 +27,22 @@ const config = {
 
 export default function AvgDailyMileageRadar() {
   return (
-    <ChartContainer config={config} className="h-64" title="Average Daily Mileage">
-      <RadarChart data={dailyMileage}>
-        <PolarGrid />
-        <PolarAngleAxis dataKey="day" />
-        <PolarRadiusAxis />
-        <ChartTooltip />
-        <Radar
-          name="Mileage"
-          dataKey="miles"
-          stroke="var(--chart-3)"
-          fill="var(--chart-3)"
-          fillOpacity={0.4}
-        />
-      </RadarChart>
-    </ChartContainer>
+    <ChartCard title="Average Daily Mileage">
+      <ChartContainer config={config} className="h-64">
+        <RadarChart data={dailyMileage}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="day" />
+          <PolarRadiusAxis />
+          <ChartTooltip />
+          <Radar
+            name="Mileage"
+            dataKey="miles"
+            stroke="var(--chart-3)"
+            fill="var(--chart-3)"
+            fillOpacity={0.4}
+          />
+        </RadarChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/HeartRateZones.tsx
+++ b/src/components/statistics/HeartRateZones.tsx
@@ -8,6 +8,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const hrZoneData = [
   { zone: "Recovery", bpm: 120 },
@@ -22,13 +23,15 @@ const config = {
 
 export default function HeartRateZones() {
   return (
-    <ChartContainer config={config} className="h-60" title="Heart Rate Zones">
-      <BarChart data={hrZoneData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="zone" tickLine={false} axisLine={false} />
-        <ChartTooltip />
-        <Bar dataKey="bpm" fill="var(--chart-8)" radius={4} />
-      </BarChart>
-    </ChartContainer>
+    <ChartCard title="Heart Rate Zones">
+      <ChartContainer config={config} className="h-60">
+        <BarChart data={hrZoneData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="zone" tickLine={false} axisLine={false} />
+          <ChartTooltip />
+          <Bar dataKey="bpm" fill="var(--chart-8)" radius={4} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/PaceDistribution.tsx
+++ b/src/components/statistics/PaceDistribution.tsx
@@ -8,6 +8,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const violinData = [
   { pace: "5:00", density: 0.1 },
@@ -25,20 +26,22 @@ const config = {
 
 export default function PaceDistribution() {
   return (
-    <ChartContainer config={config} className="h-64" title="Pace Distribution">
-      <AreaChart data={violinData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="pace" tickLine={false} axisLine={false} />
-        <ChartTooltip />
-        <Area
-          type="monotone"
-          dataKey="density"
-          stroke="var(--chart-7)"
-          fill="var(--chart-7)"
-          fillOpacity={0.4}
-          dot={false}
-        />
-      </AreaChart>
-    </ChartContainer>
+    <ChartCard title="Pace Distribution">
+      <ChartContainer config={config} className="h-64">
+        <AreaChart data={violinData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="pace" tickLine={false} axisLine={false} />
+          <ChartTooltip />
+          <Area
+            type="monotone"
+            dataKey="density"
+            stroke="var(--chart-7)"
+            fill="var(--chart-7)"
+            fillOpacity={0.4}
+            dot={false}
+          />
+        </AreaChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/PaceVsHR.tsx
+++ b/src/components/statistics/PaceVsHR.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const scatterData = Array.from({ length: 200 }, () => ({
   pace: 6 + Math.random() * 2,
@@ -22,14 +23,16 @@ const config = {
 
 export default function PaceVsHR() {
   return (
-    <ChartContainer config={config} className="h-64" title="Pace vs Heart Rate">
-      <ScatterChart>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="pace" name="Pace (min/mi)" />
-        <YAxis dataKey="hr" name="Heart Rate (bpm)" />
-        <ChartTooltip />
-        <Scatter data={scatterData} fill="var(--chart-9)" />
-      </ScatterChart>
-    </ChartContainer>
+    <ChartCard title="Pace vs Heart Rate">
+      <ChartContainer config={config} className="h-64">
+        <ScatterChart>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="pace" name="Pace (min/mi)" />
+          <YAxis dataKey="hr" name="Heart Rate (bpm)" />
+          <ChartTooltip />
+          <Scatter data={scatterData} fill="var(--chart-9)" />
+        </ScatterChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/RunDistances.tsx
+++ b/src/components/statistics/RunDistances.tsx
@@ -8,6 +8,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const runDistanceData = [
   { range: "1mi", count: 1125 },
@@ -28,13 +29,15 @@ const config = {
 
 export default function RunDistances() {
   return (
-    <ChartContainer config={config} className="h-60" title="Run Distances">
-      <BarChart layout="vertical" data={runDistanceData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis type="number" tickLine={false} axisLine={false} />
-        <ChartTooltip />
-        <Bar dataKey="count" fill="var(--chart-4)" radius={4} />
-      </BarChart>
-    </ChartContainer>
+    <ChartCard title="Run Distances">
+      <ChartContainer config={config} className="h-60">
+        <BarChart layout="vertical" data={runDistanceData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" tickLine={false} axisLine={false} />
+          <ChartTooltip />
+          <Bar dataKey="count" fill="var(--chart-4)" radius={4} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/TrainingLoadRatio.tsx
+++ b/src/components/statistics/TrainingLoadRatio.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 
 const loadData = Array.from({ length: 28 }, (_, i) => {
   const date = new Date()
@@ -28,27 +29,25 @@ const config = {
 
 export default function TrainingLoadRatio() {
   return (
-    <ChartContainer
-      config={config}
-      className="h-64"
-      title="Acute vs Chronic Load Ratio"
-    >
-      <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis
-          dataKey="date"
-          tickFormatter={(d) => new Date(d).toLocaleDateString()}
-        />
-        <YAxis domain={[0, 2]} />
-        <ChartTooltip />
-        <Area
-          type="monotone"
-          dataKey="ratio"
-          stroke="var(--chart-4)"
-          fill="var(--chart-4)"
-          fillOpacity={0.3}
-        />
-      </AreaChart>
-    </ChartContainer>
+    <ChartCard title="Acute vs Chronic Load Ratio">
+      <ChartContainer config={config} className="h-64">
+        <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="date"
+            tickFormatter={(d) => new Date(d).toLocaleDateString()}
+          />
+          <YAxis domain={[0, 2]} />
+          <ChartTooltip />
+          <Area
+            type="monotone"
+            dataKey="ratio"
+            stroke="var(--chart-4)"
+            fill="var(--chart-4)"
+            fillOpacity={0.3}
+          />
+        </AreaChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }

--- a/src/components/statistics/TreadmillVsOutdoor.tsx
+++ b/src/components/statistics/TreadmillVsOutdoor.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip as ChartTooltip,
   ChartLegend,
 } from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
 import { Cell } from "recharts"
 
 
@@ -22,30 +23,32 @@ const config = {
 
 export default function TreadmillVsOutdoor() {
   return (
-    <ChartContainer config={config} className="h-60" title="Treadmill vs Outdoor">
-      <PieChart width={200} height={160}>
-        <ChartTooltip />
+    <ChartCard title="Treadmill vs Outdoor">
+      <ChartContainer config={config} className="h-60">
+        <PieChart width={200} height={160}>
+          <ChartTooltip />
 
-        <ChartLegend verticalAlign="bottom" height={24} />
+          <ChartLegend verticalAlign="bottom" height={24} />
 
-        <Pie
-          data={treadmillData}
-          dataKey="value"
-          nameKey="name"
-          innerRadius={50}
-          outerRadius={70}
-          paddingAngle={4}
-          cornerRadius={8}
-          label={({ percent }) => `${Math.round(percent * 100)}%`}
-        >
-          {treadmillData.map((entry, idx) => (
-            <Cell
-              key={entry.name}
-              fill={idx === 0 ? "var(--chart-5)" : "var(--chart-6)"}
-            />
-          ))}
-        </Pie>
-      </PieChart>
-    </ChartContainer>
+          <Pie
+            data={treadmillData}
+            dataKey="value"
+            nameKey="name"
+            innerRadius={50}
+            outerRadius={70}
+            paddingAngle={4}
+            cornerRadius={8}
+            label={({ percent }) => `${Math.round(percent * 100)}%`}
+          >
+            {treadmillData.map((entry, idx) => (
+              <Cell
+                key={entry.name}
+                fill={idx === 0 ? "var(--chart-5)" : "var(--chart-6)"}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ChartContainer>
+    </ChartCard>
   )
 }


### PR DESCRIPTION
## Summary
- wrap each statistics chart in `ChartCard`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bcbe38e088324ad074d804874a5d8