### PR TITLE
Add range slider for Weekly Volume history chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-tooltip": "^1.2.7",
         "events": "^3.3.0",
         "lucide-react": "^0.534.0",
@@ -1388,6 +1389,39 @@
         "@radix-ui/react-visually-hidden": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.5.tgz",
+      "integrity": "sha512-rkfe2pU2NBAYfGaxa3Mqosi7VZEWX5CxKaanRv0vZd4Zhl9fvQrg0VM93dv3xGLGfrHuoTRF3JXH8nb9g+B3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-tooltip": "^1.2.7",
     "events": "^3.3.0",
     "lucide-react": "^0.534.0",

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -6,9 +6,10 @@ import {
   Bar,
   XAxis,
   CartesianGrid,
-  Brush,
   Tooltip as ChartTooltip,
 } from '@/components/ui/chart'
+import Slider from '@/components/ui/slider'
+import { useState, useEffect } from 'react'
 import ChartCard from '@/components/dashboard/ChartCard'
 import type { ChartConfig } from '@/components/ui/chart'
 import useWeeklyVolumeHistory from '@/hooks/useWeeklyVolumeHistory'
@@ -16,8 +17,17 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export default function WeeklyVolumeHistoryChart() {
   const data = useWeeklyVolumeHistory()
+  const [range, setRange] = useState<[number, number]>([0, 0])
+
+  useEffect(() => {
+    if (data) {
+      setRange([Math.max(0, data.length - 52), data.length - 1])
+    }
+  }, [data])
 
   if (!data) return <Skeleton className="h-64" />
+
+  const filtered = data.slice(range[0], range[1] + 1)
 
   const config = {
     miles: { label: 'Miles', color: 'hsl(var(--chart-1))' },
@@ -29,14 +39,23 @@ export default function WeeklyVolumeHistoryChart() {
       description="Historical weekly mileage totals"
     >
       <ChartContainer config={config} className="h-64">
-        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <BarChart data={filtered} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
           <ChartTooltip />
           <Bar dataKey="miles" fill="var(--color-miles)" radius={2} animationDuration={300} />
-          <Brush dataKey="week" height={20} travellerWidth={10} />
         </BarChart>
       </ChartContainer>
+      <div className="mt-4">
+        <Slider
+          numberOfThumbs={2}
+          min={0}
+          max={data.length - 1}
+          step={1}
+          value={range}
+          onValueChange={(val) => setRange(val as [number, number])}
+        />
+      </div>
     </ChartCard>
   )
 }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+export interface SliderProps
+  extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+  numberOfThumbs?: number
+}
+
+export const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  SliderProps
+>(({ className, numberOfThumbs = 1, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className,
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    {Array.from({ length: numberOfThumbs }).map((_, i) => (
+      <SliderPrimitive.Thumb
+        key={i}
+        className="block h-4 w-4 rounded-full border border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+      />
+    ))}
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export default Slider


### PR DESCRIPTION
## Summary
- add new Slider primitive using Radix
- filter WeeklyVolumeHistoryChart data using Slider instead of Brush
- install `@radix-ui/react-slider` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c0eba9afc8324a578f5b7a3dc11c0