### PR TITLE
Add pace vs heart rate example chart

### DIFF
--- a/src/components/examples/PaceVsHeartRate.tsx
+++ b/src/components/examples/PaceVsHeartRate.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import {
+  ChartContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from '@/components/ui/chart'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card'
+import { useRunningStats } from '@/hooks/useRunningStats'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const chartConfig = {
+  pace: { label: 'Pace', color: 'hsl(var(--chart-9))' },
+  heartRate: { label: 'Heart Rate', color: 'hsl(var(--chart-10))' },
+} as const
+
+export default function PaceVsHeartRate() {
+  const stats = useRunningStats()
+
+  if (!stats) return <Skeleton className='h-64' />
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pace vs Heart Rate</CardTitle>
+        <CardDescription>Recent workouts</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className='h-64'>
+          <ScatterChart>
+            <CartesianGrid strokeDasharray='3 3' />
+            <XAxis dataKey='pace' name='Pace (min/mi)' />
+            <YAxis dataKey='heartRate' name='Heart Rate (bpm)' />
+            <ChartTooltip />
+            <Scatter data={stats.paceVsHeart} fill='var(--chart-9)' />
+          </ScatterChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -15,6 +15,7 @@ import RadarChartWorkoutByTime from "@/components/examples/RadarChartWorkoutByTi
 import ChartBarMixed from "@/components/examples/BarChartMixed";
 import ChartBarLabelCustom from "@/components/examples/BarChartLabelCustom";
 import ScatterChartPaceHeartRate from "@/components/examples/ScatterChartPaceHeartRate";
+import PaceVsHeartRate from "@/components/examples/PaceVsHeartRate";
 import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import SegmentSlopeComparison from "@/components/examples/SegmentSlopeComparison";
 import TreadmillVsOutdoorExample from "@/components/examples/TreadmillVsOutdoor";
@@ -52,8 +53,9 @@ export default function Examples() {
       <ChartBarLabelCustom />
       <ChartPieInteractive />
       <TreadmillVsOutdoorExample />
-      
+
       <ScatterChartPaceHeartRate />
+      <PaceVsHeartRate />
       <AreaChartLoadRatio />
 
       <SegmentSlopeComparison />


### PR DESCRIPTION
## Summary
- add `PaceVsHeartRate` example component using `useRunningStats`
- include the new chart on the Examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c057939bc832497f86de2eeb3ec85