### PR TITLE
Add DashboardCharts component

### DIFF
--- a/src/components/dashboard/DashboardCharts.tsx
+++ b/src/components/dashboard/DashboardCharts.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import StepsTrendWithGoal from "./StepsTrendWithGoal";
+import { DailyStepsChart } from "./DailyStepsChart";
+import { ActivitiesChart } from "./ActivitiesChart";
+import WeeklyVolumeChart from "./WeeklyVolumeChart";
+import { useGarminDays } from "@/hooks/useGarminData";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardCharts() {
+  const days = useGarminDays();
+
+  if (!days) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2">
+        <Skeleton className="h-60 md:col-span-2" />
+        <Skeleton className="h-60" />
+        <Skeleton className="h-60" />
+        <Skeleton className="h-60" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <StepsTrendWithGoal data={days} />
+      <DailyStepsChart data={days} />
+      <ActivitiesChart />
+      <WeeklyVolumeChart />
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -6,6 +6,7 @@ export * from "./ActivitiesChart";
 export * from "./StepsChart";
 export * from "./DailyStepsChart";
 export * from "./StepsTrendWithGoal";
+export { default as DashboardCharts } from "./DashboardCharts";
 export * from "./MiniSparkline";
 export * from "./RingDetailDialog";
 export * from "./AcwrGauge";


### PR DESCRIPTION
## Summary
- add new DashboardCharts layout component
- re-export DashboardCharts from dashboard index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c26f4d030832483328efc48b8eb6a