### PR TITLE
Share city coordinates across map components

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -34,25 +34,6 @@ import { fipsToAbbr } from "@/lib/stateCodes";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 
-const CITY_COORDS: Record<string, [number, number]> = {
-  "Los Angeles": [-118.2437, 34.0522],
-  "San Francisco": [-122.4194, 37.7749],
-  "San Diego": [-117.1611, 32.7157],
-  Austin: [-97.7431, 30.2672],
-  Houston: [-95.3698, 29.7604],
-  Miami: [-80.1918, 25.7617],
-  Orlando: [-81.3792, 28.5383],
-  Tampa: [-82.4572, 27.9506],
-  Denver: [-104.9903, 39.7392],
-  Boulder: [-105.2705, 40.015],
-  "Colorado Springs": [-104.8214, 38.8339],
-  Seattle: [-122.3321, 47.6062],
-  Spokane: [-117.426, 47.6588],
-  Tacoma: [-122.4443, 47.2529],
-  Chicago: [-87.6298, 41.8781],
-};
-
-
 export default function GeoActivityExplorer() {
   const data = useStateVisits();
   const [expandedState, setExpandedState] = useState<string | null>(null);

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -20,23 +20,6 @@ import useLocationEfficiency from '@/hooks/useLocationEfficiency'
 import statesTopo from '../../../public/us-states.json'
 import CITY_COORDS from '@/lib/cityCoords'
 
-const CITY_COORDS: Record<string, [number, number]> = {
-  'Los Angeles': [-118.2437, 34.0522],
-  'San Francisco': [-122.4194, 37.7749],
-  Austin: [-97.7431, 30.2672],
-  Houston: [-95.3698, 29.7604],
-  Miami: [-80.1918, 25.7617],
-  Orlando: [-81.3792, 28.5383],
-  Tampa: [-82.4572, 27.9506],
-  Denver: [-104.9903, 39.7392],
-  Boulder: [-105.2705, 40.015],
-  'Colorado Springs': [-104.8214, 38.8339],
-  Seattle: [-122.3321, 47.6062],
-  Spokane: [-117.426, 47.6588],
-  Tacoma: [-122.4443, 47.2529],
-  Chicago: [-87.6298, 41.8781],
-}
-
 
 const config = {
   effort: { label: 'Effort', color: 'var(--chart-1)' },

--- a/src/lib/cityCoords.ts
+++ b/src/lib/cityCoords.ts
@@ -4,5 +4,15 @@ export const CITY_COORDS: Record<string, [number, number]> = {
   "San Diego": [-117.1611, 32.7157],
   Austin: [-97.7431, 30.2672],
   Houston: [-95.3698, 29.7604],
+  Miami: [-80.1918, 25.7617],
+  Orlando: [-81.3792, 28.5383],
+  Tampa: [-82.4572, 27.9506],
+  Denver: [-104.9903, 39.7392],
+  Boulder: [-105.2705, 40.015],
+  "Colorado Springs": [-104.8214, 38.8339],
+  Seattle: [-122.3321, 47.6062],
+  Spokane: [-117.426, 47.6588],
+  Tacoma: [-122.4443, 47.2529],
+  Chicago: [-87.6298, 41.8781],
 }
 export default CITY_COORDS


### PR DESCRIPTION
## Summary
- centralize city coordinate data in `src/lib/cityCoords.ts`
- use the shared coordinates in `GeoActivityExplorer` and `LocationEfficiencyComparison`

## Testing
- `npm test --silent -- --run` *(fails: Unable to find element by `[data-testid="steps-chart"]`)*

------
https://chatgpt.com/codex/tasks/task_e_688c30b0427c8324be852dd7bd4aa664