### PR TITLE
Fix missing tooltips for examples

### DIFF
--- a/src/components/examples/AreaChartLoadRatio.tsx
+++ b/src/components/examples/AreaChartLoadRatio.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip as ChartTooltip,
+  ChartTooltipContent,
 } from '@/components/ui/chart'
 import {
   Card,
@@ -52,7 +53,13 @@ export default function AreaChartLoadRatio() {
               tickFormatter={(d) => new Date(d).toLocaleDateString()}
             />
             <YAxis domain={[0, 2]} />
-            <ChartTooltip />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(d) => new Date(d).toLocaleDateString()}
+                />
+              }
+            />
             <Area
               type='monotone'
               dataKey='ratio'

--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip as ChartTooltip,
+  ChartTooltipContent,
 } from '@/components/ui/chart'
 import ChartCard from '@/components/dashboard/ChartCard'
 
@@ -87,7 +88,7 @@ export default function PerfVsEnvironmentMatrixExample() {
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='temperature' name='Temp (F)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
-            <ChartTooltip />
+            <ChartTooltip content={<ChartTooltipContent />} />
             <Scatter data={DATA} fill='var(--color-pace)' />
             <Line data={tempReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
@@ -97,7 +98,7 @@ export default function PerfVsEnvironmentMatrixExample() {
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='humidity' name='Humidity (%)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
-            <ChartTooltip />
+            <ChartTooltip content={<ChartTooltipContent />} />
             <Scatter data={DATA} fill='var(--color-pace)' />
             <Line data={humidityReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
@@ -107,7 +108,7 @@ export default function PerfVsEnvironmentMatrixExample() {
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='wind' name='Wind (mph)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
-            <ChartTooltip />
+            <ChartTooltip content={<ChartTooltipContent />} />
             <Scatter data={DATA} fill='var(--color-pace)' />
             <Line data={windReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
@@ -117,7 +118,7 @@ export default function PerfVsEnvironmentMatrixExample() {
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='elevation' name='Elevation (ft)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
-            <ChartTooltip />
+            <ChartTooltip content={<ChartTooltipContent />} />
             <Scatter data={DATA} fill='var(--color-pace)' />
             <Line data={elevReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip as ChartTooltip,
+  ChartTooltipContent,
 } from '@/components/ui/chart'
 import {
   Card,
@@ -43,7 +44,7 @@ export default function ScatterChartPaceHeartRate() {
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='pace' name='Pace (min/mi)' />
             <YAxis dataKey='hr' name='Heart Rate (bpm)' />
-            <ChartTooltip />
+            <ChartTooltip content={<ChartTooltipContent />} />
             <Scatter data={scatterData} fill='var(--color-pace)' />
           </ScatterChart>
         </ChartContainer>

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -7,6 +7,7 @@ import {
   XAxis,
   CartesianGrid,
   Tooltip as ChartTooltip,
+  ChartTooltipContent,
 } from '@/components/ui/chart'
 import Slider from '@/components/ui/slider'
 import { useState, useEffect } from 'react'
@@ -42,7 +43,19 @@ export default function WeeklyVolumeHistoryChart() {
         <BarChart data={filtered} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
-          <ChartTooltip />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                labelFormatter={(d) =>
+                  new Date(d).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })
+                }
+              />
+            }
+          />
           <Bar dataKey="miles" fill="var(--color-miles)" radius={2} animationDuration={300} />
         </BarChart>
       </ChartContainer>


### PR DESCRIPTION
## Summary
- use `ChartTooltipContent` in WeeklyVolumeHistoryChart
- apply consistent tooltip content in PerfVsEnvironmentMatrix example
- update Pace vs Heart Rate and AC Load Ratio examples to use ChartTooltipContent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c3a73f53883248a15878859f9dc3c