### PR TITLE
Add events alias for running sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-select": "^2.0.0",
+        "events": "^3.3.0",
         "lucide-react": "^0.534.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3306,6 +3307,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.0.0",
+    "events": "^3.3.0",
     "lucide-react": "^0.534.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      events: 'events',
     },
   },
 })


### PR DESCRIPTION
## Summary
- install `events` polyfill
- alias Node's events to the polyfill in Vite
- rebuild project and run tests

## Testing
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688be4e8b65c83249a5d3d68e1c8575f