### PR TITLE
Fix unclosed function in api

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -322,6 +322,8 @@ export const mockBenchmarkStats: BenchmarkStats = generateMockBenchmarkStats()
 export async function getBenchmarkStats(): Promise<BenchmarkStats> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(generateMockBenchmarkStats()), 300)
+  })
+}
 
 // ----- Running session similarity -----
 


### PR DESCRIPTION
## Summary
- fix closing braces for `getBenchmarkStats`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdeb5733083249b1773a39a387c4a