### PR TITLE
Add insights badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,24 @@ In the handoff, document what shape `useGarminData()` returns (e.g. `{ steps: nu
 { month: number; min: number; max: number }[]
 ```
 
+
 This baseline provides expected min/max values for each month which charts can
 use for reference areas.
 
 The mock implementation uses `generateMockRunningStats()` in `src/lib/api.ts` to
 create semi-random demo data each time the app loads. You can replace this
 function with real API calls for production data.
+
+`useInsights()` resolves to:
+
+```ts
+{
+  activeStreak: number
+  highHeartRate: boolean
+  lowSleep: boolean
+  calorieSurplus: boolean
+}
+```
 
 ## Charts & maps
 All charts should be wrapped in Shadcn’s `<ChartContainer>` so they inherit CSS variables for colours and spacing. Include a <ChartHeader> for titles so typography stays consistent.

--- a/src/hooks/useInsights.ts
+++ b/src/hooks/useInsights.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react'
+import { useGarminDays, useGarminData } from './useGarminData'
+
+export interface Insights {
+  /** Number of consecutive days meeting the step goal */
+  activeStreak: number
+  /** Current heart rate is unusually high */
+  highHeartRate: boolean
+  /** Less than 6h sleep last night */
+  lowSleep: boolean
+  /** Calories exceed typical daily target */
+  calorieSurplus: boolean
+}
+
+export function useInsights(): Insights | null {
+  const days = useGarminDays()
+  const data = useGarminData()
+
+  return useMemo(() => {
+    if (!days || !data) return null
+    const STEP_GOAL = 8000
+    let streak = 0
+    for (let i = days.length - 1; i >= 0; i--) {
+      if (days[i].steps >= STEP_GOAL) streak++
+      else break
+    }
+
+    return {
+      activeStreak: streak,
+      highHeartRate: data.heartRate > 100,
+      lowSleep: data.sleep < 6,
+      calorieSurplus: data.calories > 2500,
+    }
+  }, [days, data])
+}
+
+export default useInsights

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,11 +2,14 @@ import React, { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { ProgressRingWithDelta, MiniSparkline, RingDetailDialog } from "@/components/dashboard";
 import { useGarminData, useMostRecentActivity } from "@/hooks/useGarminData";
+import useInsights from "@/hooks/useInsights";
+import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
 
 export default function Dashboard() {
   type Metric = "steps" | "sleep" | "heartRate" | "calories";
   const data = useGarminData();
   const recentActivity = useMostRecentActivity();
+  const insights = useInsights();
   const [expanded, setExpanded] = useState<Metric | null>(null);
 
   if (!data) {
@@ -55,6 +58,12 @@ export default function Dashboard() {
           />
           <span className="mt-2 text-lg font-bold">{data.steps}</span>
           <MiniSparkline data={sparkData} />
+          {insights && insights.activeStreak >= 3 && (
+            <Flame
+              className="h-4 w-4 text-orange-600 mt-1"
+              aria-label={`${insights.activeStreak}-day streak`}
+            />
+          )}
         </Card>
 
         <Card
@@ -73,6 +82,12 @@ export default function Dashboard() {
           />
           <span className="mt-2 text-lg font-bold">{data.sleep}</span>
           <MiniSparkline data={sparkData} />
+          {insights && insights.lowSleep && (
+            <Moon
+              className="h-4 w-4 text-yellow-500 mt-1"
+              aria-label="Low sleep"
+            />
+          )}
         </Card>
 
         <Card
@@ -91,6 +106,12 @@ export default function Dashboard() {
           />
           <span className="mt-2 text-lg font-bold">{data.heartRate}</span>
           <MiniSparkline data={sparkData} />
+          {insights && insights.highHeartRate && (
+            <HeartPulse
+              className="h-4 w-4 text-red-600 mt-1"
+              aria-label="High heart rate"
+            />
+          )}
         </Card>
 
         <Card
@@ -109,6 +130,12 @@ export default function Dashboard() {
           />
           <span className="mt-2 text-lg font-bold">{data.calories}</span>
           <MiniSparkline data={sparkData} />
+          {insights && insights.calorieSurplus && (
+            <Pizza
+              className="h-4 w-4 text-amber-600 mt-1"
+              aria-label="Calorie surplus"
+            />
+          )}
         </Card>
       </div>
 


### PR DESCRIPTION
## Summary
- derive simple insights such as step streak and high heart rate
- show insight icons in dashboard cards
- document return type of `useInsights`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bed016e3c83249c569a5cba2c6416