### PR TITLE
Add interactive state map

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
+import { ComposableMap, Geographies, Geography } from "react-simple-maps";
 import { useStateVisits } from "@/hooks/useStateVisits";
 import type { StateVisit } from "@/lib/types";
+import { fipsToAbbr } from "@/lib/stateCodes";
 import { ChartContainer } from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -17,6 +19,61 @@ export default function GeoActivityExplorer() {
 
   return (
     <ChartContainer config={{}} title="State Visits" className="space-y-4">
+      <ComposableMap
+        projection="geoAlbersUsa"
+        className="w-full h-60"
+        data-testid="state-map"
+      >
+        <Geographies geography="/us-states.json">
+          {({ geographies }) =>
+            geographies.map((geo) => {
+              const abbr = fipsToAbbr[geo.id as string]
+              if (!abbr) return null
+              const state = data.find((d) => d.stateCode === abbr)
+              const visited = state?.visited
+              const selectedState = expanded === abbr
+              return (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  data-state={abbr}
+                  onClick={() =>
+                    setExpanded(selectedState ? null : abbr)
+                  }
+                  style={{
+                    default: {
+                      fill: visited
+                        ? "hsl(var(--primary))"
+                        : "hsl(var(--muted))",
+                      stroke: selectedState
+                        ? "hsl(var(--ring))"
+                        : "hsl(var(--border))",
+                      strokeWidth: selectedState ? 2 : 0.5,
+                      outline: "none",
+                    },
+                    hover: {
+                      fill: visited
+                        ? "hsl(var(--primary))"
+                        : "hsl(var(--muted))",
+                      stroke: "hsl(var(--ring))",
+                      strokeWidth: 2,
+                      outline: "none",
+                    },
+                    pressed: {
+                      fill: visited
+                        ? "hsl(var(--primary))"
+                        : "hsl(var(--muted))",
+                      stroke: "hsl(var(--ring))",
+                      strokeWidth: 2,
+                      outline: "none",
+                    },
+                  }}
+                />
+              )
+            })
+          }
+        </Geographies>
+      </ComposableMap>
       <div className="grid grid-cols-5 gap-2">
         {data.map((state) => (
           <button

--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -23,4 +23,15 @@ describe("GeoActivityExplorer", () => {
     fireEvent.click(button);
     expect(screen.queryByText("LA")).toBeNull();
   });
+
+  it("toggles from map click", () => {
+    render(<GeoActivityExplorer />);
+    const map = screen.getByTestId("state-map");
+    const path = map.querySelector('[data-state="CA"]') as SVGPathElement;
+    expect(path).not.toBeNull();
+    fireEvent.click(path!);
+    expect(screen.getByText("LA")).toBeInTheDocument();
+    fireEvent.click(path!);
+    expect(screen.queryByText("LA")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- expand `GeoActivityExplorer` with an interactive US map that uses react-simple-maps
- highlight and open a state when its geography or table button is clicked
- extend tests for toggling via map click

## Testing
- `npx vitest run` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_688bd4d9361c8324824e587466023c98