### PR TITLE
Add metric insights and multi-delta progress rings

### DIFF
--- a/src/components/dashboard/ProgressRingWithDelta.tsx
+++ b/src/components/dashboard/ProgressRingWithDelta.tsx
@@ -8,15 +8,15 @@ export interface ProgressRingWithDeltaProps extends ProgressRingProps {
   previous: number;
   /** Decimal places for delta percentage */
   decimalPlaces?: number;
-  /** Optional tertiary text shown below the delta */
-  tertiary?: string;
+  /** Additional deltas rendered below the primary delta */
+  deltas?: { value: number; label: string }[];
 }
 
 export function ProgressRingWithDelta({
   current,
   previous,
   decimalPlaces = 1,
-  tertiary,
+  deltas,
   ...ringProps
 }: ProgressRingWithDeltaProps) {
   const formatted = React.useMemo(() => {
@@ -35,9 +35,11 @@ export function ProgressRingWithDelta({
       >
         {formatted}
       </span>
-      {tertiary && (
+      {deltas && deltas.length > 0 && (
         <span className="text-xs text-muted-foreground" aria-label="Additional context">
-          {tertiary}
+          {deltas
+            .map((d) => `${d.value >= 0 ? "+" : ""}${(d.value * 100).toFixed(decimalPlaces)}% ${d.label}`)
+            .join(" \u2022 ")}
         </span>
       )}
     </div>

--- a/src/components/dashboard/__tests__/ProgressRingWithDelta.test.tsx
+++ b/src/components/dashboard/__tests__/ProgressRingWithDelta.test.tsx
@@ -21,4 +21,17 @@ describe("ProgressRingWithDelta", () => {
     );
     expect(screen.getByText("0.0%")).toBeInTheDocument();
   });
+
+  it("renders additional deltas", () => {
+    render(
+      <ProgressRingWithDelta
+        value={50}
+        label="Progress"
+        current={100}
+        previous={80}
+        deltas={[{ value: 0.2, label: "vs 7d" }]}
+      />
+    );
+    expect(screen.getByText("+20.0% vs 7d")).toBeInTheDocument();
+  });
 });

--- a/src/hooks/__tests__/useStepInsights.test.ts
+++ b/src/hooks/__tests__/useStepInsights.test.ts
@@ -13,6 +13,8 @@ describe('computeStepInsights', () => {
     const result = computeStepInsights(sampleDays, 1000)
     expect(result.vsYesterday).toBeCloseTo(0.1)
     expect(result.vs7DayAvg).toBeCloseTo(0.0845, 3)
+    expect(result.vsSameDayLastWeek).toBeCloseTo(0.1)
+    expect(result.vs7DayRolling).toBeCloseTo(0.0143, 3)
     expect(result.monthly.projectedTotal).toBeCloseTo(31387.5)
     expect(result.monthly.onTrack).toBe(true)
     vi.useRealTimers()

--- a/src/hooks/useCalorieInsights.ts
+++ b/src/hooks/useCalorieInsights.ts
@@ -1,0 +1,8 @@
+import useDailyMetric from './useDailyMetric'
+import useMetricInsights, { MetricInsights } from './useMetricInsights'
+import { getDailyCalories } from '@/lib/api'
+
+export default function useCalorieInsights(): MetricInsights | null {
+  const days = useDailyMetric(getDailyCalories)
+  return useMetricInsights(days)
+}

--- a/src/hooks/useDailyMetric.ts
+++ b/src/hooks/useDailyMetric.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect, useMemo } from 'react'
+import type { MetricDay } from './useMetricInsights'
+
+export default function useDailyMetric(
+  fetcher: () => Promise<MetricDay[]>,
+): MetricDay[] | null {
+  const [data, setData] = useState<MetricDay[] | null>(null)
+  useEffect(() => {
+    fetcher().then(setData)
+  }, [fetcher])
+
+  return useMemo(() => {
+    if (!data) return data
+    return [...data].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    )
+  }, [data])
+}

--- a/src/hooks/useHeartRateInsights.ts
+++ b/src/hooks/useHeartRateInsights.ts
@@ -1,0 +1,8 @@
+import useDailyMetric from './useDailyMetric'
+import useMetricInsights, { MetricInsights } from './useMetricInsights'
+import { getDailyHeartRate } from '@/lib/api'
+
+export default function useHeartRateInsights(): MetricInsights | null {
+  const days = useDailyMetric(getDailyHeartRate)
+  return useMetricInsights(days)
+}

--- a/src/hooks/useMetricInsights.ts
+++ b/src/hooks/useMetricInsights.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+
+export interface MetricDay {
+  date: string
+  value: number
+}
+
+export interface MetricInsights {
+  vsYesterday: number
+  vs7DayAvg: number
+  vsSameDayLastWeek: number
+  vs7DayRolling: number
+}
+
+export function computeMetricInsights(days: MetricDay[]): MetricInsights {
+  const sorted = [...days].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  )
+  const today = sorted[sorted.length - 1]?.value ?? 0
+  const yesterday = sorted.length > 1 ? sorted[sorted.length - 2].value : 0
+  const vsYesterday = yesterday === 0 ? 0 : (today - yesterday) / yesterday
+
+  const last7 = sorted.slice(-7).map((d) => d.value)
+  const avg7 = last7.length ? last7.reduce((s, v) => s + v, 0) / last7.length : 0
+  const vs7DayAvg = avg7 === 0 ? 0 : (today - avg7) / avg7
+
+  const lastWeek = sorted.length > 7 ? sorted[sorted.length - 8].value : 0
+  const vsSameDayLastWeek =
+    lastWeek === 0 ? 0 : (today - lastWeek) / lastWeek
+
+  const prev7 = sorted.slice(-8, -1).map((d) => d.value)
+  const avgPrev7 =
+    prev7.length > 0 ? prev7.reduce((s, v) => s + v, 0) / prev7.length : 0
+  const avgLast7 =
+    last7.length > 0 ? last7.reduce((s, v) => s + v, 0) / last7.length : 0
+  const vs7DayRolling = avgPrev7 === 0 ? 0 : (avgLast7 - avgPrev7) / avgPrev7
+
+  return { vsYesterday, vs7DayAvg, vsSameDayLastWeek, vs7DayRolling }
+}
+
+export function useMetricInsights(
+  days: MetricDay[] | null,
+): MetricInsights | null {
+  return useMemo(() => {
+    if (!days) return null
+    return computeMetricInsights(days)
+  }, [days])
+}
+
+export default useMetricInsights

--- a/src/hooks/useSleepInsights.ts
+++ b/src/hooks/useSleepInsights.ts
@@ -1,0 +1,8 @@
+import useDailyMetric from './useDailyMetric'
+import useMetricInsights, { MetricInsights } from './useMetricInsights'
+import { getDailySleep } from '@/lib/api'
+
+export default function useSleepInsights(): MetricInsights | null {
+  const days = useDailyMetric(getDailySleep)
+  return useMetricInsights(days)
+}

--- a/src/hooks/useStepInsights.ts
+++ b/src/hooks/useStepInsights.ts
@@ -1,12 +1,13 @@
 import { useMemo } from 'react'
 import type { GarminDay } from '@/lib/api'
 import { computeMonthlyStepProjection, type MonthlyStepsProjection } from './useGarminData'
+import {
+  computeMetricInsights,
+  type MetricInsights,
+  type MetricDay,
+} from './useMetricInsights'
 
-export interface StepInsights {
-  /** Ratio change vs. yesterday (e.g. 0.1 = +10%) */
-  vsYesterday: number
-  /** Ratio change vs. trailing 7‑day average */
-  vs7DayAvg: number
+export interface StepInsights extends MetricInsights {
   /** Projected totals for the month at current pace */
   monthly: MonthlyStepsProjection
 }
@@ -15,19 +16,13 @@ export function computeStepInsights(
   days: GarminDay[],
   goalPerDay = 10000,
 ): StepInsights {
+  const metricDays: MetricDay[] = days.map((d) => ({ date: d.date, value: d.steps }))
+  const comparisons = computeMetricInsights(metricDays)
   const sorted = [...days].sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   )
-  const today = sorted[sorted.length - 1]?.steps ?? 0
-  const yesterday = sorted.length > 1 ? sorted[sorted.length - 2].steps : 0
-  const vsYesterday = yesterday === 0 ? 0 : (today - yesterday) / yesterday
-  const last7 = sorted.slice(-7).map((d) => d.steps)
-  const avg7 = last7.length
-    ? last7.reduce((sum, v) => sum + v, 0) / last7.length
-    : 0
-  const vs7DayAvg = avg7 === 0 ? 0 : (today - avg7) / avg7
   const monthly = computeMonthlyStepProjection(sorted, goalPerDay)
-  return { vsYesterday, vs7DayAvg, monthly }
+  return { ...comparisons, monthly }
 }
 
 export function useStepInsights(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,6 +21,11 @@ export type GarminDay = {
   steps: number;
 };
 
+export type MetricDay = {
+  date: string;
+  value: number;
+};
+
 export interface SeasonalBaseline {
   /** Month number 1-12 */
   month: number
@@ -60,6 +65,22 @@ export const mockDailySteps: GarminDay[] = [
   { date: "2025-07-29", steps: 8456 },
   { date: "2025-07-30", steps: 10342 },
 ];
+
+function generateMockMetricDays(base: number, variance = 0.1): MetricDay[] {
+  return Array.from({ length: 30 }, (_, i) => {
+    const d = new Date();
+    d.setDate(d.getDate() - (29 - i));
+    const factor = 1 + (Math.random() - 0.5) * variance;
+    return {
+      date: d.toISOString().slice(0, 10),
+      value: +(base * factor).toFixed(2),
+    };
+  });
+}
+
+export const mockDailySleep: MetricDay[] = generateMockMetricDays(7.5, 0.2);
+export const mockDailyHeartRate: MetricDay[] = generateMockMetricDays(65, 0.15);
+export const mockDailyCalories: MetricDay[] = generateMockMetricDays(2200, 0.25);
 
 export const mockGarminData: GarminData = {
   steps: 10342,
@@ -105,6 +126,24 @@ export async function getActivityMinutes(): Promise<ActivityMinutes[]> {
 export async function getDailySteps(): Promise<GarminDay[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(mockDailySteps), 300);
+  });
+}
+
+export async function getDailySleep(): Promise<MetricDay[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockDailySleep), 300);
+  });
+}
+
+export async function getDailyHeartRate(): Promise<MetricDay[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockDailyHeartRate), 300);
+  });
+}
+
+export async function getDailyCalories(): Promise<MetricDay[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockDailyCalories), 300);
   });
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,9 @@ import {
 } from "@/hooks/useGarminData";
 import useStepInsights from "@/hooks/useStepInsights";
 import useInsights from "@/hooks/useInsights";
