### PR TITLE
Add example test for TimeInBedChart

### DIFF
--- a/src/components/examples/__tests__/TimeInBedChart.test.tsx
+++ b/src/components/examples/__tests__/TimeInBedChart.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import TimeInBedChart from "../TimeInBedChart";
+import "@testing-library/jest-dom";
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ width: 400, height: 300, top: 0, left: 0, bottom: 0, right: 0 }),
+  });
+});
+
+describe("TimeInBedChart", () => {
+  it("renders chart title and reference line", () => {
+    const { container } = render(<TimeInBedChart />);
+    expect(screen.getByText("Time in Bed")).toBeInTheDocument();
+    // reference line uses a dashed stroke
+    const refLine = container.querySelector("line[stroke-dasharray='4 4']");
+    expect(refLine).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test for the `TimeInBedChart` example checking the chart title and reference line

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c40dda3748324b9642f5062d25496