### PR TITLE
Adjust favicon appearance and theme sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard MVP</title>
-    <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)">
-    <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)">
+    <link id="favicon-light" rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)">
+    <link id="favicon-dark" rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)">
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon-dark.svg
+++ b/public/favicon-dark.svg
@@ -9,6 +9,6 @@
     text { font-family: 'Inter', sans-serif; font-weight: 600; }
   </style>
   <rect width="64" height="64" fill="#000000"/>
-  <text x="32" y="44" text-anchor="middle" fill="#ffffff" font-size="36">AJO</text>
+  <text x="32" y="44" text-anchor="middle" fill="#ffffff" font-size="30">AJO</text>
 </svg>
 

--- a/public/favicon-light.svg
+++ b/public/favicon-light.svg
@@ -9,6 +9,6 @@
     text { font-family: 'Inter', sans-serif; font-weight: 600; }
   </style>
   <rect width="64" height="64" fill="#ffffff"/>
-  <text x="32" y="44" text-anchor="middle" fill="#000000" font-size="36">AJO</text>
+  <text x="32" y="44" text-anchor="middle" fill="#000000" font-size="30">AJO</text>
 </svg>
 

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -4,12 +4,26 @@ import { Sun, Moon } from "lucide-react";
 export default function ThemeToggle() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
 
+  function updateFavicon(mode: "light" | "dark") {
+    const lightLink = document.getElementById("favicon-light") as HTMLLinkElement | null;
+    const darkLink = document.getElementById("favicon-dark") as HTMLLinkElement | null;
+    if (!lightLink || !darkLink) return;
+    if (mode === "dark") {
+      lightLink.media = "not all";
+      darkLink.media = "all";
+    } else {
+      lightLink.media = "all";
+      darkLink.media = "not all";
+    }
+  }
+
   useEffect(() => {
     const stored = localStorage.getItem("theme") as "light" | "dark" | null;
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
     const initial = stored || (prefersDark ? "dark" : "light");
     setTheme(initial);
     document.documentElement.classList.toggle("dark", initial === "dark");
+    updateFavicon(initial);
   }, []);
 
   function toggleTheme() {
@@ -17,6 +31,7 @@ export default function ThemeToggle() {
     setTheme(next);
     document.documentElement.classList.toggle("dark", next === "dark");
     localStorage.setItem("theme", next);
+    updateFavicon(next);
   }
 
   return (


### PR DESCRIPTION
## Summary
- shrink text in favicon SVGs for better readability
- assign IDs to favicon links
- update favicon dynamically when theme changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c500948988324830bdf25d2618379