### PR TITLE
Color-coded scatter dots

### DIFF
--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -13,6 +13,7 @@ import {
   ChartTooltipContent,
 } from '@/components/ui/chart'
 import ChartCard from '@/components/dashboard/ChartCard'
+import { Cell } from 'recharts'
 
 interface PerfPoint {
   pace: number
@@ -21,12 +22,14 @@ interface PerfPoint {
   humidity: number
   wind: number
   elevation: number
+  fill: string
 }
 
 function generateData(count = 50): PerfPoint[] {
   return Array.from({ length: count }, () => {
     const pace = 6 + Math.random() * 2 // 6-8 min/mi
     const power = 250 - pace * 20 + Math.random() * 10
+    const colorIndex = Math.min(5, Math.max(0, Math.floor((power - 90) / 10)))
     return {
       pace: +pace.toFixed(2),
       power: Math.round(power),
@@ -34,6 +37,7 @@ function generateData(count = 50): PerfPoint[] {
       humidity: Math.round(40 + Math.random() * 50),
       wind: +(Math.random() * 20).toFixed(1),
       elevation: Math.round(Math.random() * 300),
+      fill: `var(--chart-${colorIndex + 5})`,
     }
   })
 }
@@ -89,7 +93,11 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='temperature' name='Temp (F)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip content={<ChartTooltipContent />} />
-            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={tempReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
@@ -99,7 +107,11 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='humidity' name='Humidity (%)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip content={<ChartTooltipContent />} />
-            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={humidityReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
@@ -109,7 +121,11 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='wind' name='Wind (mph)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip content={<ChartTooltipContent />} />
-            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={windReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>
@@ -119,7 +135,11 @@ export default function PerfVsEnvironmentMatrixExample() {
             <XAxis dataKey='elevation' name='Elevation (ft)' />
             <YAxis dataKey='pace' name='Pace (min/mi)' />
             <ChartTooltip content={<ChartTooltipContent />} />
-            <Scatter data={DATA} fill='var(--color-pace)' />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={elevReg} stroke='var(--color-trend)' dot={false} />
           </ScatterChart>
         </ChartContainer>

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -20,11 +20,18 @@ import {
   CardContent,
   CardFooter,
 } from '@/components/ui/card'
+import { Cell } from 'recharts'
 
-const scatterData = Array.from({ length: 200 }, () => ({
-  pace: 6 + Math.random() * 2,
-  hr: 120 + Math.random() * 40,
-}))
+const scatterData = Array.from({ length: 200 }, () => {
+  const pace = 6 + Math.random() * 2
+  const hr = 120 + Math.random() * 40
+  const zone = Math.min(5, Math.max(0, Math.floor((hr - 120) / 8)))
+  return {
+    pace,
+    hr,
+    fill: `var(--chart-${zone + 5})`,
+  }
+})
 
 const chartConfig = {
   pace: { label: 'Pace', color: 'hsl(var(--chart-9))' },
@@ -45,7 +52,11 @@ export default function ScatterChartPaceHeartRate() {
             <XAxis dataKey='pace' name='Pace (min/mi)' />
             <YAxis dataKey='hr' name='Heart Rate (bpm)' />
             <ChartTooltip content={<ChartTooltipContent />} />
-            <Scatter data={scatterData} fill='var(--color-pace)' />
+            <Scatter data={scatterData}>
+              {scatterData.map((pt, idx) => (
+                <Cell key={idx} fill={pt.fill} />
+              ))}
+            </Scatter>
           </ScatterChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/statistics/PaceVsHR.tsx
+++ b/src/components/statistics/PaceVsHR.tsx
@@ -10,11 +10,18 @@ import {
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
 import ChartCard from "@/components/dashboard/ChartCard"
+import { Cell } from "recharts"
 
-const scatterData = Array.from({ length: 200 }, () => ({
-  pace: 6 + Math.random() * 2,
-  hr: 120 + Math.random() * 40,
-}))
+const scatterData = Array.from({ length: 200 }, () => {
+  const pace = 6 + Math.random() * 2
+  const hr = 120 + Math.random() * 40
+  const zone = Math.min(5, Math.max(0, Math.floor((hr - 120) / 8)))
+  return {
+    pace,
+    hr,
+    fill: `var(--chart-${zone + 5})`,
+  }
+})
 
 const config = {
   pace: { label: "Pace", color: "var(--chart-9)" },
@@ -33,7 +40,11 @@ export default function PaceVsHR() {
           <XAxis dataKey="pace" name="Pace (min/mi)" />
           <YAxis dataKey="hr" name="Heart Rate (bpm)" />
           <ChartTooltip />
-          <Scatter data={scatterData} fill="var(--chart-9)" />
+          <Scatter data={scatterData}>
+            {scatterData.map((pt, idx) => (
+              <Cell key={idx} fill={pt.fill} />
+            ))}
+          </Scatter>
         </ScatterChart>
       </ChartContainer>
     </ChartCard>

--- a/src/components/statistics/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/statistics/PerfVsEnvironmentMatrix.tsx
@@ -10,20 +10,23 @@ import {
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart";
 import ChartCard from "@/components/dashboard/ChartCard";
+import { Cell } from "recharts";
 
 interface PerfPoint {
-  pace: number;
-  power: number;
-  temperature: number;
-  humidity: number;
-  wind: number;
-  elevation: number;
+  pace: number
+  power: number
+  temperature: number
+  humidity: number
+  wind: number
+  elevation: number
+  fill: string
 }
 
 function generateData(count = 50): PerfPoint[] {
   return Array.from({ length: count }, () => {
     const pace = 6 + Math.random() * 2; // 6-8 min/mi
     const power = 250 - pace * 20 + Math.random() * 10;
+    const colorIndex = Math.min(5, Math.max(0, Math.floor((power - 90) / 10)))
     return {
       pace: +pace.toFixed(2),
       power: Math.round(power),
@@ -31,7 +34,8 @@ function generateData(count = 50): PerfPoint[] {
       humidity: Math.round(40 + Math.random() * 50),
       wind: +(Math.random() * 20).toFixed(1),
       elevation: Math.round(Math.random() * 300),
-    };
+      fill: `var(--chart-${colorIndex + 5})`,
+    }
   });
 }
 
@@ -86,7 +90,11 @@ export default function PerfVsEnvironmentMatrix() {
             <XAxis dataKey="temperature" name="Temp (F)" />
             <YAxis dataKey="pace" name="Pace (min/mi)" />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={tempReg} stroke={config.trend.color} dot={false} />
           </ScatterChart>
         </ChartContainer>
@@ -96,7 +104,11 @@ export default function PerfVsEnvironmentMatrix() {
             <XAxis dataKey="humidity" name="Humidity (%)" />
             <YAxis dataKey="pace" name="Pace (min/mi)" />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={humidityReg} stroke={config.trend.color} dot={false} />
           </ScatterChart>
         </ChartContainer>
@@ -106,7 +118,11 @@ export default function PerfVsEnvironmentMatrix() {
             <XAxis dataKey="wind" name="Wind (mph)" />
             <YAxis dataKey="pace" name="Pace (min/mi)" />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={windReg} stroke={config.trend.color} dot={false} />
           </ScatterChart>
         </ChartContainer>
@@ -116,7 +132,11 @@ export default function PerfVsEnvironmentMatrix() {
             <XAxis dataKey="elevation" name="Elevation (ft)" />
             <YAxis dataKey="pace" name="Pace (min/mi)" />
             <ChartTooltip />
-            <Scatter data={DATA} fill={config.pace.color} />
+            <Scatter data={DATA}>
+              {DATA.map((point, idx) => (
+                <Cell key={idx} fill={point.fill} />
+              ))}
+            </Scatter>
             <Line data={elevReg} stroke={config.trend.color} dot={false} />
           </ScatterChart>
         </ChartContainer>


### PR DESCRIPTION
## Summary
- compute color index per data point in PerfVsEnvironmentMatrix
- add Cell components for color in PerfVsEnvironmentMatrix and examples
- color Pace vs Heart Rate scatter dots by heart-rate bucket
- apply the same coloring in example scatter chart

## Testing
- `npx vitest run` *(fails: Unexpected "export" in src/lib/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688c4cceb134832487fe08463cfd9984