### PR TITLE
Add TimeInBedChart test

### DIFF
--- a/src/components/examples/TimeInBedChart.tsx
+++ b/src/components/examples/TimeInBedChart.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  ReferenceLine,
+  ChartTooltip
+} from '@/components/ui/chart'
+import ChartCard from '@/components/dashboard/ChartCard'
+import type { ChartConfig } from '@/components/ui/chart'
+
+const data = [
+  { date: '2025-07-01', hours: 7 },
+  { date: '2025-07-02', hours: 6 },
+  { date: '2025-07-03', hours: 8 },
+]
+
+const chartConfig = {
+  hours: { label: 'Hours', color: 'hsl(var(--chart-1))' },
+  goal: { label: 'Goal', color: 'hsl(var(--chart-2))' },
+} satisfies ChartConfig
+
+export default function TimeInBedChart() {
+  return (
+    <ChartCard title="Time in Bed">
+      <ChartContainer config={chartConfig} className="h-48">
+        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" hide />
+          <ReferenceLine y={8} stroke={chartConfig.goal.color} strokeDasharray="4 4" />
+          <ChartTooltip />
+          <Bar dataKey="hours" fill="var(--color-hours)" radius={2} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/examples/__tests__/TimeInBedChart.test.tsx
+++ b/src/components/examples/__tests__/TimeInBedChart.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import TimeInBedChart from '../TimeInBedChart'
+import '@testing-library/jest-dom'
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ width: 400, height: 300, top: 0, left: 0, bottom: 0, right: 0 })
+  })
+})
+
+describe('TimeInBedChart', () => {
+  it('shows title and reference line', () => {
+    render(<TimeInBedChart />)
+    expect(screen.getByText(/Time in Bed/i)).toBeInTheDocument()
+    const refLine = document.querySelector('line.recharts-reference-line-line')
+    expect(refLine).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- add a simple `TimeInBedChart` component
- test that the chart title and reference line render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c398886ac8324ab3ce4bf53137f11