### PR TITLE
Add Rings tab with charts

### DIFF
--- a/src/components/dashboard/DashboardCharts.tsx
+++ b/src/components/dashboard/DashboardCharts.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { StepsChart } from "./StepsChart";
+import { ActivitiesChart } from "./ActivitiesChart";
+import WeeklyVolumeChart from "./WeeklyVolumeChart";
+import { ChartSelectionProvider } from "./ChartSelectionContext";
+
+export default function DashboardCharts() {
+  return (
+    <ChartSelectionProvider>
+      <div className="grid gap-6 md:grid-cols-2">
+        <StepsChart />
+        <ActivitiesChart />
+        <WeeklyVolumeChart />
+      </div>
+    </ChartSelectionProvider>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -12,3 +12,4 @@ export * from "./AcwrGauge";
 export * from "./ChartSelectionContext";
 export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
 export { default as TopInsights } from "./TopInsights";
+export { default as DashboardCharts } from "./DashboardCharts";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import { Flame, HeartPulse, Moon, Pizza, Pencil } from "lucide-react";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
 import { GeoActivityExplorer } from "@/components/map";
+import { DashboardCharts } from "@/components/dashboard";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { SimpleSelect } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -140,11 +141,16 @@ export default function Dashboard() {
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <TabsList>
         <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+        <TabsTrigger value="rings">Rings</TabsTrigger>
         <TabsTrigger value="map">Map</TabsTrigger>
         <TabsTrigger value="examples">Examples</TabsTrigger>
       </TabsList>
 
       <TabsContent value="dashboard">
+        <DashboardCharts />
+      </TabsContent>
+
+      <TabsContent value="rings">
         <div className="grid gap-4">
           <TopInsights />
       <div className="flex gap-4">

--- a/src/pages/__tests__/DashboardGoals.test.tsx
+++ b/src/pages/__tests__/DashboardGoals.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/hooks/useGarminData", () => ({
   useGarminData: () => mockGarminData,
   useMostRecentActivity: () => null,
   useGarminDays: () => mockDailySteps,
+  useGarminDaysLazy: () => mockDailySteps,
 }));
 
 vi.mock("@/pages/Examples", () => ({
@@ -53,7 +54,9 @@ vi.mock("@/hooks/useInsights", () => ({
 describe("Dashboard goals", () => {
   it("updates step ring when goal changes", async () => {
     render(<Dashboard />);
-    const ring = screen.getByLabelText("Steps progress");
+    // switch to the Rings tab where the progress rings are rendered
+    fireEvent.click(screen.getByRole("button", { name: "Rings" }));
+    const ring = await screen.findByLabelText("Steps progress");
     const circle = ring.querySelectorAll("circle")[1];
     const initial = circle.getAttribute("stroke-dashoffset");
 


### PR DESCRIPTION
## Summary
- introduce `DashboardCharts` and export from dashboard index
- add new Rings tab for progress rings and ring detail dialog
- show `DashboardCharts` in Dashboard tab
- update Dashboard goals test for new tab behavior

## Testing
- `npx vitest run src/pages/__tests__/DashboardGoals.test.tsx` *(fails: chart width >0 issue)*

------
https://chatgpt.com/codex/tasks/task_e_688c26f925c88324addd7acf969ff8d7