### PR TITLE
Add map popup for state details

### DIFF
--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -7,6 +7,7 @@ vi.mock("react-map-gl/maplibre", () => ({
   Source: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Layer: () => null,
   Marker: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Popup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 import "@testing-library/jest-dom";
 
@@ -51,5 +52,13 @@ describe("GeoActivityExplorer", () => {
     fireEvent.click(trigger);
     fireEvent.click(screen.getByText("Bike"));
     expect(screen.queryByLabelText("CA visited")).not.toBeInTheDocument();
+  });
+
+  it("shows popup with summary when state clicked", () => {
+    render(<GeoActivityExplorer />);
+    const state = screen.getByLabelText("CA visited");
+    fireEvent.click(state);
+    expect(screen.getAllByText("1d").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("1mi").length).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
## Summary
- show a popup on the map with state visit details
- sync accordion selection with map clicks
- test popup behavior on state click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c47b198d48324893d4fdc28007568