### PR TITLE
Centralize ResizeObserver stub for tests

### DIFF
--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -18,13 +18,7 @@ vi.mock("@/hooks/useStateVisits", () => ({
   ],
 }));
 
-beforeAll(() => {
-  globalThis.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any;
-});
+
 
 describe("GeoActivityExplorer", () => {
   it("toggles state details", () => {

--- a/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
+++ b/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
@@ -11,13 +11,7 @@ vi.mock('@/hooks/useLocationEfficiency', () => ({
   ],
 }))
 
-beforeAll(() => {
-  globalThis.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any
-})
+
 
 describe('LocationEfficiencyComparison', () => {
   it('renders map and ranks locations', () => {

--- a/src/components/statistics/__tests__/RouteComparison.test.tsx
+++ b/src/components/statistics/__tests__/RouteComparison.test.tsx
@@ -11,13 +11,7 @@ vi.mock('@/hooks/useRouteSessions', () => ({
   ],
 }))
 
-beforeAll(() => {
-  globalThis.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any
-})
+
 
 describe('RouteComparison', () => {
   it('renders a chart per session', () => {

--- a/src/components/statistics/__tests__/RunBikeVolumeComparison.test.tsx
+++ b/src/components/statistics/__tests__/RunBikeVolumeComparison.test.tsx
@@ -11,13 +11,7 @@ vi.mock('@/hooks/useRunBikeVolume', () => ({
   ],
 }))
 
-beforeAll(() => {
-  globalThis.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any
-})
+
 
 describe('RunBikeVolumeComparison', () => {
   it('toggles metric', () => {

--- a/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
+++ b/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
@@ -19,11 +19,6 @@ vi.mock('@/hooks/useWeeklyComparison', () => ({
 }))
 
 beforeAll(() => {
-  globalThis.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any
   Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
     configurable: true,
     value: () => ({ width: 400, height: 300, top: 0, left: 0, bottom: 0, right: 0 })

--- a/src/pages/__tests__/DashboardFilters.test.tsx
+++ b/src/pages/__tests__/DashboardFilters.test.tsx
@@ -49,13 +49,6 @@ vi.mock("@/hooks/useInsights", () => ({
   default: () => null,
 }));
 
-beforeAll(() => {
-  global.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any;
-});
 
 it("updates charts when range filter changes", async () => {
   render(

--- a/src/pages/__tests__/DashboardGoals.test.tsx
+++ b/src/pages/__tests__/DashboardGoals.test.tsx
@@ -32,13 +32,6 @@ vi.mock("@/components/dashboard", async (importOriginal) => {
   };
 });
 
-beforeAll(() => {
-  global.ResizeObserver = class {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  } as any
-});
 
 vi.mock("@/hooks/useStepInsights", () => ({
   __esModule: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: './vitest.setup.ts',
   },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,7 @@
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as any
+}


### PR DESCRIPTION
## Summary
- add global ResizeObserver stub in `vitest.setup.ts`
- load new setup file via `test.setupFiles`
- remove duplicate ResizeObserver stubs from individual tests

## Testing
- `npm test --silent` *(fails: Unable to find [data-testid="steps-chart"])*

------
https://chatgpt.com/codex/tasks/task_e_688c312130a883248a82fa5baf857ab1