### PR TITLE
Add sleep session data and chart

### DIFF
--- a/src/components/dashboard/TimeInBedChart.tsx
+++ b/src/components/dashboard/TimeInBedChart.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import {
+  ChartContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  CartesianGrid,
+  YAxis,
+  Tooltip as ChartTooltip,
+} from '@/components/ui/chart'
+import ChartCard from './ChartCard'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { ChartConfig } from '@/components/ui/chart'
+import type { SleepSession } from '@/lib/api'
+import { getSleepSessions } from '@/lib/api'
+
+export default function TimeInBedChart() {
+  const [data, setData] = useState<SleepSession[] | null>(null)
+
+  useEffect(() => {
+    getSleepSessions().then(setData)
+  }, [])
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const config = {
+    timeInBed: { label: 'Hours', color: 'var(--chart-1)' },
+  } satisfies ChartConfig
+
+  return (
+    <ChartCard title="Time in Bed" description="Hours spent in bed each night">
+      <ChartContainer config={config} className="h-64">
+        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <YAxis />
+          <ChartTooltip />
+          <Bar dataKey="timeInBed" fill={config.timeInBed.color} radius={2} />
+        </BarChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -13,3 +13,4 @@ export * from "./AcwrGauge";
 export * from "./ChartSelectionContext";
 export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
 export { default as TopInsights } from "./TopInsights";
+export { default as TimeInBedChart } from "./TimeInBedChart";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -650,6 +650,30 @@ export async function getRouteSessions(route: string): Promise<RouteSession[]> {
   })
 }
 
+// ----- Sleep sessions -----
+
+export interface SleepSession {
+  date: string
+  timeInBed: number
+}
+
+export function generateMockSleepSessions(days = 30): SleepSession[] {
+  return Array.from({ length: days }, (_, i) => {
+    const d = new Date()
+    d.setDate(d.getDate() - i)
+    return {
+      date: d.toISOString().slice(0, 10),
+      timeInBed: +(6 + Math.random() * 3).toFixed(2),
+    }
+  })
+}
+
+export async function getSleepSessions(): Promise<SleepSession[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockSleepSessions()), 200)
+  })
+}
+
 // ----- Location efficiency -----
 
 export interface LocationEfficiency {


### PR DESCRIPTION
## Summary
- add mock sleep session helpers in `api.ts`
- expose `TimeInBedChart` component that fetches sessions asynchronously
- re-export `TimeInBedChart` from dashboard index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c39854d3c8324b4d93565b18fb62e