### PR TITLE
Add TopInsights dashboard card

### DIFF
--- a/src/components/dashboard/TopInsights.tsx
+++ b/src/components/dashboard/TopInsights.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
+import useInsights from "@/hooks/useInsights";
+
+export default function TopInsights() {
+  const insights = useInsights();
+
+  if (!insights) return <Skeleton className="h-8" />;
+
+  const items: React.ReactNode[] = [];
+
+  if (insights.activeStreak > 0) {
+    items.push(
+      <Badge key="streak" className="flex items-center gap-1">
+        <Flame className="w-3 h-3" />
+        {insights.activeStreak}-day streak
+      </Badge>
+    );
+  }
+  if (insights.highHeartRate) {
+    items.push(
+      <Badge key="heart" className="flex items-center gap-1">
+        <HeartPulse className="w-3 h-3 text-red-600" />
+        High heart rate
+      </Badge>
+    );
+  }
+  if (insights.lowSleep) {
+    items.push(
+      <Badge key="sleep" className="flex items-center gap-1">
+        <Moon className="w-3 h-3 text-yellow-500" />
+        Low sleep
+      </Badge>
+    );
+  }
+  if (insights.calorieSurplus) {
+    items.push(
+      <Badge key="calories" className="flex items-center gap-1">
+        <Pizza className="w-3 h-3 text-amber-600" />
+        Calorie surplus
+      </Badge>
+    );
+  }
+
+  if (items.length === 0) return null;
+
+  return <Card className="p-2 flex gap-2 flex-wrap text-xs">{items}</Card>;
+}

--- a/src/components/dashboard/__tests__/TopInsights.test.tsx
+++ b/src/components/dashboard/__tests__/TopInsights.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import "@testing-library/jest-dom";
+import TopInsights from "../TopInsights";
+
+vi.mock("@/hooks/useInsights", () => ({
+  __esModule: true,
+  default: () => ({
+    activeStreak: 3,
+    highHeartRate: true,
+    lowSleep: true,
+    calorieSurplus: true,
+    bestPaceThisMonth: null,
+    mostConsistentDay: null,
+  }),
+}));
+
+describe("TopInsights", () => {
+  it("shows insight badges", () => {
+    render(<TopInsights />);
+    expect(screen.getByText("3-day streak")).toBeInTheDocument();
+    expect(screen.getByText(/High heart rate/)).toBeInTheDocument();
+    expect(screen.getByText(/Low sleep/)).toBeInTheDocument();
+    expect(screen.getByText(/Calorie surplus/)).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -11,3 +11,4 @@ export * from "./RingDetailDialog";
 export * from "./AcwrGauge";
 export * from "./ChartSelectionContext";
 export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
+export { default as TopInsights } from "./TopInsights";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import {
   MiniSparkline,
   RingDetailDialog,
 } from "@/components/dashboard";
+import { TopInsights } from "@/components/dashboard";
 import { Badge } from "@/components/ui/badge";
 import {
   useGarminData,
@@ -80,6 +81,7 @@ export default function Dashboard() {
 
   return (
     <div className="grid gap-4">
+      <TopInsights />
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card
           role="button"


### PR DESCRIPTION
## Summary
- create `TopInsights` component for displaying quick insight badges
- export it via dashboard index
- render `TopInsights` at the top of the dashboard
- add tests for the new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c18d7f32883248144c9552db049c1