### PR TITLE
Add reading stack split chart

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -1,0 +1,61 @@
+"use client"
+import {
+  ChartContainer,
+  PieChart,
+  Pie,
+  Cell,
+  ChartTooltip,
+} from "@/components/ui/chart"
+import type { ChartConfig } from "@/components/ui/chart"
+import ChartCard from "./ChartCard"
+import useReadingMediumTotals from "@/hooks/useReadingMediumTotals"
+import { Skeleton } from "@/components/ui/skeleton"
+
+const labels: Record<string, string> = {
+  phone: "Phone",
+  computer: "Computer",
+  tablet: "Tablet",
+  kindle: "Kindle",
+  real_book: "Real Book",
+  other: "Other",
+}
+
+export default function ReadingStackSplit() {
+  const data = useReadingMediumTotals()
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const config: ChartConfig = {
+    minutes: { label: "Minutes" },
+  }
+  data.forEach((d, i) => {
+    ;(config as any)[d.medium] = {
+      label: labels[d.medium],
+      color: `hsl(var(--chart-${i + 1}))`,
+    }
+  })
+
+  return (
+    <ChartCard title="Reading Stack Split" description="Time by device">
+      <ChartContainer config={config} className="h-64">
+        <PieChart width={200} height={160}>
+          <ChartTooltip />
+          <Pie
+            data={data}
+            dataKey="minutes"
+            nameKey="medium"
+            innerRadius={50}
+            outerRadius={70}
+            paddingAngle={4}
+            cornerRadius={8}
+            label={({ percent }) => `${Math.round(percent * 100)}%`}
+          >
+            {data.map((entry, idx) => (
+              <Cell key={entry.medium} fill={`hsl(var(--chart-${idx + 1}))`} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi, describe, it, expect } from 'vitest'
+import ReadingStackSplit from '../ReadingStackSplit'
+
+vi.mock('@/hooks/useReadingMediumTotals', () => ({
+  __esModule: true,
+  default: () => [
+    { medium: 'phone', minutes: 30 },
+    { medium: 'kindle', minutes: 60 },
+  ],
+}))
+
+describe('ReadingStackSplit', () => {
+  it('renders chart title', () => {
+    render(<ReadingStackSplit />)
+    expect(screen.getByText(/Reading Stack Split/)).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -17,4 +17,6 @@ export { default as CommuteRank } from "./CommuteRank";
 export { default as ReadingFocusHeatmap } from "./ReadingFocusHeatmap";
 
 export { default as BooksVsCalories } from "./BooksVsCalories";
+
+export { default as ReadingStackSplit } from "./ReadingStackSplit";
 >

--- a/src/hooks/__tests__/useReadingHeatmap.test.ts
+++ b/src/hooks/__tests__/useReadingHeatmap.test.ts
@@ -5,9 +5,24 @@ import type { ReadingSession } from '@/lib/api'
 describe('computeReadingHeatmap', () => {
   it('bins by hour and weekday', () => {
     const sessions: ReadingSession[] = [
-      { timestamp: '2025-07-28T10:00:00Z', intensity: 0.5 },
-      { timestamp: '2025-07-28T10:30:00Z', intensity: 0.7 },
-      { timestamp: '2025-07-29T11:00:00Z', intensity: 0.2 },
+      {
+        timestamp: '2025-07-28T10:00:00Z',
+        intensity: 0.5,
+        medium: 'phone',
+        duration: 30,
+      },
+      {
+        timestamp: '2025-07-28T10:30:00Z',
+        intensity: 0.7,
+        medium: 'phone',
+        duration: 15,
+      },
+      {
+        timestamp: '2025-07-29T11:00:00Z',
+        intensity: 0.2,
+        medium: 'kindle',
+        duration: 20,
+      },
     ]
     const result = computeReadingHeatmap(sessions)
     expect(result.length).toBe(168)

--- a/src/hooks/useReadingMediumTotals.ts
+++ b/src/hooks/useReadingMediumTotals.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { getReadingMediumTotals, type ReadingMediumTotal } from '@/lib/api'
+
+export default function useReadingMediumTotals(): ReadingMediumTotal[] | null {
+  const [data, setData] = useState<ReadingMediumTotal[] | null>(null)
+
+  useEffect(() => {
+    getReadingMediumTotals().then(setData)
+  }, [])
+
+  return data
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -814,15 +814,35 @@ export async function getReadingProbability(): Promise<ReadingProbabilityPoint[]
 
 // ----- Reading sessions -----
 
+export type ReadingMedium =
+  | 'phone'
+  | 'computer'
+  | 'tablet'
+  | 'kindle'
+  | 'real_book'
+  | 'other'
+
 export interface ReadingSession {
   /** ISO timestamp when reading occurred */
   timestamp: string
   /** Focus intensity from 0-1 */
   intensity: number
+  /** Device or medium used for the session */
+  medium: ReadingMedium
+  /** Duration of the session in minutes */
+  duration: number
 }
 
 export function generateMockReadingSessions(count = 60): ReadingSession[] {
   const sessions: ReadingSession[] = []
+  const mediums: ReadingMedium[] = [
+    'phone',
+    'computer',
+    'tablet',
+    'kindle',
+    'real_book',
+    'other',
+  ]
   for (let i = 0; i < count; i++) {
     const d = new Date()
     d.setDate(d.getDate() - Math.floor(Math.random() * 30))
@@ -830,6 +850,8 @@ export function generateMockReadingSessions(count = 60): ReadingSession[] {
     sessions.push({
       timestamp: d.toISOString(),
       intensity: +Math.random().toFixed(2),
+      medium: mediums[Math.floor(Math.random() * mediums.length)],
+      duration: Math.floor(5 + Math.random() * 55),
     })
   }
   return sessions
@@ -838,6 +860,40 @@ export function generateMockReadingSessions(count = 60): ReadingSession[] {
 export async function getReadingSessions(): Promise<ReadingSession[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(generateMockReadingSessions()), 200)
+  })
+}
+
+export interface ReadingMediumTotal {
+  medium: ReadingMedium
+  minutes: number
+}
+
+export function aggregateReadingMediumTotals(
+  sessions: ReadingSession[],
+): ReadingMediumTotal[] {
+  const totals: Record<ReadingMedium, number> = {
+    phone: 0,
+    computer: 0,
+    tablet: 0,
+    kindle: 0,
+    real_book: 0,
+    other: 0,
+  }
+  sessions.forEach((s) => {
+    totals[s.medium] += s.duration
+  })
+  return (Object.keys(totals) as ReadingMedium[]).map((m) => ({
+    medium: m,
+    minutes: totals[m],
+  }))
+}
+
+export async function getReadingMediumTotals(): Promise<ReadingMediumTotal[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const sessions = generateMockReadingSessions()
+      resolve(aggregateReadingMediumTotals(sessions))
+    }, 200)
   })
 }
 

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -26,6 +26,7 @@ import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironm
 
 import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
 import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilityTimeline";
+import ReadingStackSplit from "@/components/dashboard/ReadingStackSplit";
 
 
 export default function Examples() {
@@ -39,6 +40,7 @@ export default function Examples() {
 
       <WeeklyVolumeHistoryChart />
       <ReadingProbabilityTimeline />
+      <ReadingStackSplit />
 
       <TimeInBedChart />
 


### PR DESCRIPTION
## Summary
- add medium and duration to reading sessions
- provide API & hook for reading medium totals
- display breakdown in new `ReadingStackSplit` chart
- show chart on Examples page
- update heatmap tests for new session type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4ed0573c832495add8d79d1473e9