### PR TITLE
Fix duplicate variable declarations in Dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,9 +10,6 @@ import { Badge } from "@/components/ui/badge";
 import {
   useGarminData,
   useMostRecentActivity,
-
-  useMonthlyStepsProjection,
-
   useGarminDays,
 } from "@/hooks/useGarminData";
 import useStepInsights from "@/hooks/useStepInsights";
@@ -30,13 +27,10 @@ export default function Dashboard() {
   const data = useGarminData();
 
   const { dailyStepGoal, setDailyStepGoal } = useUserGoals();
-  const monthly = useMonthlyStepsProjection(dailyStepGoal);
-
   const days = useGarminDays();
-  const stepInsights = useStepInsights(days);
+  const stepInsights = useStepInsights(days, dailyStepGoal);
 
   const recentActivity = useMostRecentActivity();
-  const days = useGarminDays();
   const insights = useInsights();
   const [expanded, setExpanded] = useState<Metric | null>(null);
   const [dismissed, setDismissed] = useState<{ pace: boolean; day: boolean }>({


### PR DESCRIPTION
## Summary
- remove duplicated hooks in Dashboard page
- adjust step insights to use daily goal

## Testing
- `npx vitest run`
- `npm run build` *(fails: Rollup failed to resolve import "@radix-ui/react-popover")*

------
https://chatgpt.com/codex/tasks/task_e_688c18c3bc7883249a71c059408c112d