### PR TITLE
Refactor FIPS mapping usage

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -30,61 +30,8 @@ import {
 import { cn } from "@/lib/utils";
 import statesTopo from "../../../public/us-states.json";
 import CITY_COORDS from "@/lib/cityCoords";
+import { fipsToAbbr } from "@/lib/stateCodes";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
-
-const FIPS_TO_ABBR: Record<string, string> = {
-  "01": "AL",
-  "02": "AK",
-  "04": "AZ",
-  "05": "AR",
-  "06": "CA",
-  "08": "CO",
-  "09": "CT",
-  "10": "DE",
-  "11": "DC",
-  "12": "FL",
-  "13": "GA",
-  "15": "HI",
-  "16": "ID",
-  "17": "IL",
-  "18": "IN",
-  "19": "IA",
-  "20": "KS",
-  "21": "KY",
-  "22": "LA",
-  "23": "ME",
-  "24": "MD",
-  "25": "MA",
-  "26": "MI",
-  "27": "MN",
-  "28": "MS",
-  "29": "MO",
-  "30": "MT",
-  "31": "NE",
-  "32": "NV",
-  "33": "NH",
-  "34": "NJ",
-  "35": "NM",
-  "36": "NY",
-  "37": "NC",
-  "38": "ND",
-  "39": "OH",
-  "40": "OK",
-  "41": "OR",
-  "42": "PA",
-  "44": "RI",
-  "45": "SC",
-  "46": "SD",
-  "47": "TN",
-  "48": "TX",
-  "49": "UT",
-  "50": "VT",
-  "51": "VA",
-  "53": "WA",
-  "54": "WV",
-  "55": "WI",
-  "56": "WY",
-};
 
 
 const CITY_COORDS: Record<string, [number, number]> = {
@@ -211,7 +158,7 @@ export default function GeoActivityExplorer() {
               <Geographies geography={statesTopo as any}>
                 {({ geographies }) =>
                   geographies.map((geo) => {
-                  const abbr = FIPS_TO_ABBR[geo.id as string];
+                  const abbr = fipsToAbbr[geo.id as string];
                   const visited = summaryMap[abbr]?.visited;
                   const intensity = summaryMap[abbr]?.totalDays || 0;
                   const colorIndex = Math.min(10, Math.max(1, Math.ceil(intensity)));


### PR DESCRIPTION
## Summary
- remove inline `FIPS_TO_ABBR` in `GeoActivityExplorer`
- import and use `fipsToAbbr` from shared library

## Testing
- `npm test` *(fails: Error: [vitest] There was an error when mocking a module)*

------
https://chatgpt.com/codex/tasks/task_e_688c2f07f83483249f0a6f733459f169