### PR TITLE
Fix missing closure in ReadingSessions

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -838,6 +838,8 @@ export function generateMockReadingSessions(count = 60): ReadingSession[] {
 export async function getReadingSessions(): Promise<ReadingSession[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(generateMockReadingSessions()), 200)
+  })
+}
 
 // ----- Reading progress -----
 export interface ReadingProgress {


### PR DESCRIPTION
## Summary
- close `getReadingSessions()` properly so TypeScript builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4c8dc3ac83248dae9f6e244bd472