### PR TITLE
Add activity minutes API and hook for radial grid chart

### DIFF
--- a/src/components/examples/RadialChartGrid.tsx
+++ b/src/components/examples/RadialChartGrid.tsx
@@ -20,14 +20,8 @@ import {
 
 export const description = 'A radial chart with a grid'
 
-// Distribution of workout minutes by activity type
-const chartData = [
-  { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
-  { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
-  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
-  { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
-  { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
-]
+import useActivityMinutes from '@/hooks/useActivityMinutes'
+import { Skeleton } from '@/components/ui/skeleton'
 
 const chartConfig = {
   minutes: { label: 'Minutes' },
@@ -39,6 +33,10 @@ const chartConfig = {
 } satisfies ChartConfig
 
 export default function ChartRadialGrid() {
+  const data = useActivityMinutes()
+
+  if (!data) return <Skeleton className='h-64' />
+
   return (
     <Card className='flex flex-col'>
       <CardHeader className='items-center pb-0'>
@@ -50,7 +48,7 @@ export default function ChartRadialGrid() {
           config={chartConfig}
           className='mx-auto aspect-square max-h-[250px]'
         >
-          <RadialBarChart data={chartData} innerRadius={30} outerRadius={100}>
+          <RadialBarChart data={data} innerRadius={30} outerRadius={100}>
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel nameKey='activity' />} />
             <PolarGrid gridType='circle' />
             <RadialBar dataKey='minutes' />

--- a/src/hooks/useActivityMinutes.ts
+++ b/src/hooks/useActivityMinutes.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from 'react'
+import { ActivityMinutes, getActivityMinutes } from '@/lib/api'
+
+export default function useActivityMinutes(): ActivityMinutes[] | null {
+  const [data, setData] = useState<ActivityMinutes[] | null>(null)
+  useEffect(() => {
+    getActivityMinutes().then(setData)
+  }, [])
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -80,6 +80,28 @@ export async function getGarminData(): Promise<GarminData> {
     }, 500)
   })
 }
+
+// ----- Activity minutes for radial chart -----
+export interface ActivityMinutes {
+  activity: string
+  minutes: number
+  /** CSS color variable string */
+  fill: string
+}
+
+export const mockActivityMinutes: ActivityMinutes[] = [
+  { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
+  { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
+  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
+  { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
+  { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
+]
+
+export async function getActivityMinutes(): Promise<ActivityMinutes[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockActivityMinutes), 200)
+  })
+}
 export async function getDailySteps(): Promise<GarminDay[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(mockDailySteps), 300);


### PR DESCRIPTION
## Summary
- provide new `getActivityMinutes` API returning workout minutes by activity
- add `useActivityMinutes` hook to fetch the data
- update `RadialChartGrid` to load data via the hook and show a skeleton while loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bffcd7d1483249756958f23ade165