### PR TITLE
Add generateTrendMessage for charts

### DIFF
--- a/src/components/examples/AreaChartLoadRatio.tsx
+++ b/src/components/examples/AreaChartLoadRatio.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import {
   ChartContainer,
   AreaChart,
@@ -63,7 +64,7 @@ export default function AreaChartLoadRatio() {
         </ChartContainer>
       </CardContent>
       <CardFooter className='flex items-center gap-2 text-sm'>
-        Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
       </CardFooter>
     </Card>
   )

--- a/src/components/examples/BarChartDefault.tsx
+++ b/src/components/examples/BarChartDefault.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts'
 
 import {
@@ -62,7 +63,7 @@ export default function ChartBarDefault() {
       </CardContent>
       <CardFooter className='flex-col items-start gap-2 text-sm'>
         <div className='flex gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total visitors for the last 6 months

--- a/src/components/examples/BarChartHorizontal.tsx
+++ b/src/components/examples/BarChartHorizontal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { Bar, BarChart, XAxis, YAxis } from 'recharts'
 
 import {
@@ -68,7 +69,7 @@ export default function ChartBarHorizontal() {
       </CardContent>
       <CardFooter className='flex-col items-start gap-2 text-sm'>
         <div className='flex gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total visitors for the last 6 months

--- a/src/components/examples/BarChartLabelCustom.tsx
+++ b/src/components/examples/BarChartLabelCustom.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from 'recharts'
 
 import {
@@ -67,7 +68,7 @@ export default function ChartBarLabelCustom() {
       </CardContent>
       <CardFooter className='flex-col items-start gap-2 text-sm'>
         <div className='flex gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing run mileage for the last 6 months

--- a/src/components/examples/BarChartMixed.tsx
+++ b/src/components/examples/BarChartMixed.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { Bar, BarChart, XAxis, YAxis } from 'recharts'
 
 import {
@@ -64,7 +65,7 @@ export default function ChartBarMixed() {
       </CardContent>
       <CardFooter className='flex-col items-start gap-2 text-sm'>
         <div className='flex gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total sessions for the last 6 months

--- a/src/components/examples/PieChartDonut.tsx
+++ b/src/components/examples/PieChartDonut.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { Pie, PieChart } from 'recharts'
 
 import {
@@ -55,7 +56,7 @@ export default function ChartPieDonut() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total workout minutes for the last 6 months

--- a/src/components/examples/RadarChartDefault.tsx
+++ b/src/components/examples/RadarChartDefault.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from 'recharts'
 
 import {
@@ -62,7 +63,7 @@ export default function ChartRadarDefault() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground flex items-center gap-2 leading-none'>
           January - June 2024

--- a/src/components/examples/RadarChartDots.tsx
+++ b/src/components/examples/RadarChartDots.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from 'recharts'
 
 import {
@@ -56,7 +57,7 @@ export default function ChartRadarDots() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground flex items-center gap-2 leading-none'>
           January - June 2024

--- a/src/components/examples/RadarChartWorkoutByTime.tsx
+++ b/src/components/examples/RadarChartWorkoutByTime.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { PolarAngleAxis, PolarGrid, Radar, RadarChart, PolarRadiusAxis } from 'recharts'
 
 import {
@@ -69,7 +70,7 @@ export default function RadarChartWorkoutByTime() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground flex items-center gap-2 leading-none'>
           Activity over a typical day

--- a/src/components/examples/RadialChartGrid.tsx
+++ b/src/components/examples/RadialChartGrid.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { PolarGrid, RadialBar, RadialBarChart } from 'recharts'
 
 import {
@@ -57,7 +58,7 @@ export default function ChartRadialGrid() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total workout minutes for the last 6 months

--- a/src/components/examples/RadialChartLabel.tsx
+++ b/src/components/examples/RadialChartLabel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import { LabelList, RadialBar, RadialBarChart } from 'recharts'
 
 import {
@@ -74,7 +75,7 @@ export default function ChartRadialLabel() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total workout minutes for the last 6 months

--- a/src/components/examples/RadialChartText.tsx
+++ b/src/components/examples/RadialChartText.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import {
   Label,
   PolarGrid,
@@ -100,7 +101,7 @@ export default function ChartRadialText() {
       </CardContent>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
-          Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+          {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
         </div>
         <div className='text-muted-foreground leading-none'>
           Showing total workout minutes for the last 6 months

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TrendingUp } from 'lucide-react'
+import { generateTrendMessage } from '@/lib/utils'
 import {
   ChartContainer,
   ScatterChart,
@@ -48,7 +49,7 @@ export default function ScatterChartPaceHeartRate() {
         </ChartContainer>
       </CardContent>
       <CardFooter className='flex items-center gap-2 text-sm'>
-        Trending up by 5.2% this month <TrendingUp className='h-4 w-4' />
+        {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
       </CardFooter>
     </Card>
   )

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,3 +8,9 @@ export function minutesSince(date: string | number | Date): number {
   return Math.floor((Date.now() - d.getTime()) / 60000)
 }
 
+export function generateTrendMessage(): string {
+  const direction = Math.random() < 0.5 ? 'up' : 'down'
+  const percentage = (Math.random() * (8 - 3) + 3).toFixed(1)
+  return `Trending ${direction} by ${percentage}% this month`
+}
+


### PR DESCRIPTION
## Summary
- add `generateTrendMessage()` to produce random up/down trend messages
- use the helper in all example charts
- keep `ShoeUsageChart.tsx` unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c3644d4708324bb167d0d0bd7c39b