### PR TITLE
Add reading heatmap feature

### DIFF
--- a/src/components/dashboard/ReadingFocusHeatmap.tsx
+++ b/src/components/dashboard/ReadingFocusHeatmap.tsx
@@ -1,0 +1,59 @@
+"use client";
+import ChartCard from "./ChartCard";
+import { ChartContainer } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
+import useReadingHeatmap, { HeatmapCell } from "@/hooks/useReadingHeatmap";
+
+const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function labelForIntensity(intensity: number): string {
+  if (intensity > 0.66) return "Deep Dive";
+  if (intensity > 0.33) return "Study";
+  if (intensity > 0) return "Skim";
+  return "";
+}
+
+export default function ReadingFocusHeatmap() {
+  const data = useReadingHeatmap();
+
+  if (!data) return <Skeleton className="h-64" />;
+
+  const grid: HeatmapCell[][] = Array.from({ length: 24 }, () =>
+    Array.from({ length: 7 }, () => ({ day: 0, hour: 0, intensity: 0 })),
+  );
+  data.forEach((c) => {
+    grid[c.hour][c.day] = c;
+  });
+
+  return (
+    <ChartCard title="Reading Focus" description="When you read most intently">
+      <ChartContainer config={{}} className="h-64">
+        <div className="grid gap-px text-center text-[10px] h-full">
+          <div className="grid grid-cols-7 text-xs font-medium">
+            {dayLabels.map((d) => (
+              <div key={d}>{d}</div>
+            ))}
+          </div>
+          <div className="overflow-y-auto">
+            {grid.map((row, hour) => (
+              <div key={hour} className="grid grid-cols-7">
+                {row.map((cell, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-center border bg-accent text-accent-foreground h-6"
+                    style={{
+                      opacity: cell.intensity,
+                    }}
+                    aria-label={labelForIntensity(cell.intensity)}
+                  >
+                    {labelForIntensity(cell.intensity)}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </ChartContainer>
+    </ChartCard>
+  );
+}

--- a/src/components/dashboard/__tests__/ReadingFocusHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingFocusHeatmap.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import ReadingFocusHeatmap from '../ReadingFocusHeatmap'
+
+vi.mock('@/hooks/useReadingHeatmap', () => ({
+  __esModule: true,
+  default: () => [
+    { day: 0, hour: 0, intensity: 0.8 },
+  ],
+}))
+
+describe('ReadingFocusHeatmap', () => {
+  it('renders chart title', () => {
+    render(<ReadingFocusHeatmap />)
+    expect(screen.getByText(/Reading Focus/)).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -11,3 +11,4 @@ export { default as WeeklyVolumeChart } from "./WeeklyVolumeChart";
 export { default as TopInsights } from "./TopInsights";
 export { default as TimeInBedChart } from "./TimeInBedChart";
 export { default as ReadingProbabilityTimeline } from "./ReadingProbabilityTimeline";
+export { default as ReadingFocusHeatmap } from "./ReadingFocusHeatmap";

--- a/src/hooks/__tests__/useReadingHeatmap.test.ts
+++ b/src/hooks/__tests__/useReadingHeatmap.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { computeReadingHeatmap } from '../useReadingHeatmap'
+import type { ReadingSession } from '@/lib/api'
+
+describe('computeReadingHeatmap', () => {
+  it('bins by hour and weekday', () => {
+    const sessions: ReadingSession[] = [
+      { timestamp: '2025-07-28T10:00:00Z', intensity: 0.5 },
+      { timestamp: '2025-07-28T10:30:00Z', intensity: 0.7 },
+      { timestamp: '2025-07-29T11:00:00Z', intensity: 0.2 },
+    ]
+    const result = computeReadingHeatmap(sessions)
+    expect(result.length).toBe(168)
+    const mon10 = result.find((c) => c.day === 1 && c.hour === 10)
+    const tue11 = result.find((c) => c.day === 2 && c.hour === 11)
+    expect(mon10?.intensity).toBeCloseTo(0.6)
+    expect(tue11?.intensity).toBeCloseTo(0.2)
+  })
+})

--- a/src/hooks/useReadingHeatmap.ts
+++ b/src/hooks/useReadingHeatmap.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { getReadingSessions, type ReadingSession } from '@/lib/api'
+
+export interface HeatmapCell {
+  day: number
+  hour: number
+  intensity: number
+}
+
+export function computeReadingHeatmap(sessions: ReadingSession[]): HeatmapCell[] {
+  const bins = Array.from({ length: 7 }, () =>
+    Array.from({ length: 24 }, () => ({ total: 0, count: 0 })),
+  )
+  for (const s of sessions) {
+    const d = new Date(s.timestamp)
+    const day = d.getDay()
+    const hour = d.getHours()
+    bins[day][hour].total += s.intensity
+    bins[day][hour].count += 1
+  }
+  const result: HeatmapCell[] = []
+  for (let day = 0; day < 7; day++) {
+    for (let hour = 0; hour < 24; hour++) {
+      const cell = bins[day][hour]
+      result.push({
+        day,
+        hour,
+        intensity: cell.count ? cell.total / cell.count : 0,
+      })
+    }
+  }
+  return result
+}
+
+export default function useReadingHeatmap(): HeatmapCell[] | null {
+  const [data, setData] = useState<HeatmapCell[] | null>(null)
+
+  useEffect(() => {
+    getReadingSessions().then((sessions) => setData(computeReadingHeatmap(sessions)))
+  }, [])
+
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -784,3 +784,32 @@ export async function getReadingProbability(): Promise<ReadingProbabilityPoint[]
     setTimeout(() => resolve(generateMockReadingProbability()), 200)
   })
 }
+
+// ----- Reading sessions -----
+
+export interface ReadingSession {
+  /** ISO timestamp when reading occurred */
+  timestamp: string
+  /** Focus intensity from 0-1 */
+  intensity: number
+}
+
+export function generateMockReadingSessions(count = 60): ReadingSession[] {
+  const sessions: ReadingSession[] = []
+  for (let i = 0; i < count; i++) {
+    const d = new Date()
+    d.setDate(d.getDate() - Math.floor(Math.random() * 30))
+    d.setHours(Math.floor(Math.random() * 24), 0, 0, 0)
+    sessions.push({
+      timestamp: d.toISOString(),
+      intensity: +Math.random().toFixed(2),
+    })
+  }
+  return sessions
+}
+
+export async function getReadingSessions(): Promise<ReadingSession[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(generateMockReadingSessions()), 200)
+  })
+}


### PR DESCRIPTION
## Summary
- mock API to provide reading session data
- compute reading heatmap bins and expose hook
- create ReadingFocusHeatmap dashboard component
- export component in dashboard index
- test heatmap binning and component rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4a7f95e883248272fcc3221e3268