### PR TITLE
Add reading probability timeline chart

### DIFF
--- a/src/components/dashboard/ReadingProbabilityTimeline.tsx
+++ b/src/components/dashboard/ReadingProbabilityTimeline.tsx
@@ -1,0 +1,83 @@
+"use client";
+import {
+  ChartContainer,
+  AreaChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ReferenceArea,
+  Tooltip as ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import ChartCard from "./ChartCard";
+import type { ChartConfig } from "@/components/ui/chart";
+import useReadingProbability from "@/hooks/useReadingProbability";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { TooltipProps } from "recharts";
+
+export default function ReadingProbabilityTimeline() {
+  const data = useReadingProbability();
+
+  if (!data) return <Skeleton className="h-64" />;
+
+  const config = {
+    probability: { label: "Probability", color: "hsl(var(--chart-1))" },
+    intensity: { label: "Intensity", color: "hsl(var(--chart-2))" },
+    highlight: { color: "hsl(var(--chart-3))" },
+  } satisfies ChartConfig;
+
+  const highAreas = data.reduce<{ x1: string; x2: string }[]>((acc, cur, i) => {
+    if (cur.probability > 0.8) {
+      const next = data[i + 1];
+      acc.push({ x1: cur.time, x2: next ? next.time : cur.time });
+    }
+    return acc;
+  }, []);
+
+  function ReadingTooltip(props: TooltipProps<number, string>) {
+    const { active, payload, label } = props;
+    if (!(active && payload && payload.length)) return null;
+    const start = new Date(label as string);
+    const end = new Date(start);
+    end.setHours(end.getHours() + 1);
+    const range = `${start.toLocaleTimeString([], { hour: "numeric" })}–${end.toLocaleTimeString([], { hour: "numeric" })}`;
+    const prob = (payload.find((p) => p.dataKey === "probability")?.value as number) || 0;
+    return (
+      <ChartTooltipContent
+        {...(props as any)}
+        nameKey="probability"
+        formatter={() => `${Math.round(prob * 100)}%`}
+        labelFormatter={() => range}
+      />
+    );
+  }
+
+  return (
+    <ChartCard title="Reading Probability" description="Likelihood of reading throughout the day">
+      <ChartContainer config={config} className="h-64">
+        <AreaChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="time" tickFormatter={(t) => new Date(t).getHours()} />
+          <YAxis domain={[0, 1]} tickFormatter={(v) => `${Math.round(v * 100)}%`} />
+          {highAreas.map((a, idx) => (
+            <ReferenceArea
+              key={idx}
+              x1={a.x1}
+              x2={a.x2}
+              y1={0}
+              y2={1}
+              strokeOpacity={0}
+              fill="var(--color-highlight)"
+              fillOpacity={0.1}
+            />
+          ))}
+          <ChartTooltip content={<ReadingTooltip />} />
+          <Area type="monotone" dataKey="intensity" stroke={config.intensity.color} fill={config.intensity.color} fillOpacity={0.2} />
+          <Line type="monotone" dataKey="probability" stroke={config.probability.color} dot={false} />
+        </AreaChart>
+      </ChartContainer>
+    </ChartCard>
+  );
+}

--- a/src/components/dashboard/__tests__/ReadingProbabilityTimeline.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingProbabilityTimeline.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react"
+import ReadingProbabilityTimeline from "../ReadingProbabilityTimeline"
+import { vi, describe, it, expect } from "vitest"
+import "@testing-library/jest-dom"
+
+vi.mock("@/hooks/useReadingProbability", () => ({
+  __esModule: true,
+  default: () => [
+    { time: "2025-07-30T00:00:00Z", probability: 0.5, intensity: 0.3 },
+  ],
+}))
+
+describe("ReadingProbabilityTimeline", () => {
+  it("renders chart title", () => {
+    render(<ReadingProbabilityTimeline />)
+    expect(screen.getByText(/Reading Probability/)).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -14,3 +14,4 @@ export * from "./ChartSelectionContext";
 export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
 export { default as TopInsights } from "./TopInsights";
 export { default as TimeInBedChart } from "./TimeInBedChart";
+export { default as ReadingProbabilityTimeline } from "./ReadingProbabilityTimeline";

--- a/src/hooks/useReadingProbability.ts
+++ b/src/hooks/useReadingProbability.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getReadingProbability, type ReadingProbabilityPoint } from '@/lib/api'
+
+export default function useReadingProbability(): ReadingProbabilityPoint[] | null {
+  const [data, setData] = useState<ReadingProbabilityPoint[] | null>(null)
+
+  useEffect(() => {
+    getReadingProbability().then(setData)
+  }, [])
+
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -759,3 +759,28 @@ export async function getLocationEfficiency(): Promise<LocationEfficiency[]> {
     setTimeout(() => resolve(mockLocationEfficiency), 200)
   })
 }
+
+// ----- Reading probability timeline -----
+export type ReadingProbabilityPoint = {
+  time: string
+  probability: number
+  intensity: number
+}
+
+export function generateMockReadingProbability(): ReadingProbabilityPoint[] {
+  return Array.from({ length: 24 }, (_, i) => {
+    const d = new Date()
+    d.setHours(i, 0, 0, 0)
+    return {
+      time: d.toISOString(),
+      probability: +Math.random().toFixed(2),
+      intensity: +Math.random().toFixed(2),
+    }
+  })
+}
+
+export async function getReadingProbability(): Promise<ReadingProbabilityPoint[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockReadingProbability()), 200)
+  })
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -25,6 +25,7 @@ import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
 import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironmentMatrix";
 
 import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
+import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilityTimeline";
 
 
 export default function Examples() {
@@ -37,6 +38,7 @@ export default function Examples() {
       <PeerBenchmarkBands />
 
       <WeeklyVolumeHistoryChart />
+      <ReadingProbabilityTimeline />
 
       <TimeInBedChart />
 


### PR DESCRIPTION
## Summary
- mock API: generate hourly reading probability data
- add `useReadingProbability` hook
- render a probability timeline chart with intensity overlay
- show demo of the chart on the Examples page
- test that the chart renders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4772a7ec8324b9cbfa20fa828688