### PR TITLE
Add run-bike volume comparison chart

### DIFF
--- a/src/components/statistics/RunBikeVolumeComparison.tsx
+++ b/src/components/statistics/RunBikeVolumeComparison.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useState } from 'react'
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  ChartTooltip,
+  ChartLegend,
+  ChartLegendContent,
+} from '@/components/ui/chart'
+import ChartCard from '@/components/dashboard/ChartCard'
+import useRunBikeVolume from '@/hooks/useRunBikeVolume'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const config = {
+  run: { label: 'Run', color: 'var(--chart-1)' },
+  bike: { label: 'Bike', color: 'var(--chart-2)' },
+} as const
+
+export default function RunBikeVolumeComparison() {
+  const data = useRunBikeVolume()
+  const [metric, setMetric] = useState<'distance' | 'time'>('distance')
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const runKey = metric === 'distance' ? 'runMiles' : 'runTime'
+  const bikeKey = metric === 'distance' ? 'bikeMiles' : 'bikeTime'
+
+  return (
+    <ChartCard title="Run vs Bike Volume">
+      <div className="flex justify-end gap-2 pb-2">
+        <button
+          data-active={metric === 'distance'}
+          className="text-xs px-2 py-1 rounded-md border data-[active=true]:bg-muted"
+          onClick={() => setMetric('distance')}
+        >
+          Distance
+        </button>
+        <button
+          data-active={metric === 'time'}
+          className="text-xs px-2 py-1 rounded-md border data-[active=true]:bg-muted"
+          onClick={() => setMetric('time')}
+        >
+          Time
+        </button>
+      </div>
+      <ChartContainer config={config} className="h-64">
+        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <ChartTooltip />
+          <ChartLegend content={<ChartLegendContent />} />
+          <Bar dataKey={runKey} fill={config.run.color} radius={2} />
+          <Bar dataKey={bikeKey} fill={config.bike.color} radius={2} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/statistics/__tests__/RunBikeVolumeComparison.test.tsx
+++ b/src/components/statistics/__tests__/RunBikeVolumeComparison.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import RunBikeVolumeComparison from '../RunBikeVolumeComparison'
+import { vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+vi.mock('@/hooks/useRunBikeVolume', () => ({
+  __esModule: true,
+  default: () => [
+    { week: '2025-07-01', runMiles: 10, bikeMiles: 20, runTime: 80, bikeTime: 60 },
+    { week: '2025-07-08', runMiles: 12, bikeMiles: 22, runTime: 90, bikeTime: 70 },
+  ],
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+})
+
+describe('RunBikeVolumeComparison', () => {
+  it('toggles metric', () => {
+    render(<RunBikeVolumeComparison />)
+    const distanceBtn = screen.getByRole('button', { name: /distance/i })
+    const timeBtn = screen.getByRole('button', { name: /time/i })
+    expect(distanceBtn).toHaveAttribute('data-active', 'true')
+    fireEvent.click(timeBtn)
+    expect(timeBtn).toHaveAttribute('data-active', 'true')
+  })
+})

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -9,6 +9,8 @@ export { default as PaceVsHR } from "./PaceVsHR";
 export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
 
+export { default as RunBikeVolumeComparison } from "./RunBikeVolumeComparison";
+
 
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";
 export { default as SessionSimilarityMap } from "./SessionSimilarityMap";

--- a/src/hooks/useRunBikeVolume.ts
+++ b/src/hooks/useRunBikeVolume.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+import { RunBikeVolumePoint, getRunBikeVolume } from '@/lib/api'
+
+export default function useRunBikeVolume(): RunBikeVolumePoint[] | null {
+  const [data, setData] = useState<RunBikeVolumePoint[] | null>(null)
+
+  useEffect(() => {
+    getRunBikeVolume().then(setData)
+  }, [])
+
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -331,6 +331,35 @@ export async function getWeeklyVolume(): Promise<WeeklyVolumePoint[]> {
   })
 }
 
+export interface RunBikeVolumePoint {
+  week: string
+  runMiles: number
+  bikeMiles: number
+  runTime: number
+  bikeTime: number
+}
+
+export function generateMockRunBikeVolume(): RunBikeVolumePoint[] {
+  const weeks: RunBikeVolumePoint[] = []
+  for (let i = 0; i < 26; i++) {
+    const date = new Date()
+    date.setDate(date.getDate() - (25 - i) * 7)
+    const week = date.toISOString().slice(0, 10)
+    const runMiles = Math.round(10 + Math.random() * 20)
+    const bikeMiles = Math.round(20 + Math.random() * 40)
+    const runTime = Math.round(runMiles * (8 + Math.random() * 2))
+    const bikeTime = Math.round(bikeMiles * (3 + Math.random()))
+    weeks.push({ week, runMiles, bikeMiles, runTime, bikeTime })
+  }
+  return weeks
+}
+
+export async function getRunBikeVolume(): Promise<RunBikeVolumePoint[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockRunBikeVolume()), 200)
+  })
+}
+
 // ----- Benchmark stats -----
 export interface BenchmarkPoint {
   date: string

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -12,6 +12,7 @@ import {
   PaceVsHR,
   TrainingLoadRatio,
   EquipmentUsageTimeline,
+  RunBikeVolumeComparison,
   PerfVsEnvironmentMatrix,
   SessionSimilarityMap,
   RouteComparison,
@@ -40,6 +41,7 @@ export default function Statistics() {
           <PaceVsHR />
           <TrainingLoadRatio />
           <EquipmentUsageTimeline />
+          <RunBikeVolumeComparison />
           <PerfVsEnvironmentMatrix />
           <SessionSimilarityMap />
           <RouteComparison route="River Loop" />


### PR DESCRIPTION
## Summary
- generate mock run/bike volume data in API helpers
- create `useRunBikeVolume` hook
- add `RunBikeVolumeComparison` chart with toggle for distance/time
- expose the new chart and display it on the Statistics page
- test chart rendering and toggle behaviour

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c01b89d0083248021dc7ecc5dec7c