### PR TITLE
Add 20-year weekly volume chart example

### DIFF
--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  CartesianGrid,
+  Brush,
+  Tooltip as ChartTooltip,
+} from '@/components/ui/chart'
+import ChartCard from '@/components/dashboard/ChartCard'
+import type { ChartConfig } from '@/components/ui/chart'
+import useWeeklyVolumeHistory from '@/hooks/useWeeklyVolumeHistory'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function WeeklyVolumeHistoryChart() {
+  const data = useWeeklyVolumeHistory()
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const config = {
+    miles: { label: 'Miles', color: 'var(--chart-1)' },
+  } satisfies ChartConfig
+
+  return (
+    <ChartCard title="Weekly Volume (20y)">
+      <ChartContainer config={config} className="h-64">
+        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <ChartTooltip />
+          <Bar dataKey="miles" fill="var(--chart-1)" radius={2} animationDuration={300} />
+          <Brush dataKey="week" height={20} travellerWidth={10} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/hooks/useWeeklyVolumeHistory.ts
+++ b/src/hooks/useWeeklyVolumeHistory.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+import { WeeklyVolumePoint, getWeeklyVolumeHistory } from "@/lib/api";
+
+export default function useWeeklyVolumeHistory(
+  years: number = 20,
+): WeeklyVolumePoint[] | null {
+  const [data, setData] = useState<WeeklyVolumePoint[] | null>(null);
+  useEffect(() => {
+    getWeeklyVolumeHistory(years).then(setData);
+  }, [years]);
+  return data;
+}

--- a/src/lib/__tests__/weeklyVolumeHistory.test.ts
+++ b/src/lib/__tests__/weeklyVolumeHistory.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest'
+import { generateMockWeeklyVolumeHistory } from '../api'
+
+describe('generateMockWeeklyVolumeHistory', () => {
+  it('creates 20 years of weekly data by default', () => {
+    const data = generateMockWeeklyVolumeHistory()
+    expect(data).toHaveLength(20 * 52)
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -353,6 +353,26 @@ export async function getWeeklyVolume(): Promise<WeeklyVolumePoint[]> {
   })
 }
 
+export function generateMockWeeklyVolumeHistory(years = 20): WeeklyVolumePoint[] {
+  const weeks: WeeklyVolumePoint[] = []
+  const total = years * 52
+  for (let i = 0; i < total; i++) {
+    const date = new Date()
+    date.setDate(date.getDate() - (total - 1 - i) * 7)
+    const week = date.toISOString().slice(0, 10)
+    weeks.push({ week, miles: Math.round(20 + Math.random() * 30) })
+  }
+  return weeks
+}
+
+export async function getWeeklyVolumeHistory(
+  years = 20,
+): Promise<WeeklyVolumePoint[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockWeeklyVolumeHistory(years)), 200)
+  })
+}
+
 export interface RunBikeVolumePoint {
   week: string
   runMiles: number

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -20,6 +20,7 @@ import SegmentSlopeComparison from "@/components/examples/SegmentSlopeComparison
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
 import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
+import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
 
 
 export default function Examples() {
@@ -30,6 +31,8 @@ export default function Examples() {
       <StepsTrendWithGoal data={mockDailySteps} />
 
       <PeerBenchmarkBands />
+
+      <WeeklyVolumeHistoryChart />
 
       <BarChartInteractive />
 


### PR DESCRIPTION
## Summary
- mock long-term weekly mileage data in `api.ts`
- expose hook `useWeeklyVolumeHistory`
- add `WeeklyVolumeHistoryChart` example
- embed the chart on the examples page
- test generation of long history data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c04800890832499083de3834d953e