### PR TITLE
Allow custom daily step goal

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import { cn } from '@/lib/utils'
+
+const Popover = PopoverPrimitive.Root
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 rounded border bg-background p-4 shadow-md outline-none',
+      className,
+    )}
+    {...props}
+  />
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/src/hooks/useInsights.ts
+++ b/src/hooks/useInsights.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useGarminDays, useGarminData } from './useGarminData'
+import useUserGoals from './useUserGoals'
 import { getRunningSessions, type RunningSession } from '@/lib/api'
 
 export interface Insights {
@@ -20,6 +21,7 @@ export interface Insights {
 export function useInsights(): Insights | null {
   const days = useGarminDays()
   const data = useGarminData()
+  const { dailyStepGoal } = useUserGoals()
   const [sessions, setSessions] = useState<RunningSession[] | null>(null)
 
   useEffect(() => {
@@ -28,7 +30,7 @@ export function useInsights(): Insights | null {
 
   return useMemo(() => {
     if (!days || !data || !sessions) return null
-    const STEP_GOAL = 8000
+    const STEP_GOAL = dailyStepGoal
     let streak = 0
     for (let i = days.length - 1; i >= 0; i--) {
       if (days[i].steps >= STEP_GOAL) streak++
@@ -70,7 +72,7 @@ export function useInsights(): Insights | null {
       bestPaceThisMonth: bestPace,
       mostConsistentDay: consistentDay,
     }
-  }, [days, data, sessions])
+  }, [days, data, sessions, dailyStepGoal])
 }
 
 export default useInsights

--- a/src/hooks/useUserGoals.ts
+++ b/src/hooks/useUserGoals.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+export interface UserGoals {
+  dailyStepGoal: number
+  setDailyStepGoal: (goal: number) => void
+}
+
+export const DEFAULT_DAILY_STEP_GOAL = 10000
+
+export function useUserGoals(): UserGoals {
+  const [dailyStepGoal, setGoal] = useState(DEFAULT_DAILY_STEP_GOAL)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('dailyStepGoal')
+    if (stored) {
+      const parsed = parseInt(stored, 10)
+      if (!Number.isNaN(parsed)) setGoal(parsed)
+    }
+  }, [])
+
+  const setDailyStepGoal = (goal: number) => {
+    setGoal(goal)
+    localStorage.setItem('dailyStepGoal', String(goal))
+  }
+
+  return { dailyStepGoal, setDailyStepGoal }
+}
+
+export default useUserGoals

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -17,12 +17,15 @@ import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
 import { GeoActivityExplorer } from "@/components/map";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import useUserGoals from "@/hooks/useUserGoals";
 
 
 export default function Dashboard() {
   type Metric = "steps" | "sleep" | "heartRate" | "calories";
   const data = useGarminData();
-  const monthly = useMonthlyStepsProjection();
+  const { dailyStepGoal, setDailyStepGoal } = useUserGoals();
+  const monthly = useMonthlyStepsProjection(dailyStepGoal);
   const recentActivity = useMostRecentActivity();
   const insights = useInsights();
   const [expanded, setExpanded] = useState<Metric | null>(null);
@@ -75,11 +78,41 @@ export default function Dashboard() {
                 {recentActivity.type}
               </span>
             )}
+            <Popover>
+              <PopoverTrigger asChild>
+                <button className="text-xs underline text-muted-foreground" aria-label="Edit goal">
+                  Edit
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-40">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    const fd = new FormData(e.currentTarget)
+                    const val = parseInt(fd.get('goal') as string, 10)
+                    if (!Number.isNaN(val)) setDailyStepGoal(val)
+                  }}
+                  className="grid gap-2"
+                >
+                  <label className="text-xs" htmlFor="goal">Daily goal</label>
+                  <input
+                    id="goal"
+                    name="goal"
+                    type="number"
+                    defaultValue={dailyStepGoal}
+                    className="border rounded px-2 py-1 text-sm"
+                  />
+                  <button type="submit" className="px-2 py-1 rounded bg-primary text-primary-foreground text-xs">
+                    Save
+                  </button>
+                </form>
+              </PopoverContent>
+            </Popover>
           </h2>
             <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Steps progress"
-            value={(data.steps / 10000) * 100}
+            value={(data.steps / dailyStepGoal) * 100}
             current={data.steps}
             previous={previousSteps}
           />


### PR DESCRIPTION
## Summary
- add `useUserGoals` hook for storing step targets in `localStorage`
- add popover form in `Dashboard` to edit the daily step goal
- use the stored goal in insights and monthly projection calculations
- expose a reusable `Popover` UI component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c13f09d0083248d1ce75d30a88ab7