### PR TITLE
Add extra state visit data and map coordinates

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -90,6 +90,16 @@ const CITY_COORDS: Record<string, [number, number]> = {
   "San Diego": [-117.1611, 32.7157],
   Austin: [-97.7431, 30.2672],
   Houston: [-95.3698, 29.7604],
+  Miami: [-80.1918, 25.7617],
+  Orlando: [-81.3792, 28.5383],
+  Tampa: [-82.4572, 27.9506],
+  Denver: [-104.9903, 39.7392],
+  Boulder: [-105.2705, 40.015],
+  "Colorado Springs": [-104.8214, 38.8339],
+  Seattle: [-122.3321, 47.6062],
+  Spokane: [-117.426, 47.6588],
+  Tacoma: [-122.4443, 47.2529],
+  Chicago: [-87.6298, 41.8781],
 };
 
 export default function GeoActivityExplorer() {

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -24,6 +24,16 @@ const CITY_COORDS: Record<string, [number, number]> = {
   'San Francisco': [-122.4194, 37.7749],
   Austin: [-97.7431, 30.2672],
   Houston: [-95.3698, 29.7604],
+  Miami: [-80.1918, 25.7617],
+  Orlando: [-81.3792, 28.5383],
+  Tampa: [-82.4572, 27.9506],
+  Denver: [-104.9903, 39.7392],
+  Boulder: [-105.2705, 40.015],
+  'Colorado Springs': [-104.8214, 38.8339],
+  Seattle: [-122.3321, 47.6062],
+  Spokane: [-117.426, 47.6588],
+  Tacoma: [-122.4443, 47.2529],
+  Chicago: [-87.6298, 41.8781],
 }
 
 const config = {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -161,6 +161,85 @@ export const mockStateVisits: StateVisit[] = [
     ],
   },
   {
+    stateCode: "FL",
+    visited: true,
+    totalDays: 7,
+    totalMiles: 900,
+    cities: [
+      { name: "Miami", days: 3, miles: 300 },
+      { name: "Orlando", days: 2, miles: 200 },
+      { name: "Tampa", days: 2, miles: 400 },
+    ],
+    log: [
+      { date: new Date().toISOString().slice(0, 10), type: "run", miles: 7 },
+      {
+        date: new Date(Date.now() - 14 * 86400000).toISOString().slice(0, 10),
+        type: "bike",
+        miles: 20,
+      },
+    ],
+  },
+  {
+    stateCode: "CO",
+    visited: true,
+    totalDays: 8,
+    totalMiles: 1100,
+    cities: [
+      { name: "Denver", days: 4, miles: 500 },
+      { name: "Boulder", days: 2, miles: 300 },
+      { name: "Colorado Springs", days: 2, miles: 300 },
+    ],
+    log: [
+      { date: new Date().toISOString().slice(0, 10), type: "bike", miles: 10 },
+      {
+        date: new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10),
+        type: "run",
+        miles: 6,
+      },
+      {
+        date: new Date(Date.now() - 35 * 86400000).toISOString().slice(0, 10),
+        type: "run",
+        miles: 9,
+      },
+    ],
+  },
+  {
+    stateCode: "WA",
+    visited: true,
+    totalDays: 6,
+    totalMiles: 800,
+    cities: [
+      { name: "Seattle", days: 3, miles: 400 },
+      { name: "Spokane", days: 2, miles: 250 },
+      { name: "Tacoma", days: 1, miles: 150 },
+    ],
+    log: [
+      { date: new Date().toISOString().slice(0, 10), type: "run", miles: 5 },
+      {
+        date: new Date(Date.now() - 21 * 86400000).toISOString().slice(0, 10),
+        type: "bike",
+        miles: 15,
+      },
+    ],
+  },
+  {
+    stateCode: "IL",
+    visited: true,
+    totalDays: 4,
+    totalMiles: 500,
+    cities: [
+      { name: "Chicago", days: 4, miles: 500 },
+    ],
+    log: [
+      { date: new Date().toISOString().slice(0, 10), type: "run", miles: 4 },
+      {
+        date: new Date(Date.now() - 20 * 86400000).toISOString().slice(0, 10),
+        type: "bike",
+        miles: 12,
+      },
+    ],
+  },
+  {
     stateCode: "NY",
     visited: false,
     totalDays: 0,


### PR DESCRIPTION
## Summary
- extend `mockStateVisits` with several additional states
- include coordinates for new cities so map markers display correctly

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c2acbac2c83249c30eea6d151ce46