### PR TITLE
Add shoe usage chart example

### DIFF
--- a/src/components/examples/ShoeUsageChart.tsx
+++ b/src/components/examples/ShoeUsageChart.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { TrendingUp } from 'lucide-react'
+import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+
+export const description = 'A shoe usage bar chart'
+
+const chartData = [
+  { model: 'Pegasus 40', miles: 120 },
+  { model: 'Alphafly 2', miles: 95 },
+  { model: 'Invincible 3', miles: 75 },
+  { model: 'Zoom Fly 5', miles: 60 },
+]
+
+const chartConfig = {
+  miles: { label: 'Miles', color: 'hsl(var(--chart-4))' },
+} satisfies ChartConfig
+
+export default function ShoeUsageChart() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Shoe Usage</CardTitle>
+        <CardDescription>Miles per model</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className='h-60'>
+          <BarChart accessibilityLayer data={chartData}>
+            <CartesianGrid vertical={false} />
+            <XAxis dataKey='model' tickLine={false} tickMargin={10} axisLine={false} />
+            <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+            <Bar dataKey='miles' fill='var(--color-miles)' radius={8} />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex gap-2 text-sm'>
+        Trending up <TrendingUp className='h-4 w-4' />
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -14,6 +14,7 @@ import ChartRadarDots from "@/components/examples/RadarChartDots";
 import RadarChartWorkoutByTime from "@/components/examples/RadarChartWorkoutByTime";
 import ChartBarMixed from "@/components/examples/BarChartMixed";
 import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
+import ShoeUsageChart from "@/components/examples/ShoeUsageChart";
 import ScatterChartPaceHeartRate from "@/components/examples/ScatterChartPaceHeartRate";
 import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import SegmentSlopeComparison from "@/components/examples/SegmentSlopeComparison";
@@ -51,6 +52,7 @@ export default function Examples() {
       <ChartBarMixed />
       <ChartBarLabelCustom />
       <ChartPieInteractive />
+      <ShoeUsageChart />
       <TreadmillVsOutdoorExample />
       
       <ScatterChartPaceHeartRate />


### PR DESCRIPTION
## Summary
- add `ShoeUsageChart` component showcasing miles per shoe model
- display the new chart on the examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c05dd22dc8324bcc819d71ec39cdd