### PR TITLE
Fix chart color variables

### DIFF
--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -28,7 +28,7 @@ export default function WeeklyVolumeChart() {
   if (!data) return <Skeleton className="h-64" />;
 
   const config = {
-    miles: { label: "Miles", color: "var(--chart-1)" },
+    miles: { label: "Miles", color: "hsl(var(--chart-1))" },
   } satisfies ChartConfig;
 
   return (
@@ -38,7 +38,7 @@ export default function WeeklyVolumeChart() {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
           <ChartTooltip />
-          <Bar dataKey="miles" fill="var(--chart-1)" radius={2} animationDuration={300} />
+          <Bar dataKey="miles" fill="var(--color-miles)" radius={2} animationDuration={300} />
           <Brush
             dataKey="week"
             height={20}

--- a/src/components/examples/PieChartInteractive.tsx
+++ b/src/components/examples/PieChartInteractive.tsx
@@ -48,23 +48,23 @@ const chartConfig = {
   },
   january: {
     label: "January",
-    color: "var(--chart-1)",
+    color: "hsl(var(--chart-1))",
   },
   february: {
     label: "February",
-    color: "var(--chart-2)",
+    color: "hsl(var(--chart-2))",
   },
   march: {
     label: "March",
-    color: "var(--chart-3)",
+    color: "hsl(var(--chart-3))",
   },
   april: {
     label: "April",
-    color: "var(--chart-4)",
+    color: "hsl(var(--chart-4))",
   },
   may: {
     label: "May",
-    color: "var(--chart-5)",
+    color: "hsl(var(--chart-5))",
   },
 } satisfies ChartConfig
 

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -20,7 +20,7 @@ export default function WeeklyVolumeHistoryChart() {
   if (!data) return <Skeleton className="h-64" />
 
   const config = {
-    miles: { label: 'Miles', color: 'var(--chart-1)' },
+    miles: { label: 'Miles', color: 'hsl(var(--chart-1))' },
   } satisfies ChartConfig
 
   return (
@@ -30,7 +30,7 @@ export default function WeeklyVolumeHistoryChart() {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
           <ChartTooltip />
-          <Bar dataKey="miles" fill="var(--chart-1)" radius={2} animationDuration={300} />
+          <Bar dataKey="miles" fill="var(--color-miles)" radius={2} animationDuration={300} />
           <Brush dataKey="week" height={20} travellerWidth={10} />
         </BarChart>
       </ChartContainer>

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -27,7 +27,7 @@ const CITY_COORDS: Record<string, [number, number]> = {
 }
 
 const config = {
-  effort: { label: 'Effort', color: 'var(--chart-1)' },
+  effort: { label: 'Effort', color: 'hsl(var(--chart-1))' },
 } as const
 
 export default function LocationEfficiencyComparison() {

--- a/src/components/statistics/AnnualMileage.tsx
+++ b/src/components/statistics/AnnualMileage.tsx
@@ -25,7 +25,7 @@ const annualData = [
 ]
 
 const config = {
-  miles: { label: "Mileage", color: "var(--chart-1)" },
+  miles: { label: "Mileage", color: "hsl(var(--chart-1))" },
 } satisfies Record<string, unknown>
 
 export default function AnnualMileage() {
@@ -36,7 +36,7 @@ export default function AnnualMileage() {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" tickLine={false} axisLine={false} />
           <ChartTooltip />
-          <Bar dataKey="miles" fill="var(--chart-1)" radius={2} />
+          <Bar dataKey="miles" fill="var(--color-miles)" radius={2} />
         </BarChart>
       </ChartContainer>
     </ChartCard>

--- a/src/components/statistics/RunBikeVolumeComparison.tsx
+++ b/src/components/statistics/RunBikeVolumeComparison.tsx
@@ -16,8 +16,8 @@ import useRunBikeVolume from '@/hooks/useRunBikeVolume'
 import { Skeleton } from '@/components/ui/skeleton'
 
 const config = {
-  run: { label: 'Run', color: 'var(--chart-1)' },
-  bike: { label: 'Bike', color: 'var(--chart-2)' },
+  run: { label: 'Run', color: 'hsl(var(--chart-1))' },
+  bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
 } as const
 
 export default function RunBikeVolumeComparison() {

--- a/src/components/statistics/SessionSimilarityMap.tsx
+++ b/src/components/statistics/SessionSimilarityMap.tsx
@@ -14,10 +14,10 @@ import { useRunningSessions } from "@/hooks/useRunningSessions"
 import { Skeleton } from "@/components/ui/skeleton"
 
 const colors = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
 ]
 
 const config = {

--- a/src/components/statistics/WeeklyComparisonChart.tsx
+++ b/src/components/statistics/WeeklyComparisonChart.tsx
@@ -30,8 +30,8 @@ export default function WeeklyComparisonChart({
   }))
 
   const config = {
-    current: { label: 'This Week', color: 'var(--chart-1)' },
-    previous: { label: 'Last Week', color: 'var(--chart-2)' },
+    current: { label: 'This Week', color: 'hsl(var(--chart-1))' },
+    previous: { label: 'Last Week', color: 'hsl(var(--chart-2))' },
   } as const
 
   return (

--- a/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
+++ b/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
@@ -35,7 +35,7 @@ describe('WeeklyComparisonChart', () => {
     render(<WeeklyComparisonChart metric="steps" />)
     expect(screen.getByText('This Week')).toBeInTheDocument()
     expect(screen.getByText('Last Week')).toBeInTheDocument()
-    const lines = document.querySelectorAll('path[stroke^="var(--chart-"]')
+    const lines = document.querySelectorAll('path[stroke^="hsl(var(--chart-"]')
     expect(lines.length).toBeGreaterThanOrEqual(2)
     expect(screen.getByText('This Week')).toBeInTheDocument()
     expect(screen.getByText('Last Week')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- apply `hsl(var(--chart-* ))` color style to mileage charts and map components
- update pie chart color tokens
- adjust WeeklyComparisonChart test for new color syntax

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0811201083248ec3d12a064ae355