### PR TITLE
Replace taco icon

### DIFF
--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
 
 export default function ThemeToggle() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
@@ -24,7 +25,11 @@ export default function ThemeToggle() {
       onClick={toggleTheme}
       aria-label="Toggle theme"
     >
-      🌮
+      {theme === "light" ? (
+        <Moon className="w-4 h-4" />
+      ) : (
+        <Sun className="w-4 h-4" />
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- swap taco emoji in ThemeToggle for dynamic Moon/Sun icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4ac729a48324bde1afd02b67a01a