### PR TITLE
Add accent color picker

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ThemeToggle from "@/components/ui/theme-toggle";
+import ThemePicker from "@/components/ui/theme-picker";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -17,7 +18,10 @@ export default function Layout({
     <div className="min-h-screen p-4">
       <header className="flex justify-between items-center mb-4">
         <h1 className="text-xl font-bold">Dashboard</h1>
-        <ThemeToggle />
+        <div className="flex gap-2 items-center">
+          <ThemePicker />
+          <ThemeToggle />
+        </div>
       </header>
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>

--- a/src/components/ui/theme-picker.tsx
+++ b/src/components/ui/theme-picker.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { SimpleSelect } from "@/components/ui/select";
+
+const options = [
+  { value: "blue", label: "Blue" },
+  { value: "green", label: "Green" },
+  { value: "rose", label: "Rose" },
+];
+
+export default function ThemePicker() {
+  const [accent, setAccent] = useState<string>("blue");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("accent");
+    if (stored && options.some(o => o.value === stored)) {
+      setAccent(stored);
+      document.documentElement.classList.add(`theme-${stored}`);
+    } else {
+      document.documentElement.classList.add("theme-blue");
+    }
+  }, []);
+
+  function handleChange(val: string) {
+    setAccent(val);
+    options.forEach(o => document.documentElement.classList.remove(`theme-${o.value}`));
+    document.documentElement.classList.add(`theme-${val}`);
+    localStorage.setItem("accent", val);
+  }
+
+  return (
+    <SimpleSelect
+      label="Accent"
+      value={accent}
+      onValueChange={handleChange}
+      options={options}
+    />
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,6 +68,36 @@
     --chart-10: 246 70% 80%;
   }
 
+  :root.theme-green {
+    --primary: 142.1 76% 36.3%;
+    --accent: 142.1 40% 96%;
+    --chart-1: 142 70% 45%;
+    --chart-2: 146 65% 50%;
+    --chart-3: 150 60% 55%;
+    --chart-4: 154 55% 60%;
+    --chart-5: 158 50% 65%;
+    --chart-6: 162 45% 70%;
+    --chart-7: 166 40% 75%;
+    --chart-8: 170 35% 80%;
+    --chart-9: 174 30% 85%;
+    --chart-10: 178 25% 90%;
+  }
+
+  :root.theme-rose {
+    --primary: 340 65% 55%;
+    --accent: 340 40% 96%;
+    --chart-1: 340 65% 55%;
+    --chart-2: 345 60% 60%;
+    --chart-3: 350 55% 65%;
+    --chart-4: 355 50% 70%;
+    --chart-5: 360 55% 75%;
+    --chart-6: 340 65% 60%;
+    --chart-7: 345 60% 65%;
+    --chart-8: 350 55% 70%;
+    --chart-9: 355 50% 75%;
+    --chart-10: 360 55% 80%;
+  }
+
   html, body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary
- add accent color themes (blue, green, rose)
- add `ThemePicker` component to choose accent color
- use `ThemePicker` in layout next to dark/light toggle

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bfb41a02c8324bed7a7f002f66ac6