### PR TITLE
Add MiniSparkline component and show recent activity

### DIFF
--- a/src/components/dashboard/MiniSparkline.tsx
+++ b/src/components/dashboard/MiniSparkline.tsx
@@ -1,0 +1,37 @@
+import { AreaChart, Area, ResponsiveContainer } from "@/components/ui/chart";
+
+export interface MiniSparklinePoint {
+  date: string;
+  value: number;
+}
+
+export interface MiniSparklineProps {
+  data: MiniSparklinePoint[];
+}
+
+export function MiniSparkline({ data }: MiniSparklineProps) {
+  return (
+    <div className="h-16 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+          <defs>
+            <linearGradient id="sparkFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0.05} />
+            </linearGradient>
+          </defs>
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke="hsl(var(--chart-1))"
+            fill="url(#sparkFill)"
+            dot={false}
+            strokeWidth={2}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export default MiniSparkline;

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -6,3 +6,4 @@ export * from "./ActivitiesChart";
 export * from "./StepsChart";
 export * from "./DailyStepsChart";
 export * from "./StepsTrendWithGoal";
+export * from "./MiniSparkline";

--- a/src/hooks/useGarminData.ts
+++ b/src/hooks/useGarminData.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect, useMemo } from "react";
-import { getGarminData, getDailySteps, GarminData, GarminDay } from "@/lib/api";
+import {
+  getGarminData,
+  getDailySteps,
+  GarminData,
+  GarminDay,
+  Activity,
+} from "@/lib/api";
 
 export function useGarminData(): GarminData | null {
   const [data, setData] = useState<GarminData | null>(null);
@@ -25,3 +31,14 @@ export function useGarminDays(): GarminDay[] | null {
 }
 
 export const useDailySteps = useGarminDays;
+
+export function useMostRecentActivity(): Activity | null {
+  const data = useGarminData();
+
+  return useMemo(() => {
+    if (!data || !data.activities?.length) return null;
+    return [...data.activities].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    )[0];
+  }, [data]);
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,13 +2,14 @@ import React, { useEffect, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ProgressRingWithDelta } from "@/components/dashboard/ProgressRingWithDelta";
-import { StepsChart } from "@/components/dashboard";
-import { useGarminData, useDailySteps } from "@/hooks/useGarminData";
+import { StepsChart, MiniSparkline } from "@/components/dashboard";
+import { useGarminData, useDailySteps, useMostRecentActivity } from "@/hooks/useGarminData";
 
 export default function Dashboard() {
   type Metric = "steps" | "sleep" | "heartRate" | "calories";
   const data = useGarminData();
   const dailySteps = useDailySteps();
+  const recentActivity = useMostRecentActivity();
   const [expanded, setExpanded] = useState<Metric | null>(null);
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
@@ -42,6 +43,7 @@ export default function Dashboard() {
   const previousSleep = data.sleep * 0.9;
   const previousHeartRate = data.heartRate * 0.9;
   const previousCalories = data.calories * 0.9;
+  const sparkData = dailySteps?.map((d) => ({ date: d.date, value: d.steps })) || [];
 
   return (
     <div className="grid gap-4">
@@ -53,7 +55,14 @@ export default function Dashboard() {
           onKeyDown={(e) => handleKey(e, "steps")}
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
-          <h2 className="text-sm mb-2">Steps</h2>
+          <h2 className="text-sm mb-2 flex items-center gap-2">
+            Steps
+            {recentActivity && (
+              <span className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground text-[10px] font-medium">
+                {recentActivity.type}
+              </span>
+            )}
+          </h2>
           <ProgressRingWithDelta
             label="Steps progress"
             value={(data.steps / 10000) * 100}
@@ -61,6 +70,7 @@ export default function Dashboard() {
             previous={previousSteps}
           />
           <span className="mt-2 text-lg font-bold">{data.steps}</span>
+          <MiniSparkline data={sparkData} />
         </Card>
 
         <Card
@@ -78,6 +88,7 @@ export default function Dashboard() {
             previous={previousSleep}
           />
           <span className="mt-2 text-lg font-bold">{data.sleep}</span>
+          <MiniSparkline data={sparkData} />
         </Card>
 
         <Card
@@ -95,6 +106,7 @@ export default function Dashboard() {
             previous={previousHeartRate}
           />
           <span className="mt-2 text-lg font-bold">{data.heartRate}</span>
+          <MiniSparkline data={sparkData} />
         </Card>
 
         <Card
@@ -112,6 +124,7 @@ export default function Dashboard() {
             previous={previousCalories}
           />
           <span className="mt-2 text-lg font-bold">{data.calories}</span>
+          <MiniSparkline data={sparkData} />
         </Card>
       </div>
 


### PR DESCRIPTION
## Summary
- implement `MiniSparkline` area chart
- export the new component
- expose latest activity from `useGarminData`
- show recent activity badge and sparklines in dashboard cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bd4e3fa608324ac2adf493e8bd382