### PR TITLE
Add editable goal popovers for dashboard metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -1255,6 +1256,43 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.14.tgz",
+      "integrity": "sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -10,33 +10,71 @@ import { Badge } from "@/components/ui/badge";
 import {
   useGarminData,
   useMostRecentActivity,
-
-  useMonthlyStepsProjection,
-
   useGarminDays,
 } from "@/hooks/useGarminData";
 import useStepInsights from "@/hooks/useStepInsights";
 import useInsights from "@/hooks/useInsights";
-import { Flame, HeartPulse, Moon, Pizza } from "lucide-react";
+import { Flame, HeartPulse, Moon, Pizza, Pencil } from "lucide-react";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
 import { GeoActivityExplorer } from "@/components/map";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
-import useUserGoals from "@/hooks/useUserGoals";
 
 
 export default function Dashboard() {
   type Metric = "steps" | "sleep" | "heartRate" | "calories";
   const data = useGarminData();
 
-  const { dailyStepGoal, setDailyStepGoal } = useUserGoals();
-  const monthly = useMonthlyStepsProjection(dailyStepGoal);
+  const [stepGoal, setStepGoalState] = useState(10000)
+  const [sleepGoal, setSleepGoalState] = useState(8)
+  const [heartGoal, setHeartGoalState] = useState(200)
+  const [calorieGoal, setCalorieGoalState] = useState(3000)
+
+  useEffect(() => {
+    const sg = localStorage.getItem('stepGoal')
+    if (sg) {
+      const n = parseInt(sg, 10)
+      if (!Number.isNaN(n)) setStepGoalState(n)
+    }
+    const sl = localStorage.getItem('sleepGoal')
+    if (sl) {
+      const n = parseInt(sl, 10)
+      if (!Number.isNaN(n)) setSleepGoalState(n)
+    }
+    const hg = localStorage.getItem('heartGoal')
+    if (hg) {
+      const n = parseInt(hg, 10)
+      if (!Number.isNaN(n)) setHeartGoalState(n)
+    }
+    const cg = localStorage.getItem('calorieGoal')
+    if (cg) {
+      const n = parseInt(cg, 10)
+      if (!Number.isNaN(n)) setCalorieGoalState(n)
+    }
+  }, [])
+
+  const setStepGoal = (n: number) => {
+    setStepGoalState(n)
+    localStorage.setItem('stepGoal', String(n))
+  }
+  const setSleepGoal = (n: number) => {
+    setSleepGoalState(n)
+    localStorage.setItem('sleepGoal', String(n))
+  }
+  const setHeartGoal = (n: number) => {
+    setHeartGoalState(n)
+    localStorage.setItem('heartGoal', String(n))
+  }
+  const setCalorieGoal = (n: number) => {
+    setCalorieGoalState(n)
+    localStorage.setItem('calorieGoal', String(n))
+  }
+
 
   const days = useGarminDays();
-  const stepInsights = useStepInsights(days);
+  const stepInsights = useStepInsights(days, stepGoal);
 
   const recentActivity = useMostRecentActivity();
-  const days = useGarminDays();
   const insights = useInsights();
   const [expanded, setExpanded] = useState<Metric | null>(null);
   const [dismissed, setDismissed] = useState<{ pace: boolean; day: boolean }>({
@@ -97,8 +135,8 @@ export default function Dashboard() {
             )}
             <Popover>
               <PopoverTrigger asChild>
-                <button className="text-xs underline text-muted-foreground" aria-label="Edit goal">
-                  Edit
+                <button aria-label="Edit steps goal" className="ml-1">
+                  <Pencil className="h-3 w-3 text-muted-foreground" />
                 </button>
               </PopoverTrigger>
               <PopoverContent className="w-40">
@@ -107,7 +145,7 @@ export default function Dashboard() {
                     e.preventDefault()
                     const fd = new FormData(e.currentTarget)
                     const val = parseInt(fd.get('goal') as string, 10)
-                    if (!Number.isNaN(val)) setDailyStepGoal(val)
+                    if (!Number.isNaN(val)) setStepGoal(val)
                   }}
                   className="grid gap-2"
                 >
@@ -116,7 +154,7 @@ export default function Dashboard() {
                     id="goal"
                     name="goal"
                     type="number"
-                    defaultValue={dailyStepGoal}
+                    defaultValue={stepGoal}
                     className="border rounded px-2 py-1 text-sm"
                   />
                   <button type="submit" className="px-2 py-1 rounded bg-primary text-primary-foreground text-xs">
@@ -129,7 +167,7 @@ export default function Dashboard() {
             <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Steps progress"
-            value={(data.steps / dailyStepGoal) * 100}
+            value={(data.steps / stepGoal) * 100}
             current={data.steps}
             previous={previousSteps}
             tertiary={stepContext}
@@ -206,11 +244,43 @@ export default function Dashboard() {
           onKeyDown={(e) => handleKey(e, "sleep")}
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
-          <h2 className="text-sm mb-2">Sleep (hrs)</h2>
-            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
+          <h2 className="text-sm mb-2 flex items-center gap-2">
+            Sleep (hrs)
+            <Popover>
+              <PopoverTrigger asChild>
+                <button aria-label="Edit sleep goal" className="ml-1">
+                  <Pencil className="h-3 w-3 text-muted-foreground" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-40">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    const fd = new FormData(e.currentTarget)
+                    const val = parseInt(fd.get('goal') as string, 10)
+                    if (!Number.isNaN(val)) setSleepGoal(val)
+                  }}
+                  className="grid gap-2"
+                >
+                  <label className="text-xs" htmlFor="sleepGoal">Daily goal</label>
+                  <input
+                    id="sleepGoal"
+                    name="goal"
+                    type="number"
+                    defaultValue={sleepGoal}
+                    className="border rounded px-2 py-1 text-sm"
+                  />
+                  <button type="submit" className="px-2 py-1 rounded bg-primary text-primary-foreground text-xs">
+                    Save
+                  </button>
+                </form>
+              </PopoverContent>
+            </Popover>
+          </h2>
+          <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Sleep progress"
-            value={(data.sleep / 8) * 100}
+            value={(data.sleep / sleepGoal) * 100}
             current={data.sleep}
             previous={previousSleep}
           />
@@ -231,11 +301,43 @@ export default function Dashboard() {
           onKeyDown={(e) => handleKey(e, "heartRate")}
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
-          <h2 className="text-sm mb-2">Heart Rate</h2>
-            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
+          <h2 className="text-sm mb-2 flex items-center gap-2">
+            Heart Rate
+            <Popover>
+              <PopoverTrigger asChild>
+                <button aria-label="Edit heart rate goal" className="ml-1">
+                  <Pencil className="h-3 w-3 text-muted-foreground" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-40">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    const fd = new FormData(e.currentTarget)
+                    const val = parseInt(fd.get('goal') as string, 10)
+                    if (!Number.isNaN(val)) setHeartGoal(val)
+                  }}
+                  className="grid gap-2"
+                >
+                  <label className="text-xs" htmlFor="hrGoal">Max HR</label>
+                  <input
+                    id="hrGoal"
+                    name="goal"
+                    type="number"
+                    defaultValue={heartGoal}
+                    className="border rounded px-2 py-1 text-sm"
+                  />
+                  <button type="submit" className="px-2 py-1 rounded bg-primary text-primary-foreground text-xs">
+                    Save
+                  </button>
+                </form>
+              </PopoverContent>
+            </Popover>
+          </h2>
+          <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Heart rate progress"
-            value={(data.heartRate / 200) * 100}
+            value={(data.heartRate / heartGoal) * 100}
             current={data.heartRate}
             previous={previousHeartRate}
           />
@@ -256,11 +358,43 @@ export default function Dashboard() {
           onKeyDown={(e) => handleKey(e, "calories")}
           className="flex flex-col items-center cursor-pointer focus:outline-none focus:ring"
         >
-          <h2 className="text-sm mb-2">Calories</h2>
-            <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
+          <h2 className="text-sm mb-2 flex items-center gap-2">
+            Calories
+            <Popover>
+              <PopoverTrigger asChild>
+                <button aria-label="Edit calories goal" className="ml-1">
+                  <Pencil className="h-3 w-3 text-muted-foreground" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-40">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    const fd = new FormData(e.currentTarget)
+                    const val = parseInt(fd.get('goal') as string, 10)
+                    if (!Number.isNaN(val)) setCalorieGoal(val)
+                  }}
+                  className="grid gap-2"
+                >
+                  <label className="text-xs" htmlFor="calGoal">Daily goal</label>
+                  <input
+                    id="calGoal"
+                    name="goal"
+                    type="number"
+                    defaultValue={calorieGoal}
+                    className="border rounded px-2 py-1 text-sm"
+                  />
+                  <button type="submit" className="px-2 py-1 rounded bg-primary text-primary-foreground text-xs">
+                    Save
+                  </button>
+                </form>
+              </PopoverContent>
+            </Popover>
+          </h2>
+          <p className="text-[10px] text-muted-foreground">Last synced {lastSyncedMinutes} min ago</p>
           <ProgressRingWithDelta
             label="Calories progress"
