### PR TITLE
Add Equipment Usage Timeline chart

### DIFF
--- a/src/components/statistics/EquipmentUsageTimeline.tsx
+++ b/src/components/statistics/EquipmentUsageTimeline.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+  ReferenceLine,
+} from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
+
+const usageData = [
+  { month: "Jan", shoe: 50, bike: 120 },
+  { month: "Feb", shoe: 110, bike: 240 },
+  { month: "Mar", shoe: 170, bike: 360 },
+  { month: "Apr", shoe: 230, bike: 420 },
+  { month: "May", shoe: 310, bike: 500 },
+  { month: "Jun", shoe: 370, bike: 580 },
+]
+
+const REPLACEMENT_MILES = 300
+
+const config = {
+  shoe: { label: "Shoes", color: "var(--chart-4)" },
+  bike: { label: "Bike", color: "var(--chart-5)" },
+  replacement: { label: "Replacement", color: "var(--chart-6)" },
+} satisfies Record<string, unknown>
+
+export default function EquipmentUsageTimeline() {
+  return (
+    <ChartCard title="Equipment Usage">
+      <ChartContainer config={config} className="h-64">
+        <BarChart data={usageData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" tickLine={false} axisLine={false} />
+          <ReferenceLine y={REPLACEMENT_MILES} stroke={config.replacement.color} strokeDasharray="4 4" />
+          <ChartTooltip />
+          <Bar dataKey="shoe" stackId="usage" fill={config.shoe.color} />
+          <Bar dataKey="bike" stackId="usage" fill={config.bike.color} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -7,3 +7,4 @@ export { default as PaceDistribution } from "./PaceDistribution";
 export { default as HeartRateZones } from "./HeartRateZones";
 export { default as PaceVsHR } from "./PaceVsHR";
 export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
+export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";

--- a/src/pages/StatisticsExamplesPage.tsx
+++ b/src/pages/StatisticsExamplesPage.tsx
@@ -1,10 +1,12 @@
 "use client"
 
+import { EquipmentUsageTimeline } from "@/components/statistics"
+
 export default function StatisticsExamplesPage() {
   return (
     <div className="space-y-12 px-6 py-8 max-w-6xl mx-auto">
       <h1 className="text-2xl font-bold">Statistics</h1>
-      <p className="text-muted-foreground">Statistics will appear here.</p>
+      <EquipmentUsageTimeline />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- create `EquipmentUsageTimeline` chart component
- export it from statistics index
- show the new chart in the statistics examples page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bd470c63c83248d11ca6c87e92ef4