### PR TITLE
Fix missing import in examples page

### DIFF
--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -15,6 +15,7 @@ import ChartRadarDots from "@/components/examples/RadarChartDots";
 import RadarChartWorkoutByTime from "@/components/examples/RadarChartWorkoutByTime";
 import ChartBarMixed from "@/components/examples/BarChartMixed";
 import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
+import ChartTreadmillVsOutdoor from "@/components/examples/TreadmillVsOutdoor";
 import ScatterChartPaceHeartRate from "@/components/examples/ScatterChartPaceHeartRate";
 import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import { mockDailySteps } from "@/lib/api";


### PR DESCRIPTION
## Summary
- repair missing import for the treadmill vs outdoor example

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bd4b93f98832488a9c316cf3e6bcf