### PR TITLE
Add sample pace and training load charts

### DIFF
--- a/src/components/examples/AreaChartLoadRatio.tsx
+++ b/src/components/examples/AreaChartLoadRatio.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import {
+  ChartContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from '@/components/ui/chart'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card'
+
+const loadData = Array.from({ length: 28 }, (_, i) => {
+  const date = new Date()
+  date.setDate(date.getDate() - (27 - i))
+  const acute = Math.round(50 + Math.random() * 20)
+  const chronic = Math.round(40 + Math.random() * 25)
+  const ratio = +(acute / chronic).toFixed(2)
+  return {
+    date: date.toISOString().slice(0, 10),
+    ratio,
+  }
+})
+
+const chartConfig = {
+  ratio: { label: 'AC Ratio', color: 'hsl(var(--chart-4))' },
+} as const
+
+export default function AreaChartLoadRatio() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Acute vs Chronic Load Ratio</CardTitle>
+        <CardDescription>Last 4 weeks</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className='h-64'>
+          <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+            <CartesianGrid strokeDasharray='3 3' />
+            <XAxis
+              dataKey='date'
+              tickFormatter={(d) => new Date(d).toLocaleDateString()}
+            />
+            <YAxis domain={[0, 2]} />
+            <ChartTooltip />
+            <Area
+              type='monotone'
+              dataKey='ratio'
+              stroke={chartConfig.ratio.color}
+              fill={chartConfig.ratio.color}
+              fillOpacity={0.3}
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex items-center gap-2 text-sm'>
+        Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import {
+  ChartContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from '@/components/ui/chart'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card'
+
+const scatterData = Array.from({ length: 200 }, () => ({
+  pace: 6 + Math.random() * 2,
+  hr: 120 + Math.random() * 40,
+}))
+
+const chartConfig = {
+  pace: { label: 'Pace', color: 'hsl(var(--chart-9))' },
+  hr: { label: 'Heart Rate', color: 'hsl(var(--chart-10))' },
+} as const
+
+export default function ScatterChartPaceHeartRate() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pace vs Heart Rate</CardTitle>
+        <CardDescription>Example scatter plot</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className='h-64'>
+          <ScatterChart>
+            <CartesianGrid strokeDasharray='3 3' />
+            <XAxis dataKey='pace' name='Pace (min/mi)' />
+            <YAxis dataKey='hr' name='Heart Rate (bpm)' />
+            <ChartTooltip />
+            <Scatter data={scatterData} fill='var(--color-pace)' />
+          </ScatterChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex items-center gap-2 text-sm'>
+        Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -15,6 +15,8 @@ import ChartRadarDots from "@/components/examples/RadarChartDots";
 import RadarChartWorkoutByTime from "@/components/examples/RadarChartWorkoutByTime";
 import ChartBarMixed from "@/components/examples/BarChartMixed";
 import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
+import ScatterChartPaceHeartRate from "@/components/examples/ScatterChartPaceHeartRate";
+import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
 
@@ -46,6 +48,9 @@ export default function Examples() {
       <ChartRadarDots />
       <ChartBarMixed />
       <ChartBarLabelCustom />
+
+      <ScatterChartPaceHeartRate />
+      <AreaChartLoadRatio />
 
     </div>
   );


### PR DESCRIPTION
## Summary
- add Pace vs Heart Rate scatter example
- add Acute vs Chronic Load Ratio area example
- display these examples on the examples page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bcd6cac7883248c23115d47e495f0