### PR TITLE
Add GeoActivityExplorer map component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Layout from "@/components/layout/Layout";
 import Dashboard from "@/pages/Dashboard";
 import Examples from "@/pages/Examples";
 import StatisticsExamplesPage from "@/pages/StatisticsExamplesPage";
+import GeoActivityExplorer from "@/components/map/GeoActivityExplorer";
 
 function App() {
   const [tab, setTab] = useState("dashboard");
@@ -10,7 +11,7 @@ function App() {
     <Layout activeTab={tab} setActiveTab={setTab}>
       {tab === "dashboard" && <Dashboard />}
       {tab === "trends" && <p>Trends coming soon...</p>}
-      {tab === "map" && <p>Map coming soon...</p>}
+      {tab === "map" && <GeoActivityExplorer />}
       {tab === "examples" && <Examples />}
       {tab === "statistics" && <StatisticsExamplesPage />}
     </Layout>

--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { useStateVisits } from "@/hooks/useStateVisits";
+import type { StateVisit } from "@/lib/types";
+import { ChartContainer } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+export default function GeoActivityExplorer() {
+  const data = useStateVisits();
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  if (!data) return <Skeleton className="h-60 w-full" />;
+
+  const selected = expanded
+    ? data.find((d) => d.stateCode === expanded) || null
+    : null;
+
+  return (
+    <ChartContainer config={{}} title="State Visits" className="space-y-4">
+      <div className="grid grid-cols-5 gap-2">
+        {data.map((state) => (
+          <button
+            key={state.stateCode}
+            aria-pressed={expanded === state.stateCode}
+            onClick={() =>
+              setExpanded(expanded === state.stateCode ? null : state.stateCode)
+            }
+            className={cn(
+              "h-12 flex items-center justify-center rounded border text-sm font-medium focus:outline-none focus:ring",
+              state.visited
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground",
+              expanded === state.stateCode && "ring-2 ring-ring"
+            )}
+          >
+            {state.stateCode}
+          </button>
+        ))}
+      </div>
+      {selected && <StateDetail state={selected} />}
+    </ChartContainer>
+  );
+}
+
+function StateDetail({ state }: { state: StateVisit }) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium">
+        {state.stateCode} &ndash; {state.totalDays} days, {state.totalMiles} miles
+      </h3>
+      {state.cities.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No cities visited</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="py-1">City</th>
+              <th className="py-1">Days</th>
+              <th className="py-1">Miles</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.cities.map((city) => (
+              <tr key={city.name} className="border-t border-border">
+                <td className="py-1">{city.name}</td>
+                <td className="py-1">{city.days}</td>
+                <td className="py-1">{city.miles}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import GeoActivityExplorer from "../GeoActivityExplorer";
+import { vi } from "vitest";
+
+vi.mock("@/hooks/useStateVisits", () => ({
+  useStateVisits: () => [
+    {
+      stateCode: "CA",
+      visited: true,
+      totalDays: 10,
+      totalMiles: 100,
+      cities: [{ name: "LA", days: 4, miles: 40 }],
+    },
+  ],
+}));
+
+describe("GeoActivityExplorer", () => {
+  it("toggles state details", () => {
+    render(<GeoActivityExplorer />);
+    const button = screen.getByRole("button", { name: "CA" });
+    fireEvent.click(button);
+    expect(screen.getByText("LA")).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(screen.queryByText("LA")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `GeoActivityExplorer` component with grid and details table
- display the explorer when the Map tab is selected
- create initial test for GeoActivityExplorer

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_688bcbffdc6c8324ba637f798788ae9f