### PR TITLE
Add dashboard filters and integrate charts

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -13,6 +13,7 @@ import {
 import ChartCard from "./ChartCard";
 import type { ChartConfig } from "@/components/ui/chart";
 import { useGarminData } from "@/hooks/useGarminData";
+import useDashboardFilters from "@/hooks/useDashboardFilters";
 
 const chartConfig = {
   distance: {
@@ -27,8 +28,22 @@ const chartConfig = {
 
 export function ActivitiesChart() {
   const data = useGarminData();
+  const { activity, range } = useDashboardFilters();
   if (!data) return null;
-  const activities = data.activities;
+  let activities = data.activities;
+
+  if (activity !== 'all') {
+    activities = activities.filter(
+      (a) => a.type.toLowerCase() === activity,
+    );
+  }
+
+  const days = range === '7d' ? 7 : range === '30d' ? 30 : 90;
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  activities = activities.filter(
+    (a) => new Date(a.date) >= start,
+  );
 
   return (
     <ChartCard

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -14,6 +14,7 @@ import type { ChartConfig } from "@/components/ui/chart";
 
 import type { GarminDay } from "@/lib/api";
 import { useGarminDaysLazy } from "@/hooks/useGarminData";
+import useDashboardFilters from "@/hooks/useDashboardFilters";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const chartConfig = {
@@ -64,9 +65,15 @@ export interface StepsChartProps {
 
 export function StepsChart({ active = true }: StepsChartProps = {}) {
   const data = useGarminDaysLazy(active);
+  const { range } = useDashboardFilters();
   if (!data) return <Skeleton className="h-60 w-full" />;
 
-  if (!data.length) {
+  const days = range === '7d' ? 7 : range === '30d' ? 30 : 90;
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  const filtered = data.filter((d) => new Date(d.date) >= start);
+
+  if (!filtered.length) {
     return (
 
       <ChartContainer
@@ -90,7 +97,7 @@ export function StepsChart({ active = true }: StepsChartProps = {}) {
       className="h-60 md:col-span-2"
       title="Daily Steps"
     >
-      <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+      <BarChart data={filtered} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
 
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis
@@ -100,7 +107,7 @@ export function StepsChart({ active = true }: StepsChartProps = {}) {
         <YAxis />
         <ChartTooltip content={<StepsTooltip />} />
         <Bar dataKey="steps" fill={chartConfig.steps.color}>
-          {data.map((day) => (
+          {filtered.map((day) => (
             <Cell
               key={day.date}
               aria-label={`${day.steps.toLocaleString()} steps on ${new Date(day.date).toLocaleDateString()}`}

--- a/src/hooks/useDashboardFilters.ts
+++ b/src/hooks/useDashboardFilters.ts
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+export type ActivityType = 'all' | 'run' | 'bike' | 'walk'
+export type DateRange = '7d' | '30d' | '90d'
+
+interface DashboardFiltersState {
+  activity: ActivityType
+  setActivity: (t: ActivityType) => void
+  range: DateRange
+  setRange: (r: DateRange) => void
+}
+
+const DashboardFiltersContext = createContext<DashboardFiltersState | undefined>(undefined)
+
+function useProvideDashboardFilters(): DashboardFiltersState {
+  const [activity, setActivity] = useState<ActivityType>('all')
+  const [range, setRange] = useState<DateRange>('30d')
+
+  return { activity, setActivity, range, setRange }
+}
+
+export function DashboardFiltersProvider({ children }: { children: ReactNode }) {
+  const value = useProvideDashboardFilters()
+  return <DashboardFiltersContext.Provider value={value}>{children}</DashboardFiltersContext.Provider>
+}
+
+export default function useDashboardFilters(): DashboardFiltersState {
+  const ctx = useContext(DashboardFiltersContext)
+  const fallback = useProvideDashboardFilters()
+  return ctx || fallback
+}

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -16,24 +16,58 @@ import {
   SessionSimilarityMap,
 } from "@/components/statistics"
 import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands"
+import { ActivitiesChart, StepsChart } from "@/components/dashboard"
+import { SimpleSelect } from "@/components/ui/select"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import useDashboardFilters, { DashboardFiltersProvider } from "@/hooks/useDashboardFilters"
 
+
+function Filters() {
+  const { activity, setActivity, range, setRange } = useDashboardFilters()
+  return (
+    <div className="flex flex-wrap gap-4 p-6 pt-0">
+      <SimpleSelect
+        value={range}
+        onValueChange={setRange}
+        options={[
+          { value: '90d', label: 'Last 90 days' },
+          { value: '30d', label: 'Last 30 days' },
+          { value: '7d', label: 'Last 7 days' },
+        ]}
+      />
+      <Tabs value={activity} onValueChange={setActivity}>
+        <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="run">Run</TabsTrigger>
+          <TabsTrigger value="bike">Bike</TabsTrigger>
+          <TabsTrigger value="walk">Walk</TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  )
+}
 
 export default function Statistics() {
   return (
-    <div className="grid gap-6 p-6">
-      <AnnualMileage />
-      <ActivityByTime />
-      <AvgDailyMileageRadar />
-      <RunDistances />
-      <TreadmillVsOutdoor />
-      <PaceDistribution />
-      <HeartRateZones />
-      <PaceVsHR />
-      <TrainingLoadRatio />
-      <EquipmentUsageTimeline />
-      <PerfVsEnvironmentMatrix />
-      <SessionSimilarityMap />
-      <PeerBenchmarkBands />
-    </div>
+    <DashboardFiltersProvider>
+      <Filters />
+      <div className="grid gap-6 p-6 pt-0">
+        <AnnualMileage />
+        <ActivitiesChart />
+        <StepsChart />
+        <ActivityByTime />
+        <AvgDailyMileageRadar />
+        <RunDistances />
+        <TreadmillVsOutdoor />
+        <PaceDistribution />
+        <HeartRateZones />
+        <PaceVsHR />
+        <TrainingLoadRatio />
+        <EquipmentUsageTimeline />
+        <PerfVsEnvironmentMatrix />
+        <SessionSimilarityMap />
+        <PeerBenchmarkBands />
+      </div>
+    </DashboardFiltersProvider>
   )
 }


### PR DESCRIPTION
## Summary
- add new `useDashboardFilters` hook with provider
- show date and activity filters on the statistics page
- filter `ActivitiesChart` and `StepsChart` based on selected filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bebfe26bc8324a0efe60efac6fed5