### PR TITLE
Add BooksVsCalories progress component

### DIFF
--- a/src/components/dashboard/BooksVsCalories.tsx
+++ b/src/components/dashboard/BooksVsCalories.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import useReadingProgress from '@/hooks/useReadingProgress'
+import { useGarminData } from '@/hooks/useGarminData'
+import useUserGoals from '@/hooks/useUserGoals'
+
+function ProgressBar({ value, max, testId }: { value: number; max: number; testId: string }) {
+  const pct = max === 0 ? 0 : Math.max(Math.min((value / max) * 100, 100), 0)
+  return (
+    <div className="h-2 w-full rounded bg-muted">
+      <div
+        data-testid={testId}
+        className="h-2 rounded bg-primary"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  )
+}
+
+export default function BooksVsCalories() {
+  const reading = useReadingProgress()
+  const garmin = useGarminData()
+  const { calorieGoal } = useUserGoals()
+
+  if (!reading || !garmin) return <Skeleton className="h-8" />
+
+  const unread = Math.max(reading.readingGoal - reading.pagesRead, 0)
+  const unburned = Math.max(calorieGoal - garmin.calories, 0)
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Card
+            className="flex gap-2 p-4"
+            tabIndex={0}
+            role="img"
+            aria-label="Books vs Calories"
+          >
+            <ProgressBar value={unread} max={reading.readingGoal} testId="pages-bar" />
+            <ProgressBar value={unburned} max={calorieGoal} testId="calorie-bar" />
+          </Card>
+        </TooltipTrigger>
+        <TooltipContent>
+          {`Pages left: ${unread} / Calories to burn: ${unburned}.`}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/dashboard/__tests__/BooksVsCalories.test.tsx
+++ b/src/components/dashboard/__tests__/BooksVsCalories.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { vi, describe, it, expect } from "vitest"
+import BooksVsCalories from "../BooksVsCalories"
+
+vi.mock("@/hooks/useReadingProgress", () => ({
+  __esModule: true,
+  default: () => ({ pagesRead: 40, readingGoal: 100, unreadPages: 60 }),
+}))
+
+vi.mock("@/hooks/useGarminData", () => ({
+  __esModule: true,
+  useGarminData: () => ({
+    steps: 0,
+    sleep: 0,
+    heartRate: 0,
+    calories: 200,
+    activities: [],
+    lastSync: "",
+  }),
+}))
+
+vi.mock("@/hooks/useUserGoals", () => ({
+  __esModule: true,
+  default: () => ({
+    dailyStepGoal: 0,
+    setDailyStepGoal: vi.fn(),
+    sleepGoal: 0,
+    setSleepGoal: vi.fn(),
+    heartRateGoal: 0,
+    setHeartRateGoal: vi.fn(),
+    calorieGoal: 500,
+    setCalorieGoal: vi.fn(),
+    readingGoal: 100,
+    setReadingGoal: vi.fn(),
+  }),
+}))
+
+describe("BooksVsCalories", () => {
+  it("renders bars and tooltip", () => {
+    vi.useFakeTimers()
+    render(<BooksVsCalories />)
+    const pagesBar = screen.getByTestId("pages-bar")
+    const calorieBar = screen.getByTestId("calorie-bar")
+    expect(pagesBar.style.width).toBe("60%")
+    expect(calorieBar.style.width).toBe("60%")
+
+    const card = screen.getByRole("img", { name: /Books vs Calories/i })
+    fireEvent.focus(card)
+    vi.advanceTimersByTime(1)
+    expect(
+      screen.getAllByText("Pages left: 60 / Calories to burn: 300.").length
+    ).toBeGreaterThan(0)
+    vi.useRealTimers()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -11,3 +11,4 @@ export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
 export { default as TopInsights } from "./TopInsights";
 export { default as TimeInBedChart } from "./TimeInBedChart";
 export { default as ReadingProbabilityTimeline } from "./ReadingProbabilityTimeline";
+export { default as BooksVsCalories } from "./BooksVsCalories";

--- a/src/hooks/useReadingProgress.ts
+++ b/src/hooks/useReadingProgress.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import { getReadingProgress, type ReadingProgress } from '@/lib/api'
+
+export interface ReadingProgressState extends ReadingProgress {
+  unreadPages: number
+}
+
+export default function useReadingProgress(): ReadingProgressState | null {
+  const [data, setData] = useState<ReadingProgressState | null>(null)
+
+  useEffect(() => {
+    getReadingProgress().then((d) =>
+      setData({ ...d, unreadPages: Math.max(d.readingGoal - d.pagesRead, 0) })
+    )
+  }, [])
+
+  return data
+}

--- a/src/hooks/useUserGoals.ts
+++ b/src/hooks/useUserGoals.ts
@@ -9,18 +9,22 @@ export interface UserGoals {
   setHeartRateGoal: (goal: number) => void
   calorieGoal: number
   setCalorieGoal: (goal: number) => void
+  readingGoal: number
+  setReadingGoal: (goal: number) => void
 }
 
 export const DEFAULT_DAILY_STEP_GOAL = 10000
 export const DEFAULT_SLEEP_GOAL = 8
 export const DEFAULT_HEART_RATE_GOAL = 200
 export const DEFAULT_CALORIE_GOAL = 3000
+export const DEFAULT_READING_GOAL = 300
 
 export function useUserGoals(): UserGoals {
   const [dailyStepGoal, setStepGoal] = useState(DEFAULT_DAILY_STEP_GOAL)
   const [sleepGoal, setSleep] = useState(DEFAULT_SLEEP_GOAL)
   const [heartRateGoal, setHeart] = useState(DEFAULT_HEART_RATE_GOAL)
   const [calorieGoal, setCalories] = useState(DEFAULT_CALORIE_GOAL)
+  const [readingGoal, setReading] = useState(DEFAULT_READING_GOAL)
 
   useEffect(() => {
     const sg = localStorage.getItem('dailyStepGoal')
@@ -42,6 +46,11 @@ export function useUserGoals(): UserGoals {
     if (cg) {
       const parsed = parseInt(cg, 10)
       if (!Number.isNaN(parsed)) setCalories(parsed)
+    }
+    const rg = localStorage.getItem('readingGoal')
+    if (rg) {
+      const parsed = parseInt(rg, 10)
+      if (!Number.isNaN(parsed)) setReading(parsed)
     }
   }, [])
 
@@ -65,6 +74,11 @@ export function useUserGoals(): UserGoals {
     localStorage.setItem('calorieGoal', String(goal))
   }
 
+  const setReadingGoal = (goal: number) => {
+    setReading(goal)
+    localStorage.setItem('readingGoal', String(goal))
+  }
+
   return {
     dailyStepGoal,
     setDailyStepGoal,
@@ -74,6 +88,8 @@ export function useUserGoals(): UserGoals {
     setHeartRateGoal,
     calorieGoal,
     setCalorieGoal,
+    readingGoal,
+    setReadingGoal,
   }
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -784,3 +784,20 @@ export async function getReadingProbability(): Promise<ReadingProbabilityPoint[]
     setTimeout(() => resolve(generateMockReadingProbability()), 200)
   })
 }
+
+// ----- Reading progress -----
+export interface ReadingProgress {
+  pagesRead: number
+  readingGoal: number
+}
+
+export const mockReadingProgress: ReadingProgress = {
+  pagesRead: 120,
+  readingGoal: 300,
+}
+
+export async function getReadingProgress(): Promise<ReadingProgress> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockReadingProgress), 200)
+  })
+}


### PR DESCRIPTION
## Summary
- mock getReadingProgress API
- compute unread pages with `useReadingProgress`
- extend `useUserGoals` with `readingGoal`
- add `BooksVsCalories` dashboard card with tooltip
- export new component and test it

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c4a6bcd8c83248cbddb1807957eeb