### PR TITLE
Improve delta accessibility

### DIFF
--- a/src/components/dashboard/ProgressRingWithDelta.tsx
+++ b/src/components/dashboard/ProgressRingWithDelta.tsx
@@ -16,13 +16,20 @@ export function ProgressRingWithDelta({
   decimalPlaces = 1,
   ...ringProps
 }: ProgressRingWithDeltaProps) {
-  const delta = previous === 0 ? 0 : (current - previous) / previous;
-  const formatted = `${delta > 0 ? "+" : ""}${(delta * 100).toFixed(decimalPlaces)}%`;
+  const formatted = React.useMemo(() => {
+    const delta = previous === 0 ? 0 : (current - previous) / previous;
+    return `${delta > 0 ? "+" : ""}${(delta * 100).toFixed(decimalPlaces)}%`;
+  }, [current, previous, decimalPlaces]);
 
   return (
     <div className="flex flex-col items-center">
       <ProgressRing {...ringProps} />
-      <span className="text-xs mt-1" aria-label="Change from previous">
+      <span
+        className="text-xs mt-1"
+        aria-label="Change from previous"
+        aria-live="polite"
+        key={formatted}
+      >
         {formatted}
       </span>
     </div>

--- a/src/components/dashboard/__tests__/ProgressRingWithDelta.test.tsx
+++ b/src/components/dashboard/__tests__/ProgressRingWithDelta.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import ProgressRingWithDelta from "../ProgressRingWithDelta";
+import "@testing-library/jest-dom";
+
+describe("ProgressRingWithDelta", () => {
+  it("adds aria-live attribute", () => {
+    render(
+      <ProgressRingWithDelta value={50} label="Progress" current={100} previous={80} />
+    );
+    const delta = screen.getByLabelText("Change from previous");
+    expect(delta).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("updates delta text when current changes", () => {
+    const { rerender } = render(
+      <ProgressRingWithDelta value={50} label="Progress" current={100} previous={80} />
+    );
+    expect(screen.getByText("+25.0%")).toBeInTheDocument();
+    rerender(
+      <ProgressRingWithDelta value={50} label="Progress" current={80} previous={80} />
+    );
+    expect(screen.getByText("0.0%")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add React `useMemo` and an `aria-live` attribute so screen readers announce delta changes
- add unit tests for `ProgressRingWithDelta`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c13f188bc83249e838db1433811da