### PR TITLE
Add location efficiency comparison map

### DIFF
--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -1,0 +1,89 @@
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  Marker,
+} from 'react-simple-maps'
+import ChartCard from '@/components/dashboard/ChartCard'
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ChartTooltip,
+} from '@/components/ui/chart'
+import { Cell } from 'recharts'
+import { Skeleton } from '@/components/ui/skeleton'
+import useLocationEfficiency from '@/hooks/useLocationEfficiency'
+import statesTopo from '../../../public/us-states.json'
+
+const CITY_COORDS: Record<string, [number, number]> = {
+  'Los Angeles': [-118.2437, 34.0522],
+  'San Francisco': [-122.4194, 37.7749],
+  Austin: [-97.7431, 30.2672],
+  Houston: [-95.3698, 29.7604],
+}
+
+const config = {
+  effort: { label: 'Effort', color: 'var(--chart-1)' },
+} as const
+
+export default function LocationEfficiencyComparison() {
+  const data = useLocationEfficiency()
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const sorted = [...data].sort((a, b) => b.effort - a.effort)
+
+  return (
+    <ChartCard title="Location Efficiency">
+      <div className="flex gap-4">
+        <div className="w-64 h-40" aria-label="location map">
+          <ComposableMap projection="geoAlbersUsa">
+            <Geographies geography={statesTopo as any}>
+              {({ geographies }) =>
+                geographies.map((geo) => (
+                  <Geography
+                    key={geo.rsmKey}
+                    geography={geo}
+                    style={{ default: { fill: 'hsl(var(--muted))', outline: 'none' } }}
+                  />
+                ))
+              }
+            </Geographies>
+            {sorted.map((loc) => {
+              const coords = CITY_COORDS[loc.city]
+              return coords ? (
+                <Marker key={loc.city} coordinates={coords}>
+                  <circle r={3} fill="hsl(var(--primary))" />
+                </Marker>
+              ) : null
+            })}
+          </ComposableMap>
+        </div>
+        <div className="flex-1">
+          <ChartContainer config={config} className="h-40">
+            <BarChart data={sorted} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="city" />
+              <YAxis />
+              <ChartTooltip />
+              <Bar dataKey="effort" fill={config.effort.color} animationDuration={300}>
+                {sorted.map((l) => (
+                  <Cell key={l.city} aria-label={`Effort for ${l.city}`} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ChartContainer>
+          <ol aria-label="ranking" className="sr-only">
+            {sorted.map((l) => (
+              <li key={l.city}>{l.city}</li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </ChartCard>
+  )
+}

--- a/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
+++ b/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import LocationEfficiencyComparison from '../LocationEfficiencyComparison'
+import { vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+vi.mock('@/hooks/useLocationEfficiency', () => ({
+  __esModule: true,
+  default: () => [
+    { state: 'CA', city: 'Los Angeles', distance: 10, pace: 8, effort: 80 },
+    { state: 'TX', city: 'Austin', distance: 8, pace: 7, effort: 56 },
+  ],
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+})
+
+describe('LocationEfficiencyComparison', () => {
+  it('renders map and ranks locations', () => {
+    render(<LocationEfficiencyComparison />)
+    expect(screen.getByLabelText(/location map/i)).toBeInTheDocument()
+    const ranking = screen.getByLabelText('ranking')
+    expect(ranking.textContent?.startsWith('Los Angeles')).toBe(true)
+  })
+})

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -1,0 +1,2 @@
+export { default as GeoActivityExplorer } from './GeoActivityExplorer'
+export { default as LocationEfficiencyComparison } from './LocationEfficiencyComparison'

--- a/src/hooks/useLocationEfficiency.ts
+++ b/src/hooks/useLocationEfficiency.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+import { getLocationEfficiency, LocationEfficiency } from '@/lib/api'
+
+export default function useLocationEfficiency(): LocationEfficiency[] | null {
+  const [data, setData] = useState<LocationEfficiency[] | null>(null)
+
+  useEffect(() => {
+    getLocationEfficiency().then(setData)
+  }, [])
+
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -496,3 +496,50 @@ export async function getRouteSessions(route: string): Promise<RouteSession[]> {
     setTimeout(() => resolve(generateMockRouteSessions(route)), 200)
   })
 }
+
+// ----- Location efficiency -----
+
+export interface LocationEfficiency {
+  state: string
+  city: string
+  distance: number
+  pace: number
+  effort: number
+}
+
+export const mockLocationEfficiency: LocationEfficiency[] = [
+  {
+    state: 'CA',
+    city: 'Los Angeles',
+    distance: 10,
+    pace: 8,
+    effort: 80,
+  },
+  {
+    state: 'CA',
+    city: 'San Francisco',
+    distance: 8,
+    pace: 7.5,
+    effort: 60,
+  },
+  {
+    state: 'TX',
+    city: 'Austin',
+    distance: 6,
+    pace: 7,
+    effort: 42,
+  },
+  {
+    state: 'TX',
+    city: 'Houston',
+    distance: 5,
+    pace: 8,
+    effort: 40,
+  },
+]
+
+export async function getLocationEfficiency(): Promise<LocationEfficiency[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockLocationEfficiency), 200)
+  })
+}


### PR DESCRIPTION
## Summary
- add location efficiency dataset and API
- create `useLocationEfficiency` hook
- build `LocationEfficiencyComparison` map component
- export map components through `src/components/map/index.ts`
- test map ranking rendering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c0678a0cc832493488bdf5758b353