### PR TITLE
Implement monthly projections and weather notes

### DIFF
--- a/src/components/dashboard/StepsTrendWithGoal.tsx
+++ b/src/components/dashboard/StepsTrendWithGoal.tsx
@@ -16,6 +16,8 @@ import type { ChartConfig } from "@/components/ui/chart";
 import type { GarminDay } from "@/lib/api";
 import { useMemo } from "react";
 import { useSeasonalBaseline } from "@/hooks/useGarminData";
+import { useRunningStats } from "@/hooks/useRunningStats";
+import { Info } from "lucide-react";
 
 export interface StepsTrendWithGoalProps {
   data: GarminDay[];
@@ -40,6 +42,16 @@ export function StepsTrendWithGoal({
   }, [data, window]);
 
   const baselines = useSeasonalBaseline();
+  const stats = useRunningStats();
+  const weatherNote = useMemo(() => {
+    if (!stats) return null;
+    const rainy = stats.weatherConditions.find((w) => w.label === 'Rain')?.count || 0;
+    const snowy = stats.weatherConditions.find((w) => w.label === 'Snow')?.count || 0;
+    if (rainy + snowy > 0) {
+      return 'Recent rain or snow may have reduced activity';
+    }
+    return null;
+  }, [stats]);
 
   const baselineAreas = useMemo(() => {
     if (!baselines) return [];
@@ -114,9 +126,15 @@ export function StepsTrendWithGoal({
             stroke={chartConfig.steps.color}
             fill="url(#fillSteps)"
           />
-          <Line dataKey="avg" type="monotone" stroke={chartConfig.avg.color} dot={false} />
-        </AreaChart>
+        <Line dataKey="avg" type="monotone" stroke={chartConfig.avg.color} dot={false} />
+      </AreaChart>
       </ChartContainer>
+      {weatherNote && (
+        <p className="mt-2 flex items-center text-xs text-muted-foreground" title={weatherNote}>
+          <Info className="w-3 h-3 mr-1" />
+          {weatherNote}
+        </p>
+      )}
     </ChartCard>
   );
 }

--- a/src/hooks/__tests__/useMonthlyProjection.test.ts
+++ b/src/hooks/__tests__/useMonthlyProjection.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import { computeMonthlyStepProjection } from '../useGarminData'
+import type { GarminDay } from '@/lib/api'
+
+// helper fixed date
+
+const sampleDays: GarminDay[] = Array.from({length: 15}, (_, i) => ({
+  date: `2025-07-${String(i+1).padStart(2,'0')}`,
+  steps: 1000,
+}))
+
+describe('computeMonthlyStepProjection', () => {
+  it('projects totals based on current progress', () => {
+    vi.setSystemTime(new Date('2025-07-15'))
+    const result = computeMonthlyStepProjection(sampleDays, 1000)
+    // July has 31 days -> projected total should equal avg (1000) * 31
+    expect(result.projectedTotal).toBe(31000)
+    expect(result.goalTotal).toBe(31000)
+    expect(result.onTrack).toBe(true)
+    vi.useRealTimers()
+  })
+})

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,15 @@
 import React, { useState } from "react";
 import { Card } from "@/components/ui/card";
-import { ProgressRingWithDelta, MiniSparkline, RingDetailDialog } from "@/components/dashboard";
-import { useGarminData, useMostRecentActivity } from "@/hooks/useGarminData";
+import {
+  ProgressRingWithDelta,
+  MiniSparkline,
+  RingDetailDialog,
+} from "@/components/dashboard";
+import {
+  useGarminData,
+  useMostRecentActivity,
+  useMonthlyStepsProjection,
+} from "@/hooks/useGarminData";
 
 export default function Dashboard() {
   type Metric = "steps" | "sleep" | "heartRate" | "calories";
@@ -28,6 +36,7 @@ export default function Dashboard() {
   const previousHeartRate = data.heartRate * 0.9;
   const previousCalories = data.calories * 0.9;
   const sparkData: { date: string; value: number }[] = [];
+  const monthly = useMonthlyStepsProjection();
 
   return (
     <div className="grid gap-4">
@@ -53,6 +62,21 @@ export default function Dashboard() {
             current={data.steps}
             previous={previousSteps}
           />
+          {monthly && (
+            <div className="w-full mt-1" aria-label={`Projected ${Math.round(monthly.projectedTotal).toLocaleString()} steps`}>
+              <div className="h-1 w-full bg-muted rounded">
+                <div
+                  className={`h-full rounded ${monthly.onTrack ? 'bg-green-500' : 'bg-red-500'}`}
+                  style={{ width: `${Math.min(100, monthly.pctOfGoal).toFixed(0)}%` }}
+                />
+              </div>
+              <p
+                className={`text-[10px] mt-1 ${monthly.onTrack ? 'text-green-600' : 'text-red-600'}`}
+              >
+                {monthly.onTrack ? 'On track' : 'Off track'}
+              </p>
+            </div>
+          )}
           <span className="mt-2 text-lg font-bold">{data.steps}</span>
           <MiniSparkline data={sparkData} />
         </Card>


### PR DESCRIPTION
## Summary
- add monthly steps projection utilities and hook
- surface monthly progress bar on dashboard
- show weather-related tooltip on steps trend chart
- test monthly projection calculations

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bed19df9883249d7102d7fd2a1940