### PR TITLE
Fix duplicate DashboardCharts export

### DIFF
--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -13,4 +13,3 @@ export * from "./AcwrGauge";
 export * from "./ChartSelectionContext";
 export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
 export { default as TopInsights } from "./TopInsights";
-export { default as DashboardCharts } from "./DashboardCharts";


### PR DESCRIPTION
## Summary
- remove duplicate DashboardCharts export to avoid Vite esbuild error

## Testing
- `npm test` *(fails: DashboardFilters.test.tsx unable to find steps-chart)*

------
https://chatgpt.com/codex/tasks/task_e_688c2ec9a598832493a95a9ce23e8365