### PR TITLE
Fix map container height for GeoActivityExplorer

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -163,7 +163,11 @@ export default function GeoActivityExplorer() {
   )
 
   return (
-    <ChartContainer config={legendConfig} title="State Visits" className="space-y-6">
+    <ChartContainer
+      config={legendConfig}
+      title="State Visits"
+      className="h-60 space-y-6"
+    >
       <div className="flex gap-4 mb-4">
         <SimpleSelect
           label="Activity"


### PR DESCRIPTION
## Summary
- ensure GeoActivityExplorer's ChartContainer has a height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c04c13ebc8324bae5bf21e303aeac