### PR TITLE
Centralize city coordinates for map components

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import statesTopo from "../../../public/us-states.json";
+import CITY_COORDS from "@/lib/cityCoords";
 
 const FIPS_TO_ABBR: Record<string, string> = {
   "01": "AL",
@@ -84,13 +85,6 @@ const FIPS_TO_ABBR: Record<string, string> = {
   "56": "WY",
 };
 
-const CITY_COORDS: Record<string, [number, number]> = {
-  "Los Angeles": [-118.2437, 34.0522],
-  "San Francisco": [-122.4194, 37.7749],
-  "San Diego": [-117.1611, 32.7157],
-  Austin: [-97.7431, 30.2672],
-  Houston: [-95.3698, 29.7604],
-};
 
 export default function GeoActivityExplorer() {
   const data = useStateVisits();

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -18,13 +18,8 @@ import { Cell } from 'recharts'
 import { Skeleton } from '@/components/ui/skeleton'
 import useLocationEfficiency from '@/hooks/useLocationEfficiency'
 import statesTopo from '../../../public/us-states.json'
+import CITY_COORDS from '@/lib/cityCoords'
 
-const CITY_COORDS: Record<string, [number, number]> = {
-  'Los Angeles': [-118.2437, 34.0522],
-  'San Francisco': [-122.4194, 37.7749],
-  Austin: [-97.7431, 30.2672],
-  Houston: [-95.3698, 29.7604],
-}
 
 const config = {
   effort: { label: 'Effort', color: 'var(--chart-1)' },

--- a/src/lib/cityCoords.ts
+++ b/src/lib/cityCoords.ts
@@ -1,0 +1,8 @@
+export const CITY_COORDS: Record<string, [number, number]> = {
+  "Los Angeles": [-118.2437, 34.0522],
+  "San Francisco": [-122.4194, 37.7749],
+  "San Diego": [-117.1611, 32.7157],
+  Austin: [-97.7431, 30.2672],
+  Houston: [-95.3698, 29.7604],
+}
+export default CITY_COORDS


### PR DESCRIPTION
## Summary
- add `CITY_COORDS` map in `src/lib/cityCoords.ts`
- refactor `GeoActivityExplorer` and `LocationEfficiencyComparison` to import the shared map

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c2ad374e48324a5c1714c145327f3