### PR TITLE
Add interactive treadmill vs outdoor chart

### DIFF
--- a/src/components/examples/TreadmillVsOutdoor.tsx
+++ b/src/components/examples/TreadmillVsOutdoor.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import {
   ChartContainer,
   PieChart,
@@ -8,13 +9,30 @@ import {
   ChartLegend,
 } from '@/components/ui/chart'
 import { Cell } from 'recharts'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 export const description = 'A treadmill vs outdoor chart'
 
-const chartData = [
-  { name: 'Outdoor', value: 1254 },
-  { name: 'Treadmill', value: 477 },
-]
+const monthlyData = [
+  { month: 'january', outdoor: 180, treadmill: 60 },
+  { month: 'february', outdoor: 170, treadmill: 70 },
+  { month: 'march', outdoor: 190, treadmill: 50 },
+  { month: 'april', outdoor: 210, treadmill: 40 },
+  { month: 'may', outdoor: 200, treadmill: 55 },
+] as const
 
 const chartConfig = {
   Outdoor: { label: 'Outdoor', color: 'var(--chart-5)' },
@@ -22,29 +40,61 @@ const chartConfig = {
 } satisfies Record<string, unknown>
 
 export default function TreadmillVsOutdoorExample() {
+  const [activeMonth, setActiveMonth] = React.useState(monthlyData[0].month)
+
+  const pieData = React.useMemo(() => {
+    const current = monthlyData.find((d) => d.month === activeMonth) ?? monthlyData[0]
+    return [
+      { name: 'Outdoor', value: current.outdoor },
+      { name: 'Treadmill', value: current.treadmill },
+    ]
+  }, [activeMonth])
+
   return (
-    <ChartContainer config={chartConfig} className='h-60' title='Treadmill vs Outdoor'>
-      <PieChart width={200} height={160}>
-        <ChartTooltip />
-        <ChartLegend verticalAlign='bottom' height={24} />
-        <Pie
-          data={chartData}
-          dataKey='value'
-          nameKey='name'
-          innerRadius={50}
-          outerRadius={70}
-          paddingAngle={4}
-          cornerRadius={8}
-          label={({ percent }) => `${Math.round(percent * 100)}%`}
-        >
-          {chartData.map((entry, idx) => (
-            <Cell
-              key={entry.name}
-              fill={idx === 0 ? 'var(--chart-5)' : 'var(--chart-6)'}
-            />
-          ))}
-        </Pie>
-      </PieChart>
-    </ChartContainer>
+    <Card className='flex flex-col'>
+      <CardHeader className='flex-row items-start space-y-0 pb-0'>
+        <div className='grid gap-1'>
+          <CardTitle>Treadmill vs Outdoor</CardTitle>
+          <CardDescription>January - May 2024</CardDescription>
+        </div>
+        <Select value={activeMonth} onValueChange={setActiveMonth}>
+          <SelectTrigger className='ml-auto h-7 w-[130px] rounded-lg pl-2.5' aria-label='Select month'>
+            <SelectValue placeholder='Select month' />
+          </SelectTrigger>
+          <SelectContent align='end' className='rounded-xl'>
+            {monthlyData.map((m) => (
+              <SelectItem key={m.month} value={m.month} className='capitalize'>
+                {m.month}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className='flex flex-1 justify-center pb-0'>
+        <ChartContainer config={chartConfig} className='h-60'>
+          <PieChart width={200} height={160}>
+            <ChartTooltip />
+            <ChartLegend verticalAlign='bottom' height={24} />
+            <Pie
+              data={pieData}
+              dataKey='value'
+              nameKey='name'
+              innerRadius={50}
+              outerRadius={70}
+              paddingAngle={4}
+              cornerRadius={8}
+              label={({ percent }) => `${Math.round(percent * 100)}%`}
+            >
+              {pieData.map((entry) => (
+                <Cell
+                  key={entry.name}
+                  fill={`var(--chart-${entry.name === 'Outdoor' ? 5 : 6})`}
+                />
+              ))}
+            </Pie>
+          </PieChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
   )
 }

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -17,6 +17,7 @@ import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
 import ScatterChartPaceHeartRate from "@/components/examples/ScatterChartPaceHeartRate";
 import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import SegmentSlopeComparison from "@/components/examples/SegmentSlopeComparison";
+import TreadmillVsOutdoorExample from "@/components/examples/TreadmillVsOutdoor";
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
 import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
@@ -50,6 +51,7 @@ export default function Examples() {
       <ChartBarMixed />
       <ChartBarLabelCustom />
       <ChartPieInteractive />
+      <TreadmillVsOutdoorExample />
       
       <ScatterChartPaceHeartRate />
       <AreaChartLoadRatio />


### PR DESCRIPTION
## Summary
- add month-selectable treadmill vs outdoor chart
- showcase new chart on the Examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0286e88883248105448cad4816aa