### PR TITLE
Implement peer benchmark bands chart

### DIFF
--- a/src/components/statistics/PeerBenchmarkBands.tsx
+++ b/src/components/statistics/PeerBenchmarkBands.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import {
+  ChartContainer,
+  AreaChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
+import { useBenchmarkStats } from "@/hooks/useBenchmarkStats"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { ChartConfig } from "@/components/ui/chart"
+
+export default function PeerBenchmarkBands() {
+  const stats = useBenchmarkStats()
+
+  if (!stats) {
+    return <Skeleton className="h-64" />
+  }
+
+  const paceData = stats.pace.map((d) => ({
+    date: d.date,
+    p50: d.p50,
+    band75: d.p75 - d.p50,
+    band90: d.p90 - d.p75,
+    user: d.user,
+  }))
+
+  const config = {
+    p50: { label: "50th", color: "hsl(var(--chart-4))" },
+    band75: { label: "75th", color: "hsl(var(--chart-5))" },
+    band90: { label: "90th", color: "hsl(var(--chart-6))" },
+    user: { label: "You", color: "hsl(var(--chart-2))" },
+  } satisfies ChartConfig
+
+  return (
+    <ChartCard title="Pace Benchmark">
+      <ChartContainer config={config} className="h-64">
+        <AreaChart data={paceData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <YAxis />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                nameKey="user"
+                labelFormatter={(d) =>
+                  new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })
+                }
+              />
+            }
+          />
+          <ChartLegend content={<ChartLegendContent />} />
+          <Area
+            type="monotone"
+            stackId="bands"
+            dataKey="p50"
+            stroke={config.p50.color}
+            fill={config.p50.color}
+            fillOpacity={0.3}
+          />
+          <Area
+            type="monotone"
+            stackId="bands"
+            dataKey="band75"
+            stroke={config.band75.color}
+            fill={config.band75.color}
+            fillOpacity={0.3}
+          />
+          <Area
+            type="monotone"
+            stackId="bands"
+            dataKey="band90"
+            stroke={config.band90.color}
+            fill={config.band90.color}
+            fillOpacity={0.3}
+          />
+          <Line type="monotone" dataKey="user" stroke={config.user.color} dot={false} />
+        </AreaChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -8,3 +8,4 @@ export { default as HeartRateZones } from "./HeartRateZones";
 export { default as PaceVsHR } from "./PaceVsHR";
 export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
+export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";

--- a/src/hooks/useBenchmarkStats.ts
+++ b/src/hooks/useBenchmarkStats.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+import { getBenchmarkStats, BenchmarkStats } from "@/lib/api";
+
+export function useBenchmarkStats(): BenchmarkStats | null {
+  const [data, setData] = useState<BenchmarkStats | null>(null);
+
+  useEffect(() => {
+    getBenchmarkStats().then(setData);
+  }, []);
+
+  return data;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -274,3 +274,53 @@ export async function getRunningStats(): Promise<RunningStats> {
     setTimeout(() => resolve(generateMockRunningStats()), 300)
   })
 }
+
+// ----- Benchmark stats -----
+export interface BenchmarkPoint {
+  date: string
+  /** User value for the metric on this date */
+  user: number
+  /** 50th percentile for the cohort */
+  p50: number
+  /** 75th percentile for the cohort */
+  p75: number
+  /** 90th percentile for the cohort */
+  p90: number
+}
+
+export interface BenchmarkStats {
+  pace: BenchmarkPoint[]
+  load: BenchmarkPoint[]
+}
+
+export function generateMockBenchmarkStats(): BenchmarkStats {
+  const pace: BenchmarkPoint[] = []
+  const load: BenchmarkPoint[] = []
+  for (let i = 0; i < 28; i++) {
+    const date = new Date()
+    date.setDate(date.getDate() - (27 - i))
+
+    const p50Pace = +(7.5 + Math.random() * 0.2).toFixed(2)
+    const p75Pace = +(7.2 + Math.random() * 0.2).toFixed(2)
+    const p90Pace = +(6.8 + Math.random() * 0.2).toFixed(2)
+    const userPace = +(p90Pace + Math.random() * 0.6).toFixed(2)
+
+    const p50Load = +(1.2 + Math.random() * 0.1).toFixed(2)
+    const p75Load = +(1.5 + Math.random() * 0.1).toFixed(2)
+    const p90Load = +(2.0 + Math.random() * 0.1).toFixed(2)
+    const userLoad = +(1.3 + Math.random() * 0.5).toFixed(2)
+
+    const iso = date.toISOString().slice(0, 10)
+    pace.push({ date: iso, user: userPace, p50: p50Pace, p75: p75Pace, p90: p90Pace })
+    load.push({ date: iso, user: userLoad, p50: p50Load, p75: p75Load, p90: p90Load })
+  }
+  return { pace, load }
+}
+
+export const mockBenchmarkStats: BenchmarkStats = generateMockBenchmarkStats()
+
+export async function getBenchmarkStats(): Promise<BenchmarkStats> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockBenchmarkStats()), 300)
+  })
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -20,6 +20,7 @@ import ScatterChartPaceHeartRate from "@/components/examples/ScatterChartPaceHea
 import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
+import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
 
 
 export default function Examples() {
@@ -28,6 +29,8 @@ export default function Examples() {
       <AreaChartInteractive />
 
       <StepsTrendWithGoal data={mockDailySteps} />
+
+      <PeerBenchmarkBands />
 
       <BarChartInteractive />
 


### PR DESCRIPTION
## Summary
- add benchmark data generator and fetch hook
- implement PeerBenchmarkBands chart component
- export new chart and show it on the examples page

## Testing
- `npx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd6b8760c8324a014120a4659300f