### PR TITLE
Add ACWR gauge component

### DIFF
--- a/src/components/dashboard/AcwrGauge.tsx
+++ b/src/components/dashboard/AcwrGauge.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import useAcwr from "@/hooks/useAcwr";
+
+export interface AcwrGaugeProps {
+  /** Array of daily training load values ordered from oldest to newest */
+  loads: number[];
+  /** Size of the gauge in pixels */
+  size?: number;
+  /** Stroke width for gauge arcs */
+  strokeWidth?: number;
+  /** Safe range for the ratio [min, max] */
+  safeRange?: [number, number];
+}
+
+/**
+ * Semicircular gauge displaying the Acute:Chronic Workload Ratio.
+ */
+export function AcwrGauge({
+  loads,
+  size = 160,
+  strokeWidth = 12,
+  safeRange = [0.8, 1.3],
+}: AcwrGaugeProps) {
+  const ratio = useAcwr(loads);
+  const normalized = Math.min(Math.max(ratio, 0), 2) / 2; // 0-2 mapped to 0-1
+
+  const radius = size / 2 - strokeWidth / 2;
+  const circumference = Math.PI * radius; // half circle
+  const offset = circumference - normalized * circumference;
+
+  let color = "hsl(var(--chart-3))";
+  if (ratio < safeRange[0]) {
+    color = "hsl(var(--chart-8))";
+  } else if (ratio > safeRange[1]) {
+    color = "hsl(var(--destructive))";
+  }
+
+  return (
+    <div className="flex flex-col items-center" role="img" aria-label={`ACWR ${ratio.toFixed(2)}`}>
+      <svg width={size} height={size / 2} viewBox={`0 0 ${size} ${size / 2}`}>
+        <path
+          d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${
+            size - strokeWidth / 2
+          } ${size / 2 - strokeWidth / 2}`}
+          stroke="hsl(var(--muted))"
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <path
+          d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${
+            size - strokeWidth / 2
+          } ${size / 2 - strokeWidth / 2}`}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          fill="none"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+        />
+      </svg>
+      <span className="mt-2 text-lg font-bold tabular-nums">{ratio.toFixed(2)}</span>
+    </div>
+  );
+}
+
+export default AcwrGauge;

--- a/src/components/dashboard/__tests__/AcwrGauge.test.tsx
+++ b/src/components/dashboard/__tests__/AcwrGauge.test.tsx
@@ -1,0 +1,23 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import AcwrGauge from "../AcwrGauge";
+import { useAcwr } from "@/hooks/useAcwr";
+import { describe, it, expect } from "vitest";
+
+describe("useAcwr", () => {
+  it("computes ratio of 7d to 28d load", () => {
+    const loads = Array.from({ length: 28 }, (_, i) => i + 1); // 1..28
+    const { result } = renderHook(() => useAcwr(loads));
+    const ratio = result.current;
+    // average of last 7 = 25
+    // average of last 28 = 14.5
+    expect(ratio).toBeCloseTo(25 / 14.5);
+  });
+});
+
+describe("AcwrGauge", () => {
+  it("renders the ratio text", () => {
+    const loads = Array(28).fill(10);
+    render(<AcwrGauge loads={loads} />);
+    expect(screen.getByText("1.00")).toBeTruthy();
+  });
+});

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -8,3 +8,4 @@ export * from "./DailyStepsChart";
 export * from "./StepsTrendWithGoal";
 export * from "./MiniSparkline";
 export * from "./RingDetailDialog";
+export * from "./AcwrGauge";

--- a/src/hooks/useAcwr.ts
+++ b/src/hooks/useAcwr.ts
@@ -1,0 +1,20 @@
+import { useMemo } from "react";
+
+/**
+ * Compute the Acute:Chronic Workload Ratio (ACWR).
+ * @param loads Array of daily training load values (oldest -> newest).
+ * @returns The ratio of the 7‑day average load to the 28‑day average load.
+ */
+export function useAcwr(loads: number[]): number {
+  return useMemo(() => {
+    if (!loads || !loads.length) return 0;
+    const last7 = loads.slice(-7);
+    const last28 = loads.slice(-28);
+    const recent7 = last7.reduce((sum, v) => sum + v, 0) / last7.length;
+    const recent28 = last28.reduce((sum, v) => sum + v, 0) / last28.length;
+    if (recent28 === 0) return 0;
+    return recent7 / recent28;
+  }, [loads]);
+}
+
+export default useAcwr;


### PR DESCRIPTION
## Summary
- add `useAcwr` hook to compute the acute:chronic workload ratio
- implement `AcwrGauge` semicircle component for dashboard
- export new gauge from dashboard index
- add unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bde6dbb4883249514059b05f64046