### PR TITLE
Add last sync timestamp

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -50,6 +50,7 @@ export function ActivitiesChart() {
       title="Activities"
       description="Distance vs Duration"
       className="md:col-span-2"
+      lastSync={data.lastSync}
     >
       <ChartContainer config={chartConfig} className="h-60">
         <LineChart data={activities} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/ChartCard.tsx
+++ b/src/components/dashboard/ChartCard.tsx
@@ -1,23 +1,27 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ReactNode } from "react";
-import { cn } from "@/lib/utils";
+import { cn, minutesSince } from "@/lib/utils";
 
 export interface ChartCardProps {
+  lastSync?: string;
   title?: string;
   description?: string;
   className?: string;
   children: ReactNode;
 }
 
-export function ChartCard({ title, description, className, children }: ChartCardProps) {
+export function ChartCard({ title, description, className, children, lastSync }: ChartCardProps) {
   return (
     <Card className={cn(className)}>
       {(title || description) && (
         <CardHeader>
           {title && <CardTitle>{title}</CardTitle>}
           {description && <CardDescription>{description}</CardDescription>}
+          {lastSync && (
+            <p className="text-xs text-muted-foreground">Last synced {minutesSince(lastSync)} min ago</p>
+          )}
         </CardHeader>
-      )}
+        )}
       <CardContent className="pt-0">{children}</CardContent>
     </Card>
   );

--- a/src/hooks/useGarminData.ts
+++ b/src/hooks/useGarminData.ts
@@ -10,11 +10,26 @@ import {
 } from "@/lib/api";
 
 export function useGarminData(): GarminData | null {
-  const [data, setData] = useState<GarminData | null>(null);
+  const [data, setData] = useState<GarminData | null>(null)
+
   useEffect(() => {
-    getGarminData().then(setData);
-  }, []);
-  return data;
+    let active = true
+
+    const fetchData = () => {
+      getGarminData().then((d) => {
+        if (active) setData(d)
+      })
+    }
+
+    fetchData()
+    const id = setInterval(fetchData, 60_000)
+    return () => {
+      active = false
+      clearInterval(id)
+    }
+  }, [])
+
+  return data
 }
 
 export function useGarminDays(): GarminDay[] | null {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,6 +12,8 @@ export type GarminData = {
   heartRate: number;
   calories: number;
   activities: Activity[];
+  /** ISO timestamp of the last sync with Garmin */
+  lastSync: string;
 };
 
 export type GarminDay = {
@@ -68,14 +70,16 @@ export const mockGarminData: GarminData = {
     { id: 1, type: "Run", distance: 5.2, duration: 42, date: "2025-07-30" },
     { id: 2, type: "Walk", distance: 2.1, duration: 25, date: "2025-07-29" },
   ],
+  lastSync: new Date().toISOString(),
 };
 
 export async function getGarminData(): Promise<GarminData> {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(mockGarminData), 500);
-  });
+    setTimeout(() => {
+      resolve({ ...mockGarminData, lastSync: new Date().toISOString() })
+    }, 500)
+  })
 }
-
 export async function getDailySteps(): Promise<GarminDay[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(mockDailySteps), 300);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,3 +2,9 @@
 export function cn(...classes: (string | undefined | false | null)[]) {
   return classes.filter(Boolean).join(" ");
 }
+
+export function minutesSince(date: string | number | Date): number {
+  const d = new Date(date)
+  return Math.floor((Date.now() - d.getTime()) / 60000)
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Card } from "@/components/ui/card";
 
 import { ProgressRingWithDelta, MiniSparkline, RingDetailDialog } from "@/components/dashboard";
+import { minutesSince } from "@/lib/utils";
 import { useGarminData, useMostRecentActivity } from "@/hooks/useGarminData";
 import useInsights from "@/hooks/useInsights";
 import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
@@ -45,6 +46,7 @@ export default function Dashboard() {
   const previousCalories = data.calories * 0.9;
   const sparkData: { date: string; value: number }[] = [];
   const monthly = useMonthlyStepsProjection();
+  const lastSyncedMinutes = minutesSince(data.lastSync);
 
   return (
     <div className="grid gap-4">
@@ -64,6 +66,7 @@ export default function Dashboard() {
               </span>
             )}
           </h2>
+            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Steps progress"
             value={(data.steps / 10000) * 100}
@@ -103,6 +106,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Sleep (hrs)</h2>
+            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Sleep progress"
             value={(data.sleep / 8) * 100}
@@ -127,6 +131,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Heart Rate</h2>
+            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Heart rate progress"
             value={(data.heartRate / 200) * 100}
@@ -151,6 +156,7 @@ export default function Dashboard() {
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
           <h2 className="text-sm mb-2">Calories</h2>
+            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Calories progress"
             value={(data.calories / 3000) * 100}


### PR DESCRIPTION
## Summary
- track `lastSync` timestamp in Garmin API mock
- poll for new Garmin data in `useGarminData`
- expose last sync info in `ChartCard` and dashboard cards
- expose helper `minutesSince` in utils
- display last sync header in activities chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bf1ac94ec8324bd71cf88fcd115e2