### PR TITLE
Add geo activity map to dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import useInsights from "@/hooks/useInsights";
 import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
+import { GeoActivityExplorer } from "@/components/map";
 
 
 export default function Dashboard() {
@@ -225,6 +226,7 @@ export default function Dashboard() {
 
       <RingDetailDialog metric={expanded} onClose={() => setExpanded(null)} />
       <Examples />
+      <GeoActivityExplorer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show `GeoActivityExplorer` after existing example charts on the dashboard

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688c11fdb5048324adb24460c3d512ec