### PR TITLE
Add monthly pace insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ function with real API calls for production data.
   highHeartRate: boolean
   lowSleep: boolean
   calorieSurplus: boolean
+  bestPaceThisMonth: number | null
+  mostConsistentDay: string | null
 }
 ```
 

--- a/src/hooks/useInsights.ts
+++ b/src/hooks/useInsights.ts
@@ -1,5 +1,6 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useGarminDays, useGarminData } from './useGarminData'
+import { getRunningSessions, type RunningSession } from '@/lib/api'
 
 export interface Insights {
   /** Number of consecutive days meeting the step goal */
@@ -10,14 +11,23 @@ export interface Insights {
   lowSleep: boolean
   /** Calories exceed typical daily target */
   calorieSurplus: boolean
+  /** Fastest pace recorded this month in min/mile */
+  bestPaceThisMonth: number | null
+  /** Day of week with most runs this month */
+  mostConsistentDay: string | null
 }
 
 export function useInsights(): Insights | null {
   const days = useGarminDays()
   const data = useGarminData()
+  const [sessions, setSessions] = useState<RunningSession[] | null>(null)
+
+  useEffect(() => {
+    getRunningSessions().then(setSessions)
+  }, [])
 
   return useMemo(() => {
-    if (!days || !data) return null
+    if (!days || !data || !sessions) return null
     const STEP_GOAL = 8000
     let streak = 0
     for (let i = days.length - 1; i >= 0; i--) {
@@ -25,13 +35,42 @@ export function useInsights(): Insights | null {
       else break
     }
 
+    const now = new Date()
+    const month = now.getMonth()
+    const year = now.getFullYear()
+    const monthly = sessions.filter((s) => {
+      const d = new Date(s.date)
+      return d.getMonth() === month && d.getFullYear() === year
+    })
+    const bestPace = monthly.length
+      ? Math.min(...monthly.map((s) => s.pace))
+      : null
+    const counts = Array.from({ length: 7 }, () => 0)
+    monthly.forEach((s) => {
+      counts[new Date(s.date).getDay()]++
+    })
+    const maxCount = Math.max(...counts)
+    const dayIndex = counts.findIndex((c) => c === maxCount)
+    const dayNames = [
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]
+    const consistentDay = maxCount > 0 ? dayNames[dayIndex] : null
+
     return {
       activeStreak: streak,
       highHeartRate: data.heartRate > 100,
       lowSleep: data.sleep < 6,
       calorieSurplus: data.calories > 2500,
+      bestPaceThisMonth: bestPace,
+      mostConsistentDay: consistentDay,
     }
-  }, [days, data])
+  }, [days, data, sessions])
 }
 
 export default useInsights

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import {
   MiniSparkline,
   RingDetailDialog,
 } from "@/components/dashboard";
+import { Badge } from "@/components/ui/badge";
 import {
   useGarminData,
   useMostRecentActivity,
@@ -22,6 +23,10 @@ export default function Dashboard() {
   const recentActivity = useMostRecentActivity();
   const insights = useInsights();
   const [expanded, setExpanded] = useState<Metric | null>(null);
+  const [dismissed, setDismissed] = useState<{ pace: boolean; day: boolean }>({
+    pace: false,
+    day: false,
+  });
 
   if (!data) {
     return (
@@ -98,6 +103,46 @@ export default function Dashboard() {
               className="h-4 w-4 text-orange-600 mt-1"
               aria-label={`${insights.activeStreak}-day streak`}
             />
+          )}
+          {insights && insights.bestPaceThisMonth && !dismissed.pace && (
+            <div className="mt-1 text-[10px] flex items-center gap-1">
+              <Badge>
+                Best pace {insights.bestPaceThisMonth.toFixed(2)}
+              </Badge>
+              <button
+                className="text-muted-foreground"
+                onClick={() => setDismissed({ ...dismissed, pace: true })}
+                aria-label="Dismiss best pace message"
+              >
+                ×
+              </button>
+              <button
+                className="underline text-muted-foreground"
+                onClick={() => setExpanded("steps")}
+              >
+                Learn more
+              </button>
+            </div>
+          )}
+          {insights && insights.mostConsistentDay && !dismissed.day && (
+            <div className="mt-1 text-[10px] flex items-center gap-1">
+              <Badge>
+                Consistent on {insights.mostConsistentDay}
+              </Badge>
+              <button
+                className="text-muted-foreground"
+                onClick={() => setDismissed({ ...dismissed, day: true })}
+                aria-label="Dismiss consistent day message"
+              >
+                ×
+              </button>
+              <button
+                className="underline text-muted-foreground"
+                onClick={() => setExpanded("steps")}
+              >
+                Learn more
+              </button>
+            </div>
           )}
         </Card>
 


### PR DESCRIPTION
## Summary
- calculate pace-based insights about runs
- update README fields for the new insight data
- show badges on dashboard for best pace and most consistent day

## Testing
- `npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_688bfa46057c83249cf9b6e40d212b1c