### PR TITLE
Switch Dashboard tabs to NavigationMenu

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -22,12 +22,18 @@ import useCalorieInsights from "@/hooks/useCalorieInsights";
 import useUserGoals from "@/hooks/useUserGoals";
 
 import { Flame, HeartPulse, Moon, Pizza, Pencil } from "lucide-react";
-import { minutesSince } from "@/lib/utils";
+import { minutesSince, cn } from "@/lib/utils";
 import Examples from "@/pages/Examples";
 import { GeoActivityExplorer } from "@/components/map";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { SimpleSelect } from "@/components/ui/select";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+} from "@/components/ui/navigation-menu";
+import Statistics from "@/pages/Statistics";
 import useDashboardFilters, {
   type ActivityType,
   type DateRange,
@@ -190,14 +196,77 @@ export default function Dashboard() {
   };
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab}>
-      <TabsList>
-        <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
-        <TabsTrigger value="map">Map</TabsTrigger>
-        <TabsTrigger value="examples">Examples</TabsTrigger>
-      </TabsList>
+    <>
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuLink asChild>
+              <button
+                onClick={() => setActiveTab('dashboard')}
+                aria-current={activeTab === 'dashboard' ? 'page' : undefined}
+                className={cn(
+                  'px-3 py-1 rounded',
+                  activeTab === 'dashboard'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted hover:bg-muted-foreground',
+                )}
+              >
+                Dashboard
+              </button>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink asChild>
+              <button
+                onClick={() => setActiveTab('map')}
+                aria-current={activeTab === 'map' ? 'page' : undefined}
+                className={cn(
+                  'px-3 py-1 rounded',
+                  activeTab === 'map'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted hover:bg-muted-foreground',
+                )}
+              >
+                Map
+              </button>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink asChild>
+              <button
+                onClick={() => setActiveTab('examples')}
+                aria-current={activeTab === 'examples' ? 'page' : undefined}
+                className={cn(
+                  'px-3 py-1 rounded',
+                  activeTab === 'examples'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted hover:bg-muted-foreground',
+                )}
+              >
+                Examples
+              </button>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink asChild>
+              <button
+                onClick={() => setActiveTab('statistics')}
+                aria-current={activeTab === 'statistics' ? 'page' : undefined}
+                className={cn(
+                  'px-3 py-1 rounded',
+                  activeTab === 'statistics'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted hover:bg-muted-foreground',
+                )}
+              >
+                Statistics
+              </button>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>
 
-      <TabsContent value="dashboard">
+      {activeTab === 'dashboard' && (
         <div className="grid gap-4">
           <TopInsights />
       <div className="flex gap-4">
@@ -527,22 +596,19 @@ export default function Dashboard() {
           <p className="sr-only" aria-live="polite">{calorieSummary}</p>
         </Card>
       </div>
+      <RingDetailDialog
+        metric={expanded}
+        onClose={() => setExpanded(null)}
+        summary={expanded ? summaries[expanded] : undefined}
+      />
+    </div>
+  )}
 
-          <RingDetailDialog
-            metric={expanded}
-            onClose={() => setExpanded(null)}
-            summary={expanded ? summaries[expanded] : undefined}
-          />
-        </div>
-      </TabsContent>
+      {activeTab === 'map' && <GeoActivityExplorer />}
 
-      <TabsContent value="map">
-        <GeoActivityExplorer />
-      </TabsContent>
+      {activeTab === 'examples' && <Examples />}
 
-      <TabsContent value="examples">
-        <Examples />
-      </TabsContent>
-    </Tabs>
+      {activeTab === 'statistics' && <Statistics />}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- swap Tabs for NavigationMenu components in `Dashboard`
- show new Statistics view placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c41e8346c8324bd4ada1770e122ee