### PR TITLE
Add weekly comparison chart

### DIFF
--- a/src/components/statistics/WeeklyComparisonChart.tsx
+++ b/src/components/statistics/WeeklyComparisonChart.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  CartesianGrid,
+  ChartTooltip,
+  ChartLegend,
+  ChartLegendContent,
+} from '@/components/ui/chart'
+import ChartCard from '@/components/dashboard/ChartCard'
+import useWeeklyComparison from '@/hooks/useWeeklyComparison'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function WeeklyComparisonChart({
+  metric,
+}: {
+  metric: string
+}) {
+  const data = useWeeklyComparison(metric)
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const merged = data.current.map((p, i) => ({
+    date: p.date,
+    current: p.value,
+    previous: data.previous[i]?.value ?? null,
+  }))
+
+  const config = {
+    current: { label: 'This Week', color: 'var(--chart-1)' },
+    previous: { label: 'Last Week', color: 'var(--chart-2)' },
+  } as const
+
+  return (
+    <ChartCard title="Weekly Comparison">
+      <ChartContainer config={config} className="h-64">
+        <LineChart data={merged} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString('en-US', { weekday: 'short' })} />
+          <ChartTooltip />
+          <ChartLegend content={<ChartLegendContent />} />
+          <Line type="monotone" dataKey="current" stroke={config.current.color} dot={false} />
+          <Line type="monotone" dataKey="previous" stroke={config.previous.color} dot={false} strokeOpacity={0.5} />
+        </LineChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
+++ b/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import WeeklyComparisonChart from '../WeeklyComparisonChart'
+import { vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+vi.mock('@/hooks/useWeeklyComparison', () => ({
+  __esModule: true,
+  default: () => ({
+    current: [
+      { date: '2025-07-01', value: 10 },
+      { date: '2025-07-02', value: 12 },
+    ],
+    previous: [
+      { date: '2025-06-24', value: 8 },
+      { date: '2025-06-25', value: 9 },
+    ],
+    lastYear: [],
+  }),
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ width: 400, height: 300, top: 0, left: 0, bottom: 0, right: 0 })
+  })
+})
+
+describe('WeeklyComparisonChart', () => {
+  it('shows both series and tooltip labels', () => {
+    render(<WeeklyComparisonChart metric="steps" />)
+    expect(screen.getByText('This Week')).toBeInTheDocument()
+    expect(screen.getByText('Last Week')).toBeInTheDocument()
+    const lines = document.querySelectorAll('path[stroke^="var(--chart-"]')
+    expect(lines.length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText('This Week')).toBeInTheDocument()
+    expect(screen.getByText('Last Week')).toBeInTheDocument()
+  })
+})

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -10,6 +10,7 @@ export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
 
 export { default as RunBikeVolumeComparison } from "./RunBikeVolumeComparison";
+export { default as WeeklyComparisonChart } from "./WeeklyComparisonChart";
 
 
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";

--- a/src/hooks/useWeeklyComparison.ts
+++ b/src/hooks/useWeeklyComparison.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import {
+  WeeklyMetricPoint,
+  getCurrentWeek,
+  getPreviousWeek,
+  getSameWeekLastYear,
+} from '@/lib/api'
+
+export interface WeeklyComparisonData {
+  current: WeeklyMetricPoint[]
+  previous: WeeklyMetricPoint[]
+  lastYear: WeeklyMetricPoint[]
+}
+
+export default function useWeeklyComparison(
+  metric: string,
+): WeeklyComparisonData | null {
+  const [data, setData] = useState<WeeklyComparisonData | null>(null)
+
+  useEffect(() => {
+    let active = true
+    Promise.all([
+      getCurrentWeek(metric),
+      getPreviousWeek(metric),
+      getSameWeekLastYear(metric),
+    ]).then(([current, previous, lastYear]) => {
+      if (active) setData({ current, previous, lastYear })
+    })
+    return () => {
+      active = false
+    }
+  }, [metric])
+
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -336,6 +336,11 @@ export interface WeeklyVolumePoint {
   miles: number
 }
 
+export interface WeeklyMetricPoint {
+  date: string
+  value: number
+}
+
 export function generateMockWeeklyVolume(): WeeklyVolumePoint[] {
   const weeks: WeeklyVolumePoint[] = []
   for (let i = 0; i < 26; i++) {
@@ -379,6 +384,55 @@ export function generateMockRunBikeVolume(): RunBikeVolumePoint[] {
 export async function getRunBikeVolume(): Promise<RunBikeVolumePoint[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(generateMockRunBikeVolume()), 200)
+  })
+}
+
+// ----- Weekly comparison metrics -----
+function startOfWeek(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  d.setDate(d.getDate() - day)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function generateWeek(start: Date): WeeklyMetricPoint[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    return {
+      date: d.toISOString().slice(0, 10),
+      value: Math.round(50 + Math.random() * 50),
+    }
+  })
+}
+
+export async function getCurrentWeek(
+  _metric: string,
+): Promise<WeeklyMetricPoint[]> {
+  return new Promise((resolve) => {
+    const start = startOfWeek(new Date())
+    setTimeout(() => resolve(generateWeek(start)), 150)
+  })
+}
+
+export async function getPreviousWeek(
+  _metric: string,
+): Promise<WeeklyMetricPoint[]> {
+  return new Promise((resolve) => {
+    const start = startOfWeek(new Date())
+    start.setDate(start.getDate() - 7)
+    setTimeout(() => resolve(generateWeek(start)), 150)
+  })
+}
+
+export async function getSameWeekLastYear(
+  _metric: string,
+): Promise<WeeklyMetricPoint[]> {
+  return new Promise((resolve) => {
+    const start = startOfWeek(new Date())
+    start.setFullYear(start.getFullYear() - 1)
+    setTimeout(() => resolve(generateWeek(start)), 150)
   })
 }
 

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -13,6 +13,7 @@ import {
   TrainingLoadRatio,
   EquipmentUsageTimeline,
   RunBikeVolumeComparison,
+  WeeklyComparisonChart,
   PerfVsEnvironmentMatrix,
   SessionSimilarityMap,
   RouteComparison,
@@ -31,6 +32,7 @@ export default function Statistics() {
       <ChartSelectionProvider>
         <div className="grid gap-6 p-6">
           <WeeklyVolumeChart />
+          <WeeklyComparisonChart metric="steps" />
           <AnnualMileage />
           <ActivityByTime />
           <AvgDailyMileageRadar />


### PR DESCRIPTION
## Summary
- extend api with weekly metric helpers for current, previous, and last year
- add useWeeklyComparison hook
- implement WeeklyComparisonChart with ghosted last week overlay
- export and show chart in statistics page
- test that chart renders both series and legend labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0674b1d0832488d2cbde9e4d8dfb