### PR TITLE
Add accessible AJO favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard MVP</title>
+    <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)">
+    <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)">
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon-dark.svg
+++ b/public/favicon-dark.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 600;
+      src: url('https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf') format('truetype');
+    }
+    text { font-family: 'Inter', sans-serif; font-weight: 600; }
+  </style>
+  <rect width="64" height="64" fill="#000000"/>
+  <text x="32" y="44" text-anchor="middle" fill="#ffffff" font-size="36">AJO</text>
+</svg>
+

--- a/public/favicon-light.svg
+++ b/public/favicon-light.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 600;
+      src: url('https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf') format('truetype');
+    }
+    text { font-family: 'Inter', sans-serif; font-weight: 600; }
+  </style>
+  <rect width="64" height="64" fill="#ffffff"/>
+  <text x="32" y="44" text-anchor="middle" fill="#000000" font-size="36">AJO</text>
+</svg>
+


### PR DESCRIPTION
## Summary
- add light & dark mode favicons with "AJO" text using Inter font
- include new favicons in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4bc814708324a2a4ee7f7296e6f5