### PR TITLE
Implement route comparison charts

### DIFF
--- a/src/components/statistics/RouteComparison.tsx
+++ b/src/components/statistics/RouteComparison.tsx
@@ -1,0 +1,25 @@
+import SmallRouteSummary from './SmallRouteSummary'
+import useRouteSessions from '@/hooks/useRouteSessions'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function RouteComparison({ route }: { route: string }) {
+  const sessions = useRouteSessions(route)
+
+  if (!sessions) {
+    return (
+      <div className="flex gap-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="w-28 h-20" />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {sessions.map((s) => (
+        <SmallRouteSummary key={s.id} session={s} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/statistics/SmallRouteSummary.tsx
+++ b/src/components/statistics/SmallRouteSummary.tsx
@@ -1,0 +1,24 @@
+import { AreaChart, Area, BarChart, Bar, ResponsiveContainer } from '@/components/ui/chart'
+import type { RouteSession } from '@/lib/api'
+
+export default function SmallRouteSummary({ session }: { session: RouteSession }) {
+  return (
+    <div className="w-28" aria-label={`Session ${session.date}`}>
+      <div className="h-10 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={session.profile} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+            <Area dataKey="elevation" stroke="hsl(var(--chart-1))" fill="hsl(var(--chart-1))" strokeWidth={1} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="h-10 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={session.paceDistribution} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+            <Bar dataKey="upper" fill="hsl(var(--chart-2))" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="text-xs text-center mt-1">{session.date}</p>
+    </div>
+  )
+}

--- a/src/components/statistics/__tests__/RouteComparison.test.tsx
+++ b/src/components/statistics/__tests__/RouteComparison.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import RouteComparison from '../RouteComparison'
+import { vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+vi.mock('@/hooks/useRouteSessions', () => ({
+  __esModule: true,
+  default: () => [
+    { id: 1, route: 'Test', date: '2025-07-01', profile: [], paceDistribution: [] },
+    { id: 2, route: 'Test', date: '2025-07-02', profile: [], paceDistribution: [] },
+  ],
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+})
+
+describe('RouteComparison', () => {
+  it('renders a chart per session', () => {
+    render(<RouteComparison route="Test" />)
+    expect(screen.getAllByLabelText(/Session/).length).toBe(2)
+  })
+})

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -13,3 +13,4 @@ export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";
 export { default as SessionSimilarityMap } from "./SessionSimilarityMap";
 
+export { default as RouteComparison } from './RouteComparison'

--- a/src/hooks/useRouteSessions.ts
+++ b/src/hooks/useRouteSessions.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+import { getRouteSessions, RouteSession } from '@/lib/api'
+
+export function useRouteSessions(route: string | null): RouteSession[] | null {
+  const [sessions, setSessions] = useState<RouteSession[] | null>(null)
+
+  useEffect(() => {
+    if (!route) return
+    getRouteSessions(route).then(setSessions)
+  }, [route])
+
+  return sessions
+}
+
+export default useRouteSessions

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -377,3 +377,39 @@ export async function getRunningSessions(): Promise<RunningSession[]> {
 
   })
 }
+
+export interface RouteProfilePoint {
+  distance: number
+  elevation: number
+}
+
+export interface RouteSession {
+  id: number
+  route: string
+  date: string
+  profile: RouteProfilePoint[]
+  paceDistribution: PaceDistributionBin[]
+}
+
+export function generateMockRouteSessions(route = 'River Loop'): RouteSession[] {
+  return Array.from({ length: 4 }, (_, i) => ({
+    id: i + 1,
+    route,
+    date: new Date(Date.now() - i * 86400000).toISOString().slice(0, 10),
+    profile: Array.from({ length: 8 }, (__, j) => ({
+      distance: j,
+      elevation: 20 * Math.sin(j / 2) + Math.random() * 5,
+    })),
+    paceDistribution: Array.from({ length: 5 }, (__, j) => ({
+      bin: `${5 + j}:00`,
+      upper: Math.round(Math.random() * 8 + 2),
+      lower: 0,
+    })),
+  }))
+}
+
+export async function getRouteSessions(route: string): Promise<RouteSession[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockRouteSessions(route)), 200)
+  })
+}

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -14,6 +14,7 @@ import {
   EquipmentUsageTimeline,
   PerfVsEnvironmentMatrix,
   SessionSimilarityMap,
+  RouteComparison,
 } from "@/components/statistics"
 import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands"
 
@@ -44,6 +45,7 @@ function Filters() {
         <EquipmentUsageTimeline />
         <PerfVsEnvironmentMatrix />
         <SessionSimilarityMap />
+        <RouteComparison route="River Loop" />
         <PeerBenchmarkBands />
       </div>
     </ChartSelectionProvider>
@@ -70,6 +72,7 @@ export default function Statistics() {
         <EquipmentUsageTimeline />
         <PerfVsEnvironmentMatrix />
         <SessionSimilarityMap />
+        <RouteComparison route="River Loop" />
         <PeerBenchmarkBands />
       </div>
     </DashboardFiltersProvider>


### PR DESCRIPTION
## Summary
- add mock route session data and API
- provide `useRouteSessions` hook
- create `SmallRouteSummary` and `RouteComparison` components
- use new route comparison view in the statistics page
- test route comparison rendering

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688bdfa125048324857dc38d29266784