### PR TITLE
Fix missing Brush export

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -18,6 +18,7 @@ export {
   PolarAngleAxis,
   PolarRadiusAxis,
   CartesianGrid,
+  Brush,
   Tooltip,
   ReferenceLine,
   ReferenceArea,


### PR DESCRIPTION
## Summary
- export `Brush` from the shared chart component

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688bf7d9016083248b4a1187b4fdd336