-            value={(data.calories / 3000) * 100}
+            value={(data.calories / calorieGoal) * 100}
             current={data.calories}
             previous={previousCalories}
           />

--- a/src/pages/__tests__/DashboardGoals.test.tsx
+++ b/src/pages/__tests__/DashboardGoals.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Dashboard from "../Dashboard";
+import { vi } from "vitest";
+import "@testing-library/jest-dom";
+import { mockGarminData, mockDailySteps } from "@/lib/api";
+
+vi.mock("@/hooks/useGarminData", () => ({
+  useGarminData: () => mockGarminData,
+  useMostRecentActivity: () => null,
+  useGarminDays: () => mockDailySteps,
+}));
+
+vi.mock("@/pages/Examples", () => ({
+  __esModule: true,
+  default: () => React.createElement("div"),
+}));
+
+vi.mock("@/components/map", () => ({
+  __esModule: true,
+  GeoActivityExplorer: () => React.createElement("div"),
+}));
+
+vi.mock("@/components/dashboard", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    __esModule: true,
+    ...actual,
+    MiniSparkline: () => React.createElement("div"),
+    RingDetailDialog: () => React.createElement("div"),
+  };
+});
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+});
+
+vi.mock("@/hooks/useStepInsights", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/hooks/useInsights", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+
+describe("Dashboard goals", () => {
+  it("updates step ring when goal changes", async () => {
+    render(<Dashboard />);
+    const ring = screen.getByLabelText("Steps progress");
+    const circle = ring.querySelectorAll("circle")[1];
+    const initial = circle.getAttribute("stroke-dashoffset");
+
+    fireEvent.click(screen.getByLabelText("Edit steps goal"));
+    const input = await screen.findByLabelText("Daily goal") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5000" } });
+    fireEvent.submit(input.form!);
+
+    const updated = circle.getAttribute("stroke-dashoffset");
+    expect(updated).not.toBe(initial);
+  });
+});


### PR DESCRIPTION
## Summary
- add per-metric goal state to Dashboard and persist via localStorage
- show edit icon on each ring to update goal via Popover
- adjust progress calculations to use editable goals
- test editing the step goal on the dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c18e0b0648324ac64813482949f3f