### PR TITLE
Add descriptions to chart headers

### DIFF
--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -26,7 +26,11 @@ const chartConfig = {
 
 export function DailyStepsChart({ data }: DailyStepsChartProps) {
   return (
-    <ChartCard title="Daily Steps" className="md:col-span-2">
+    <ChartCard
+      title="Daily Steps"
+      description="Historical daily step totals"
+      className="md:col-span-2"
+    >
       <ChartContainer config={chartConfig} className="h-60">
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/dashboard/StepsTrendWithGoal.tsx
+++ b/src/components/dashboard/StepsTrendWithGoal.tsx
@@ -124,7 +124,11 @@ export function StepsTrendWithGoal({
   }
 
   return (
-    <ChartCard title="Pace Trend (min/mile)" className="md:col-span-2">
+    <ChartCard
+      title="Pace Trend (min/mile)"
+      description="How pace varies with weather conditions"
+      className="md:col-span-2"
+    >
       <ChartContainer config={chartConfig} className="h-60">
         <AreaChart data={dataWithAvg} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <defs>

--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -32,7 +32,7 @@ export default function WeeklyVolumeChart() {
   } satisfies ChartConfig;
 
   return (
-    <ChartCard title="Weekly Volume">
+    <ChartCard title="Weekly Volume" description="Historical weekly mileage totals">
       <ChartContainer config={config} className="h-64">
         <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -76,7 +76,11 @@ export default function PerfVsEnvironmentMatrixExample() {
   const elevReg = regression(DATA, 'elevation', 'pace')
 
   return (
-    <ChartCard title='Perf vs Environment' className='space-y-4'>
+    <ChartCard
+      title='Perf vs Environment'
+      description='How pace varies with weather conditions'
+      className='space-y-4'
+    >
       <div className='grid gap-4 md:grid-cols-2'>
         <ChartContainer config={config} className='h-60'>
           <ScatterChart>

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -24,7 +24,10 @@ export default function WeeklyVolumeHistoryChart() {
   } satisfies ChartConfig
 
   return (
-    <ChartCard title="Weekly Volume (20y)">
+    <ChartCard
+      title="Weekly Volume (20y)"
+      description="Historical weekly mileage totals"
+    >
       <ChartContainer config={config} className="h-64">
         <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -38,7 +38,10 @@ export default function LocationEfficiencyComparison() {
   const sorted = [...data].sort((a, b) => b.effort - a.effort)
 
   return (
-    <ChartCard title="Location Efficiency">
+    <ChartCard
+      title="Location Efficiency"
+      description="Relative efficiency by location"
+    >
       <div className="flex gap-4">
         <div className="w-64 h-40" aria-label="location map">
           <ComposableMap projection="geoAlbersUsa">

--- a/src/components/statistics/ActivityByTime.tsx
+++ b/src/components/statistics/ActivityByTime.tsx
@@ -32,7 +32,10 @@ const config = {
 
 export default function ActivityByTime() {
   return (
-    <ChartCard title="Workout Activity by Time">
+    <ChartCard
+      title="Workout Activity by Time"
+      description="Sessions by time of day"
+    >
       <ChartContainer config={config} className="h-64">
         <RadarChart data={activityByTimeData}>
           <PolarGrid />

--- a/src/components/statistics/AnnualMileage.tsx
+++ b/src/components/statistics/AnnualMileage.tsx
@@ -30,7 +30,10 @@ const config = {
 
 export default function AnnualMileage() {
   return (
-    <ChartCard title="Annual Mileage">
+    <ChartCard
+      title="Annual Mileage"
+      description="Mileage totals by month"
+    >
       <ChartContainer config={config} className="h-64">
         <BarChart data={annualData}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/AvgDailyMileageRadar.tsx
+++ b/src/components/statistics/AvgDailyMileageRadar.tsx
@@ -27,7 +27,10 @@ const config = {
 
 export default function AvgDailyMileageRadar() {
   return (
-    <ChartCard title="Average Daily Mileage">
+    <ChartCard
+      title="Average Daily Mileage"
+      description="Average mileage by day of week"
+    >
       <ChartContainer config={config} className="h-64">
         <RadarChart data={dailyMileage}>
           <PolarGrid />

--- a/src/components/statistics/EquipmentUsageTimeline.tsx
+++ b/src/components/statistics/EquipmentUsageTimeline.tsx
@@ -30,7 +30,10 @@ const config = {
 
 export default function EquipmentUsageTimeline() {
   return (
-    <ChartCard title="Equipment Usage">
+    <ChartCard
+      title="Equipment Usage"
+      description="Bike and shoe usage over time"
+    >
       <ChartContainer config={config} className="h-64">
         <BarChart data={usageData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/HeartRateZones.tsx
+++ b/src/components/statistics/HeartRateZones.tsx
@@ -24,7 +24,10 @@ export default function HeartRateZones() {
   if (!stats) return <Skeleton className="h-60" />
 
   return (
-    <ChartCard title="Heart Rate Zones">
+    <ChartCard
+      title="Heart Rate Zones"
+      description="Percent of time per zone"
+    >
       <ChartContainer config={config} className="h-60">
         <BarChart data={stats.heartRateZones}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/PaceDistribution.tsx
+++ b/src/components/statistics/PaceDistribution.tsx
@@ -24,7 +24,10 @@ export default function PaceDistribution() {
   if (!stats) return <Skeleton className="h-64" />
 
   return (
-    <ChartCard title="Pace Distribution">
+    <ChartCard
+      title="Pace Distribution"
+      description="Distribution of paces across runs"
+    >
       <ChartContainer config={config} className="h-64">
         <AreaChart data={stats.paceDistribution}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/PaceVsHR.tsx
+++ b/src/components/statistics/PaceVsHR.tsx
@@ -23,7 +23,10 @@ const config = {
 
 export default function PaceVsHR() {
   return (
-    <ChartCard title="Pace vs Heart Rate">
+    <ChartCard
+      title="Pace vs Heart Rate"
+      description="Correlation between pace and heart rate"
+    >
       <ChartContainer config={config} className="h-64">
         <ScatterChart>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/PeerBenchmarkBands.tsx
+++ b/src/components/statistics/PeerBenchmarkBands.tsx
@@ -41,7 +41,10 @@ export default function PeerBenchmarkBands() {
   } satisfies ChartConfig
 
   return (
-    <ChartCard title="Pace Benchmark">
+    <ChartCard
+      title="Pace Benchmark"
+      description="Percentile bands compared to peers"
+    >
       <ChartContainer config={config} className="h-64">
         <AreaChart data={paceData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/statistics/PerfVsEnvironmentMatrix.tsx
@@ -74,7 +74,11 @@ export default function PerfVsEnvironmentMatrix() {
   const elevReg = regression(DATA, "elevation", "pace");
 
   return (
-    <ChartCard title="Perf vs Environment" className="space-y-4">
+    <ChartCard
+      title="Perf vs Environment"
+      description="How pace varies with weather conditions"
+      className="space-y-4"
+    >
       <div className="grid gap-4 md:grid-cols-2">
         <ChartContainer config={config} className="h-60">
           <ScatterChart>

--- a/src/components/statistics/RunBikeVolumeComparison.tsx
+++ b/src/components/statistics/RunBikeVolumeComparison.tsx
@@ -30,7 +30,10 @@ export default function RunBikeVolumeComparison() {
   const bikeKey = metric === 'distance' ? 'bikeMiles' : 'bikeTime'
 
   return (
-    <ChartCard title="Run vs Bike Volume">
+    <ChartCard
+      title="Run vs Bike Volume"
+      description="Compare running and cycling volume"
+    >
       <div className="flex justify-end gap-2 pb-2">
         <button
           data-active={metric === 'distance'}

--- a/src/components/statistics/RunDistances.tsx
+++ b/src/components/statistics/RunDistances.tsx
@@ -29,7 +29,10 @@ const config = {
 
 export default function RunDistances() {
   return (
-    <ChartCard title="Run Distances">
+    <ChartCard
+      title="Run Distances"
+      description="Popular run distance buckets"
+    >
       <ChartContainer config={config} className="h-60">
         <BarChart layout="vertical" data={runDistanceData}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/SessionSimilarityMap.tsx
+++ b/src/components/statistics/SessionSimilarityMap.tsx
@@ -34,7 +34,10 @@ export default function SessionSimilarityMap() {
   const clusters = Array.from(new Set(data.map((d) => d.cluster)))
 
   return (
-    <ChartCard title="Session Similarity">
+    <ChartCard
+      title="Session Similarity"
+      description="Similarity of recent runs"
+    >
       <ChartContainer config={config} className="h-64">
         <ScatterChart>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/TrainingLoadRatio.tsx
+++ b/src/components/statistics/TrainingLoadRatio.tsx
@@ -29,7 +29,10 @@ const config = {
 
 export default function TrainingLoadRatio() {
   return (
-    <ChartCard title="Acute vs Chronic Load Ratio">
+    <ChartCard
+      title="Acute vs Chronic Load Ratio"
+      description="Acute vs chronic training load"
+    >
       <ChartContainer config={config} className="h-64">
         <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/statistics/TreadmillVsOutdoor.tsx
+++ b/src/components/statistics/TreadmillVsOutdoor.tsx
@@ -23,7 +23,10 @@ const config = {
 
 export default function TreadmillVsOutdoor() {
   return (
-    <ChartCard title="Treadmill vs Outdoor">
+    <ChartCard
+      title="Treadmill vs Outdoor"
+      description="Indoor vs outdoor mileage split"
+    >
       <ChartContainer config={config} className="h-60">
         <PieChart width={200} height={160}>
           <ChartTooltip />

--- a/src/components/statistics/WeeklyComparisonChart.tsx
+++ b/src/components/statistics/WeeklyComparisonChart.tsx
@@ -35,7 +35,10 @@ export default function WeeklyComparisonChart({
   } as const
 
   return (
-    <ChartCard title="Weekly Comparison">
+    <ChartCard
+      title="Weekly Comparison"
+      description="Compare this week to last week"
+    >
       <ChartContainer config={config} className="h-64">
         <LineChart data={merged} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />


### PR DESCRIPTION
## Summary
- add description prop to ChartCard usages
- update map and statistics cards with helpful explanatory text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0d5f74ec832491c2201e9d348492