### PR TITLE
Fix missing key warning in map

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -151,10 +151,9 @@ export default function GeoActivityExplorer() {
                     ? `${baseFill.replace(')', ' / 0.7)')}`
                     : baseFill;
                   return (
-                    <Tooltip>
+                    <Tooltip key={geo.rsmKey}>
                       <TooltipTrigger asChild>
                         <Geography
-                            key={geo.rsmKey}
                             geography={geo}
                             role="button"
                             tabIndex={0}


### PR DESCRIPTION
## Summary
- assign key to Tooltip wrapper in `GeoActivityExplorer`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c38013958832485288ba38511e570