### PR TITLE
Use activity-themed mock data for example charts

### DIFF
--- a/src/components/examples/BarChartDefault.tsx
+++ b/src/components/examples/BarChartDefault.tsx
@@ -20,18 +20,19 @@ import {
 
 export const description = 'A bar chart'
 
+// Mock monthly mileage totals so the chart resembles fitness data
 const chartData = [
-  { month: 'January', desktop: 186 },
-  { month: 'February', desktop: 305 },
-  { month: 'March', desktop: 237 },
-  { month: 'April', desktop: 73 },
-  { month: 'May', desktop: 209 },
-  { month: 'June', desktop: 214 },
+  { month: 'January', miles: 120 },
+  { month: 'February', miles: 150 },
+  { month: 'March', miles: 95 },
+  { month: 'April', miles: 160 },
+  { month: 'May', miles: 175 },
+  { month: 'June', miles: 140 },
 ]
 
 const chartConfig = {
-  desktop: {
-    label: 'Desktop',
+  miles: {
+    label: 'Miles',
     color: 'hsl(var(--chart-1))',
   },
 } satisfies ChartConfig
@@ -55,7 +56,7 @@ export default function ChartBarDefault() {
               tickFormatter={(value) => value.slice(0, 3)}
             />
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
-            <Bar dataKey='desktop' fill='var(--color-desktop)' radius={8} />
+            <Bar dataKey='miles' fill='var(--color-miles)' radius={8} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/examples/BarChartHorizontal.tsx
+++ b/src/components/examples/BarChartHorizontal.tsx
@@ -20,18 +20,19 @@ import {
 
 export const description = 'A horizontal bar chart'
 
+// Monthly mileage totals used as mock activity data
 const chartData = [
-  { month: 'January', desktop: 186 },
-  { month: 'February', desktop: 305 },
-  { month: 'March', desktop: 237 },
-  { month: 'April', desktop: 73 },
-  { month: 'May', desktop: 209 },
-  { month: 'June', desktop: 214 },
+  { month: 'January', miles: 120 },
+  { month: 'February', miles: 150 },
+  { month: 'March', miles: 95 },
+  { month: 'April', miles: 160 },
+  { month: 'May', miles: 175 },
+  { month: 'June', miles: 140 },
 ]
 
 const chartConfig = {
-  desktop: {
-    label: 'Desktop',
+  miles: {
+    label: 'Miles',
     color: 'hsl(var(--chart-1))',
   },
 } satisfies ChartConfig
@@ -51,7 +52,7 @@ export default function ChartBarHorizontal() {
             layout='vertical'
             margin={{ left: -20 }}
           >
-            <XAxis type='number' dataKey='desktop' hide />
+            <XAxis type='number' dataKey='miles' hide />
             <YAxis
               dataKey='month'
               type='category'
@@ -61,7 +62,7 @@ export default function ChartBarHorizontal() {
               tickFormatter={(value) => value.slice(0, 3)}
             />
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
-            <Bar dataKey='desktop' fill='var(--color-desktop)' radius={5} />
+            <Bar dataKey='miles' fill='var(--color-miles)' radius={5} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/examples/BarChartLabelCustom.tsx
+++ b/src/components/examples/BarChartLabelCustom.tsx
@@ -20,18 +20,19 @@ import {
 
 export const description = 'A bar chart with a custom label'
 
+// Mock monthly mileage split by activity type
 const chartData = [
-  { month: 'January', desktop: 186, mobile: 80 },
-  { month: 'February', desktop: 305, mobile: 200 },
-  { month: 'March', desktop: 237, mobile: 120 },
-  { month: 'April', desktop: 73, mobile: 190 },
-  { month: 'May', desktop: 209, mobile: 130 },
-  { month: 'June', desktop: 214, mobile: 140 },
+  { month: 'January', run: 60, bike: 40 },
+  { month: 'February', run: 70, bike: 50 },
+  { month: 'March', run: 55, bike: 65 },
+  { month: 'April', run: 80, bike: 80 },
+  { month: 'May', run: 90, bike: 85 },
+  { month: 'June', run: 75, bike: 65 },
 ]
 
 const chartConfig = {
-  desktop: { label: 'Desktop', color: 'hsl(var(--chart-2))' },
-  mobile: { label: 'Mobile', color: 'hsl(var(--chart-2))' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
   label: { color: 'hsl(var(--background))' },
 } satisfies ChartConfig
 
@@ -55,11 +56,11 @@ export default function ChartBarLabelCustom() {
               tickFormatter={(value) => value.slice(0, 3)}
               hide
             />
-            <XAxis dataKey='desktop' type='number' hide />
+            <XAxis dataKey='run' type='number' hide />
             <ChartTooltip cursor={false} content={<ChartTooltipContent indicator='line' />} />
-            <Bar dataKey='desktop' layout='vertical' fill='var(--color-desktop)' radius={4}>
+            <Bar dataKey='run' layout='vertical' fill='var(--color-run)' radius={4}>
               <LabelList dataKey='month' position='insideLeft' offset={8} className='fill-[var(--color-label)]' fontSize={12} />
-              <LabelList dataKey='desktop' position='right' offset={8} className='fill-foreground' fontSize={12} />
+              <LabelList dataKey='run' position='right' offset={8} className='fill-foreground' fontSize={12} />
             </Bar>
           </BarChart>
         </ChartContainer>
@@ -69,7 +70,7 @@ export default function ChartBarLabelCustom() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing run mileage for the last 6 months
         </div>
       </CardFooter>
     </Card>

--- a/src/components/examples/BarChartMixed.tsx
+++ b/src/components/examples/BarChartMixed.tsx
@@ -20,20 +20,21 @@ import {
 
 export const description = 'A mixed bar chart'
 
+// Share of different activity types measured in session counts
 const chartData = [
-  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
-  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
-  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
-  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
-  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+  { activity: 'run', sessions: 45, fill: 'var(--color-run)' },
+  { activity: 'bike', sessions: 30, fill: 'var(--color-bike)' },
+  { activity: 'swim', sessions: 12, fill: 'var(--color-swim)' },
+  { activity: 'hike', sessions: 8, fill: 'var(--color-hike)' },
+  { activity: 'other', sessions: 6, fill: 'var(--color-other)' },
 ]
 
 const chartConfig = {
-  visitors: { label: 'Visitors' },
-  chrome: { label: 'Chrome', color: 'hsl(var(--chart-1))' },
-  safari: { label: 'Safari', color: 'hsl(var(--chart-2))' },
-  firefox: { label: 'Firefox', color: 'hsl(var(--chart-3))' },
-  edge: { label: 'Edge', color: 'hsl(var(--chart-4))' },
+  sessions: { label: 'Sessions' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
+  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  hike: { label: 'Hike', color: 'hsl(var(--chart-4))' },
   other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig
 
@@ -48,16 +49,16 @@ export default function ChartBarMixed() {
         <ChartContainer config={chartConfig} className='h-60'>
           <BarChart accessibilityLayer data={chartData} layout='vertical' margin={{ left: 0 }}>
             <YAxis
-              dataKey='browser'
+              dataKey='activity'
               type='category'
               tickLine={false}
               tickMargin={10}
               axisLine={false}
               tickFormatter={(value) => chartConfig[value as keyof typeof chartConfig]?.label}
             />
-            <XAxis dataKey='visitors' type='number' hide />
+            <XAxis dataKey='sessions' type='number' hide />
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
-            <Bar dataKey='visitors' layout='vertical' radius={5} />
+            <Bar dataKey='sessions' layout='vertical' radius={5} />
           </BarChart>
         </ChartContainer>
       </CardContent>
@@ -66,7 +67,7 @@ export default function ChartBarMixed() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing total sessions for the last 6 months
         </div>
       </CardFooter>
     </Card>

--- a/src/components/examples/PieChartDonut.tsx
+++ b/src/components/examples/PieChartDonut.tsx
@@ -20,20 +20,21 @@ import {
 
 export const description = 'A donut chart'
 
+// Distribution of workout minutes by activity type
 const chartData = [
-  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
-  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
-  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
-  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
-  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+  { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
+  { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
+  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
+  { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
+  { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
 ]
 
 const chartConfig = {
-  visitors: { label: 'Visitors' },
-  chrome: { label: 'Chrome', color: 'hsl(var(--chart-1))' },
-  safari: { label: 'Safari', color: 'hsl(var(--chart-2))' },
-  firefox: { label: 'Firefox', color: 'hsl(var(--chart-3))' },
-  edge: { label: 'Edge', color: 'hsl(var(--chart-4))' },
+  minutes: { label: 'Minutes' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
+  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  strength: { label: 'Strength', color: 'hsl(var(--chart-4))' },
   other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig
 
@@ -48,7 +49,7 @@ export default function ChartPieDonut() {
         <ChartContainer config={chartConfig} className='mx-auto aspect-square max-h-[250px]'>
           <PieChart>
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
-            <Pie data={chartData} dataKey='visitors' nameKey='browser' innerRadius={60} />
+            <Pie data={chartData} dataKey='minutes' nameKey='activity' innerRadius={60} />
           </PieChart>
         </ChartContainer>
       </CardContent>
@@ -57,7 +58,7 @@ export default function ChartPieDonut() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing total workout minutes for the last 6 months
         </div>
       </CardFooter>
     </Card>

--- a/src/components/examples/RadarChartDots.tsx
+++ b/src/components/examples/RadarChartDots.tsx
@@ -20,18 +20,19 @@ import {
 
 export const description = 'A radar chart with dots'
 
+// Mock mileage data by month
 const chartData = [
-  { month: 'January', desktop: 186 },
-  { month: 'February', desktop: 305 },
-  { month: 'March', desktop: 237 },
-  { month: 'April', desktop: 273 },
-  { month: 'May', desktop: 209 },
-  { month: 'June', desktop: 214 },
+  { month: 'January', miles: 120 },
+  { month: 'February', miles: 150 },
+  { month: 'March', miles: 95 },
+  { month: 'April', miles: 160 },
+  { month: 'May', miles: 175 },
+  { month: 'June', miles: 140 },
 ]
 
 const chartConfig = {
-  desktop: {
-    label: 'Desktop',
+  miles: {
+    label: 'Miles',
     color: 'hsl(var(--chart-1))',
   },
 } satisfies ChartConfig
@@ -41,7 +42,7 @@ export default function ChartRadarDots() {
     <Card>
       <CardHeader className='items-center'>
         <CardTitle>Radar Chart - Dots</CardTitle>
-        <CardDescription>Showing total visitors for the last 6 months</CardDescription>
+        <CardDescription>Showing monthly mileage for the last 6 months</CardDescription>
       </CardHeader>
       <CardContent className='pb-0'>
         <ChartContainer config={chartConfig} className='mx-auto aspect-square max-h-[250px]'>
@@ -49,7 +50,7 @@ export default function ChartRadarDots() {
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
             <PolarAngleAxis dataKey='month' />
             <PolarGrid />
-            <Radar dataKey='desktop' fill='var(--color-desktop)' fillOpacity={0.6} dot={{ r: 4, fillOpacity: 1 }} />
+            <Radar dataKey='miles' fill='var(--color-miles)' fillOpacity={0.6} dot={{ r: 4, fillOpacity: 1 }} />
           </RadarChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/examples/RadialChartGrid.tsx
+++ b/src/components/examples/RadialChartGrid.tsx
@@ -20,20 +20,21 @@ import {
 
 export const description = 'A radial chart with a grid'
 
+// Distribution of workout minutes by activity type
 const chartData = [
-  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
-  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
-  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
-  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
-  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+  { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
+  { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
+  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
+  { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
+  { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
 ]
 
 const chartConfig = {
-  visitors: { label: 'Visitors' },
-  chrome: { label: 'Chrome', color: 'hsl(var(--chart-1))' },
-  safari: { label: 'Safari', color: 'hsl(var(--chart-2))' },
-  firefox: { label: 'Firefox', color: 'hsl(var(--chart-3))' },
-  edge: { label: 'Edge', color: 'hsl(var(--chart-4))' },
+  minutes: { label: 'Minutes' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
+  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  strength: { label: 'Strength', color: 'hsl(var(--chart-4))' },
   other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig
 
@@ -50,9 +51,9 @@ export default function ChartRadialGrid() {
           className='mx-auto aspect-square max-h-[250px]'
         >
           <RadialBarChart data={chartData} innerRadius={30} outerRadius={100}>
-            <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel nameKey='browser' />} />
+            <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel nameKey='activity' />} />
             <PolarGrid gridType='circle' />
-            <RadialBar dataKey='visitors' />
+            <RadialBar dataKey='minutes' />
           </RadialBarChart>
         </ChartContainer>
       </CardContent>
@@ -61,7 +62,7 @@ export default function ChartRadialGrid() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing total workout minutes for the last 6 months
         </div>
       </CardFooter>
     </Card>

--- a/src/components/examples/RadialChartLabel.tsx
+++ b/src/components/examples/RadialChartLabel.tsx
@@ -20,38 +20,22 @@ import {
 
 export const description = 'A radial chart with a label'
 
+// Distribution of workout minutes by activity type
 const chartData = [
-  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
-  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
-  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
-  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
-  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+  { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
+  { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
+  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
+  { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
+  { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
 ]
 
 const chartConfig = {
-  visitors: {
-    label: 'Visitors',
-  },
-  chrome: {
-    label: 'Chrome',
-    color: 'hsl(var(--chart-1))',
-  },
-  safari: {
-    label: 'Safari',
-    color: 'hsl(var(--chart-2))',
-  },
-  firefox: {
-    label: 'Firefox',
-    color: 'hsl(var(--chart-3))',
-  },
-  edge: {
-    label: 'Edge',
-    color: 'hsl(var(--chart-4))',
-  },
-  other: {
-    label: 'Other',
-    color: 'hsl(var(--chart-5))',
-  },
+  minutes: { label: 'Minutes' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
+  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  strength: { label: 'Strength', color: 'hsl(var(--chart-4))' },
+  other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig
 
 export default function ChartRadialLabel() {
@@ -75,12 +59,12 @@ export default function ChartRadialLabel() {
           >
             <ChartTooltip
               cursor={false}
-              content={<ChartTooltipContent hideLabel nameKey='browser' />}
+              content={<ChartTooltipContent hideLabel nameKey='activity' />}
             />
-            <RadialBar dataKey='visitors' background>
+            <RadialBar dataKey='minutes' background>
               <LabelList
                 position='insideStart'
-                dataKey='browser'
+                dataKey='activity'
                 className='fill-white capitalize mix-blend-luminosity'
                 fontSize={11}
               />
@@ -93,7 +77,7 @@ export default function ChartRadialLabel() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing total workout minutes for the last 6 months
         </div>
       </CardFooter>
     </Card>

--- a/src/components/examples/RadialChartSimple.tsx
+++ b/src/components/examples/RadialChartSimple.tsx
@@ -20,38 +20,22 @@ import {
 
 export const description = 'A radial chart'
 
+// Distribution of workout minutes by activity type
 const chartData = [
-  { browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
-  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
-  { browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
-  { browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
-  { browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+  { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
+  { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
+  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
+  { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
+  { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
 ]
 
 const chartConfig = {
-  visitors: {
-    label: 'Visitors',
-  },
-  chrome: {
-    label: 'Chrome',
-    color: 'hsl(var(--chart-1))',
-  },
-  safari: {
-    label: 'Safari',
-    color: 'hsl(var(--chart-2))',
-  },
-  firefox: {
-    label: 'Firefox',
-    color: 'hsl(var(--chart-3))',
-  },
-  edge: {
-    label: 'Edge',
-    color: 'hsl(var(--chart-4))',
-  },
-  other: {
-    label: 'Other',
-    color: 'hsl(var(--chart-5))',
-  },
+  minutes: { label: 'Minutes' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
+  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  strength: { label: 'Strength', color: 'hsl(var(--chart-4))' },
+  other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig
 
 export default function ChartRadialSimple() {
@@ -69,9 +53,9 @@ export default function ChartRadialSimple() {
           <RadialBarChart data={chartData} innerRadius={30} outerRadius={110}>
             <ChartTooltip
               cursor={false}
-              content={<ChartTooltipContent hideLabel nameKey='browser' />}
+              content={<ChartTooltipContent hideLabel nameKey='activity' />}
             />
-            <RadialBar dataKey='visitors' background />
+            <RadialBar dataKey='minutes' background />
           </RadialBarChart>
         </ChartContainer>
       </CardContent>
@@ -80,7 +64,7 @@ export default function ChartRadialSimple() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing total workout minutes for the last 6 months
         </div>
       </CardFooter>
     </Card>

--- a/src/components/examples/RadialChartText.tsx
+++ b/src/components/examples/RadialChartText.tsx
@@ -21,17 +21,18 @@ import { ChartConfig, ChartContainer } from '@/components/ui/chart'
 
 export const description = 'A radial chart with text'
 
+// Single activity with minutes value for demonstration
 const chartData = [
-  { browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+  { activity: 'Run', minutes: 200, fill: 'var(--color-run)' },
 ]
 
 const chartConfig = {
-  visitors: {
-    label: 'Visitors',
+  minutes: {
+    label: 'Minutes',
   },
-  safari: {
-    label: 'Safari',
-    color: 'hsl(var(--chart-2))',
+  run: {
+    label: 'Run',
+    color: 'hsl(var(--chart-1))',
   },
 } satisfies ChartConfig
 
@@ -61,7 +62,7 @@ export default function ChartRadialText() {
               className='first:fill-muted last:fill-background'
               polarRadius={[86, 74]}
             />
-            <RadialBar dataKey='visitors' background cornerRadius={10} />
+            <RadialBar dataKey='minutes' background cornerRadius={10} />
             <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
               <Label
                 content={({ viewBox }) => {
@@ -78,14 +79,14 @@ export default function ChartRadialText() {
                           y={viewBox.cy}
                           className='fill-foreground text-4xl font-bold'
                         >
-                          {chartData[0].visitors.toLocaleString()}
+                          {chartData[0].minutes.toLocaleString()}
                         </tspan>
                         <tspan
                           x={viewBox.cx}
                           y={(viewBox.cy || 0) + 24}
                           className='fill-muted-foreground'
                         >
-                          Visitors
+                          Minutes
                         </tspan>
                       </text>
                     )
@@ -101,7 +102,7 @@ export default function ChartRadialText() {
           Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
-          Showing total visitors for the last 6 months
+          Showing total workout minutes for the last 6 months
         </div>
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Summary
- replace generic browser/visitor data with mock activity stats
- update labels and colors to match the new activity data
- keep examples page visually consistent with fitness theme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bcc7912b883249066c3b1d1699daa