+import useSleepInsights from "@/hooks/useSleepInsights";
+import useHeartRateInsights from "@/hooks/useHeartRateInsights";
+import useCalorieInsights from "@/hooks/useCalorieInsights";
 import { Flame, HeartPulse, Moon, Pizza, Pencil } from "lucide-react";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
@@ -92,6 +95,9 @@ export default function Dashboard() {
   }, [days, range]);
 
   const stepInsights = useStepInsights(filteredDays, stepGoal);
+  const sleepInsights = useSleepInsights();
+  const heartRateInsights = useHeartRateInsights();
+  const calorieInsights = useCalorieInsights();
 
 
   const recentActivity = useMostRecentActivity();
@@ -135,9 +141,26 @@ export default function Dashboard() {
   const lastSyncedMinutes = minutesSince(data.lastSync);
 
   const monthly = stepInsights?.monthly;
-  const stepContext = stepInsights
-    ? `${stepInsights.vsYesterday >= 0 ? '+' : ''}${(stepInsights.vsYesterday * 100).toFixed(0)}% vs yesterday • ${stepInsights.vs7DayAvg >= 0 ? '+' : ''}${(stepInsights.vs7DayAvg * 100).toFixed(0)}% vs 7d avg`
-    : undefined;
+  const stepDeltas =
+    stepInsights && [
+      { value: stepInsights.vsYesterday, label: 'vs yesterday' },
+      { value: stepInsights.vs7DayAvg, label: 'vs 7d avg' },
+    ];
+  const sleepDeltas =
+    sleepInsights && [
+      { value: sleepInsights.vsYesterday, label: 'vs yesterday' },
+      { value: sleepInsights.vs7DayAvg, label: 'vs 7d avg' },
+    ];
+  const heartDeltas =
+    heartRateInsights && [
+      { value: heartRateInsights.vsYesterday, label: 'vs yesterday' },
+      { value: heartRateInsights.vs7DayAvg, label: 'vs 7d avg' },
+    ];
+  const calorieDeltas =
+    calorieInsights && [
+      { value: calorieInsights.vsYesterday, label: 'vs yesterday' },
+      { value: calorieInsights.vs7DayAvg, label: 'vs 7d avg' },
+    ];
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -225,7 +248,7 @@ export default function Dashboard() {
             value={(data.steps / stepGoal) * 100}
             current={data.steps}
             previous={previousSteps}
-            tertiary={stepContext}
+            deltas={stepDeltas}
           />
           {monthly && (
             <div className="w-full mt-1" aria-label={`Projected ${Math.round(monthly.projectedTotal).toLocaleString()} steps`}>
@@ -338,6 +361,7 @@ export default function Dashboard() {
             value={(data.sleep / sleepGoal) * 100}
             current={data.sleep}
             previous={previousSleep}
+            deltas={sleepDeltas}
           />
           <span className="mt-2 text-lg font-bold">{data.sleep}</span>
           <MiniSparkline data={sparkData} />
@@ -395,6 +419,7 @@ export default function Dashboard() {
             value={(data.heartRate / heartGoal) * 100}
             current={data.heartRate}
             previous={previousHeartRate}
+            deltas={heartDeltas}
           />
           <span className="mt-2 text-lg font-bold">{data.heartRate}</span>
           <MiniSparkline data={sparkData} />
@@ -452,6 +477,7 @@ export default function Dashboard() {
             value={(data.calories / calorieGoal) * 100}
             current={data.calories}
             previous={previousCalories}
+            deltas={calorieDeltas}
           />
           <span className="mt-2 text-lg font-bold">{data.calories}</span>
           <MiniSparkline data={sparkData} />


### PR DESCRIPTION
## Summary
- extend step insights to use generic metric comparisons
- add generic `useMetricInsights` and hooks for sleep, heart rate, and calories
- create mock daily data for additional metrics
- enhance `ProgressRingWithDelta` to render multiple comparison deltas
- surface new deltas on Dashboard
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c3998ce4c832490dc832ce1af384b