### PR TITLE
Add homepage dashboard with sample charts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import Layout from "@/components/layout/Layout";
-import Dashboard from "@/pages/Dashboard";
+import Home from "@/pages/Home";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 
 function App() {
   return (
     <DashboardFiltersProvider>
       <Layout>
-        <Dashboard />
+        <Home />
       </Layout>
     </DashboardFiltersProvider>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import ChartRadialLabel from '@/components/examples/RadialChartLabel'
+import ChartRadialText from '@/components/examples/RadialChartText'
+import ChartBarDefault from '@/components/examples/BarChartDefault'
+import ChartRadialGrid from '@/components/examples/RadialChartGrid'
+
+export default function Home() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+      <div className="grid gap-6 md:grid-cols-2">
+        <ChartRadialLabel />
+        <ChartRadialText />
+        <ChartBarDefault />
+        <ChartRadialGrid />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `Home` page showing a grid of example charts
- render the new page from `App`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c2b4284908324bddc0c06ac26899d