### PR TITLE
Fix example chart colors

### DIFF
--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -65,8 +65,8 @@ function regression(
 const DATA = generateData()
 
 const config = {
-  pace: { label: 'Pace', color: 'var(--chart-8)' },
-  trend: { label: 'Trend', color: 'var(--chart-3)' },
+  pace: { label: 'Pace', color: 'hsl(var(--chart-1))' },
+  trend: { label: 'Trend', color: 'hsl(var(--chart-2))' },
 } as const
 
 export default function PerfVsEnvironmentMatrixExample() {
@@ -84,8 +84,8 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='temperature' name='Temp (F)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
-            <Line data={tempReg} stroke={config.trend.color} dot={false} />
+            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Line data={tempReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
         <ChartContainer config={config} className='h-60'>
@@ -94,8 +94,8 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='humidity' name='Humidity (%)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
-            <Line data={humidityReg} stroke={config.trend.color} dot={false} />
+            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Line data={humidityReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
         <ChartContainer config={config} className='h-60'>
@@ -104,8 +104,8 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='wind' name='Wind (mph)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
-            <Line data={windReg} stroke={config.trend.color} dot={false} />
+            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Line data={windReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
         <ChartContainer config={config} className='h-60'>
@@ -114,8 +114,8 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='elevation' name='Elevation (ft)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
-            <Line data={elevReg} stroke={config.trend.color} dot={false} />
+            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Line data={elevReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
       </div>

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -20,7 +20,7 @@ export default function WeeklyVolumeHistoryChart() {
   if (!data) return <Skeleton className="h-64" />
 
   const config = {
-    miles: { label: 'Miles', color: 'var(--chart-1)' },
+    miles: { label: 'Miles', color: 'hsl(var(--chart-1))' },
   } satisfies ChartConfig
 
   return (
@@ -30,7 +30,7 @@ export default function WeeklyVolumeHistoryChart() {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
           <ChartTooltip />
-          <Bar dataKey="miles" fill="var(--chart-1)" radius={2} animationDuration={300} />
+          <Bar dataKey="miles" fill="var(--color-miles)" radius={2} animationDuration={300} />
           <Brush dataKey="week" height={20} travellerWidth={10} />
         </BarChart>
       </ChartContainer>


### PR DESCRIPTION
## Summary
- use `hsl(--chart-1)` token in WeeklyVolumeHistoryChart
- hook up PerfVsEnvironmentMatrix to common chart colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0c2ed4d883249a6f6d0634730d1f