### PR TITLE
Add treadmill vs outdoor chart example

### DIFF
--- a/src/components/examples/TreadmillVsOutdoor.tsx
+++ b/src/components/examples/TreadmillVsOutdoor.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import {
+  ChartContainer,
+  PieChart,
+  Pie,
+  Tooltip as ChartTooltip,
+  ChartLegend,
+} from '@/components/ui/chart'
+import { Cell } from 'recharts'
+
+export const description = 'A treadmill vs outdoor chart'
+
+const chartData = [
+  { name: 'Outdoor', value: 1254 },
+  { name: 'Treadmill', value: 477 },
+]
+
+const chartConfig = {
+  Outdoor: { label: 'Outdoor', color: 'var(--chart-5)' },
+  Treadmill: { label: 'Treadmill', color: 'var(--chart-6)' },
+} satisfies Record<string, unknown>
+
+export default function TreadmillVsOutdoorExample() {
+  return (
+    <ChartContainer config={chartConfig} className='h-60' title='Treadmill vs Outdoor'>
+      <PieChart width={200} height={160}>
+        <ChartTooltip />
+        <ChartLegend verticalAlign='bottom' height={24} />
+        <Pie
+          data={chartData}
+          dataKey='value'
+          nameKey='name'
+          innerRadius={50}
+          outerRadius={70}
+          paddingAngle={4}
+          cornerRadius={8}
+          label={({ percent }) => `${Math.round(percent * 100)}%`}
+        >
+          {chartData.map((entry, idx) => (
+            <Cell
+              key={entry.name}
+              fill={idx === 0 ? 'var(--chart-5)' : 'var(--chart-6)'}
+            />
+          ))}
+        </Pie>
+      </PieChart>
+    </ChartContainer>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -15,6 +15,7 @@ import ChartRadarDots from "@/components/examples/RadarChartDots";
 import RadarChartWorkoutByTime from "@/components/examples/RadarChartWorkoutByTime";
 import ChartBarMixed from "@/components/examples/BarChartMixed";
 import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
+import ChartTreadmillVsOutdoor from "@/components/examples/TreadmillVsOutdoor";
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
 
@@ -46,6 +47,7 @@ export default function Examples() {
       <ChartRadarDots />
       <ChartBarMixed />
       <ChartBarLabelCustom />
+      <ChartTreadmillVsOutdoor />
 
     </div>
   );


### PR DESCRIPTION
## Summary
- add a Treadmill vs Outdoor pie chart example component
- show the new example on the Examples page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bcd153bf8832492ac261d17a9ba1a