### PR TITLE
Compute reading probability

### DIFF
--- a/src/components/dashboard/__tests__/ReadingProbabilityTimeline.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingProbabilityTimeline.test.tsx
@@ -1,18 +1,38 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, renderHook, waitFor } from "@testing-library/react"
 import ReadingProbabilityTimeline from "../ReadingProbabilityTimeline"
+import useReadingProbability from "@/hooks/useReadingProbability"
+import { getReadingSessions } from "@/lib/api"
 import { vi, describe, it, expect } from "vitest"
 import "@testing-library/jest-dom"
 
-vi.mock("@/hooks/useReadingProbability", () => ({
+vi.mock("@/lib/api", () => ({
   __esModule: true,
-  default: () => [
-    { time: "2025-07-30T00:00:00Z", probability: 0.5, intensity: 0.3 },
-  ],
+  getReadingSessions: vi.fn(),
 }))
 
 describe("ReadingProbabilityTimeline", () => {
-  it("renders chart title", () => {
+  it("renders chart title", async () => {
+    ;(getReadingSessions as any).mockResolvedValue([])
     render(<ReadingProbabilityTimeline />)
-    expect(screen.getByText(/Reading Probability/)).toBeInTheDocument()
+    expect(await screen.findByText(/Reading Probability/)).toBeInTheDocument()
+  })
+})
+
+describe("useReadingProbability", () => {
+  it("computes hourly percentages", async () => {
+    const sessions = [
+      { timestamp: "2025-07-30T00:15:00Z", intensity: 0.5 },
+      { timestamp: "2025-07-30T01:45:00Z", intensity: 0.7 },
+    ]
+    ;(getReadingSessions as any).mockResolvedValue(sessions)
+    const { result } = renderHook(() => useReadingProbability())
+    await waitFor(() => result.current !== null)
+    const data = result.current!
+    const h0 = data.find((d) => new Date(d.time).getHours() === 0)
+    const h1 = data.find((d) => new Date(d.time).getHours() === 1)
+    expect(h0?.probability).toBeCloseTo(0.5)
+    expect(h1?.probability).toBeCloseTo(0.5)
+    expect(h0?.intensity).toBeCloseTo(0.5)
+    expect(h1?.intensity).toBeCloseTo(0.7)
   })
 })

--- a/src/hooks/useReadingProbability.ts
+++ b/src/hooks/useReadingProbability.ts
@@ -1,11 +1,41 @@
 import { useEffect, useState } from 'react'
-import { getReadingProbability, type ReadingProbabilityPoint } from '@/lib/api'
+import {
+  getReadingSessions,
+  type ReadingSession,
+  type ReadingProbabilityPoint,
+} from '@/lib/api'
+
+export function computeReadingProbability(
+  sessions: ReadingSession[],
+): ReadingProbabilityPoint[] {
+  const bins = Array.from({ length: 24 }, () => ({ count: 0, total: 0 }))
+  for (const s of sessions) {
+    const d = new Date(s.timestamp)
+    const hour = d.getHours()
+    bins[hour].count += 1
+    bins[hour].total += s.intensity
+  }
+  const totalSessions = sessions.length
+  return bins.map((b, i) => {
+    const d = new Date()
+    d.setHours(i, 0, 0, 0)
+    const probability = totalSessions ? b.count / totalSessions : 0
+    const intensity = b.count ? b.total / b.count : 0
+    return {
+      time: d.toISOString(),
+      probability: +probability.toFixed(2),
+      intensity: +intensity.toFixed(2),
+    }
+  })
+}
 
 export default function useReadingProbability(): ReadingProbabilityPoint[] | null {
   const [data, setData] = useState<ReadingProbabilityPoint[] | null>(null)
 
   useEffect(() => {
-    getReadingProbability().then(setData)
+    getReadingSessions().then((sessions) =>
+      setData(computeReadingProbability(sessions)),
+    )
   }, [])
 
   return data


### PR DESCRIPTION
## Summary
- derive reading probability from reading sessions
- compute intensity per hour and probability for each session
- update timeline hook
- verify hourly percentage calculations in tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688c4f903b448324be0d0f70d48d8350