### PR TITLE
Remove tabs and show examples on dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,11 @@
-import React, { useState } from "react";
+import React from "react";
 import Layout from "@/components/layout/Layout";
 import Dashboard from "@/pages/Dashboard";
-import Examples from "@/pages/Examples";
-import Statistics from "@/pages/Statistics";
-import GeoActivityExplorer from "@/components/map/GeoActivityExplorer";
 
 function App() {
-  const [tab, setTab] = useState("dashboard");
   return (
-    <Layout activeTab={tab} setActiveTab={setTab}>
-      {tab === "dashboard" && <Dashboard />}
-      {tab === "trends" && <p>Trends coming soon...</p>}
-      {tab === "map" && <GeoActivityExplorer />}
-      {tab === "examples" && <Examples />}
-      {tab === "statistics" && <Statistics />}
+    <Layout>
+      <Dashboard />
     </Layout>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,43 +1,17 @@
 import React from "react";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ThemeToggle from "@/components/ui/theme-toggle";
 
 interface LayoutProps {
   children: React.ReactNode;
-  activeTab: string;
-  setActiveTab: (tab: string) => void;
 }
 
-export default function Layout({
-  children,
-  activeTab,
-  setActiveTab
-}: LayoutProps) {
+export default function Layout({ children }: LayoutProps) {
   return (
     <div className="min-h-screen p-4">
       <header className="flex justify-between items-center mb-4">
         <h1 className="text-xl font-bold">Dashboard</h1>
         <ThemeToggle />
       </header>
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList>
-          <TabsTrigger value="dashboard" onClick={() => setActiveTab("dashboard")}>
-            Dashboard
-          </TabsTrigger>
-          <TabsTrigger value="trends" onClick={() => setActiveTab("trends")}>
-            Trends
-          </TabsTrigger>
-          <TabsTrigger value="map" onClick={() => setActiveTab("map")}>
-            Map
-          </TabsTrigger>
-          <TabsTrigger value="examples" onClick={() => setActiveTab("examples")}>
-            Examples
-          </TabsTrigger>
-          <TabsTrigger value="statistics" onClick={() => setActiveTab("statistics")}>
-            Statistics
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
       <div className="mt-2">{children}</div>
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
 import useInsights from "@/hooks/useInsights";
 import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
 import { minutesSince } from "@/lib/utils";
+import Examples from "@/pages/Examples";
 
 
 export default function Dashboard() {
@@ -223,6 +224,7 @@ export default function Dashboard() {
       </div>
 
       <RingDetailDialog metric={expanded} onClose={() => setExpanded(null)} />
+      <Examples />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- simplify `Layout` component and remove tab UI
- clean up `App` to show the Dashboard only
- append example charts after ring metrics on the Dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0ed8a7688324a6038de1a30b571c