### PR TITLE
Add StateVisitCallout component

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -20,6 +20,7 @@ import {
 import { SimpleSelect } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import StateVisitSummary from "./StateVisitSummary";
+import StateVisitCallout from "./StateVisitCallout";
 
 import statesTopo from "../../../public/us-states.json";
 import CITY_COORDS from "@/lib/cityCoords";
@@ -172,7 +173,7 @@ export default function GeoActivityExplorer() {
       </div>
       <StateVisitSummary />
       <div className="flex gap-12">
-        <div className="w-80 h-60">
+        <div className="relative w-80 h-60">
           <Map
             mapLib={maplibregl}
             mapStyle="https://demotiles.maplibre.org/style.json"
@@ -248,6 +249,7 @@ export default function GeoActivityExplorer() {
             payload={legendPayload}
             content={<ChartLegendContent nameKey="value" hideIcon />}
           />
+          <StateVisitCallout />
         </div>
 
         <div className="flex-1">

--- a/src/components/map/StateVisitCallout.tsx
+++ b/src/components/map/StateVisitCallout.tsx
@@ -1,0 +1,31 @@
+import React, { useMemo } from "react";
+import { useStateVisits } from "@/hooks/useStateVisits";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function StateVisitCallout() {
+  const visits = useStateVisits();
+
+  const latest = useMemo(() => {
+    if (!visits) return null;
+    let entry: { date: string; type: string; miles: number; stateCode: string } | null = null;
+    visits.forEach((state) => {
+      state.log.forEach((l) => {
+        if (!entry || new Date(l.date) > new Date(entry.date)) {
+          entry = { ...l, stateCode: state.stateCode };
+        }
+      });
+    });
+    return entry;
+  }, [visits]);
+
+  if (!visits) return <Skeleton className="h-4 w-full" />;
+  if (!latest) return null;
+
+  const message = `Latest ${latest.type}: ${latest.miles}mi in ${latest.stateCode}`;
+
+  return (
+    <div className="absolute bottom-2 left-2 rounded bg-background/80 px-2 text-xs text-muted-foreground">
+      {message}
+    </div>
+  );
+}

--- a/src/components/map/__tests__/StateVisitCallout.test.tsx
+++ b/src/components/map/__tests__/StateVisitCallout.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import StateVisitCallout from "../StateVisitCallout";
+import { vi } from "vitest";
+import "@testing-library/jest-dom";
+
+vi.mock("@/hooks/useStateVisits", () => ({
+  useStateVisits: () => [
+    {
+      stateCode: "CA",
+      visited: true,
+      totalDays: 0,
+      totalMiles: 0,
+      cities: [],
+      log: [
+        { date: "2025-01-01", type: "run", miles: 5 },
+        { date: "2025-02-01", type: "bike", miles: 10 },
+      ],
+    },
+    {
+      stateCode: "TX",
+      visited: true,
+      totalDays: 0,
+      totalMiles: 0,
+      cities: [],
+      log: [
+        { date: "2024-12-31", type: "run", miles: 3 },
+      ],
+    },
+  ],
+}));
+
+describe("StateVisitCallout", () => {
+  it("shows latest activity", () => {
+    render(<div className="relative h-10"><StateVisitCallout /></div>);
+    expect(screen.getByText("Latest bike: 10mi in CA")).toBeInTheDocument();
+  });
+});

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -1,3 +1,4 @@
 export { default as GeoActivityExplorer } from './GeoActivityExplorer'
 export { default as LocationEfficiencyComparison } from './LocationEfficiencyComparison'
 export { default as StateVisitSummary } from './StateVisitSummary'
+export { default as StateVisitCallout } from './StateVisitCallout'


### PR DESCRIPTION
## Summary
- add `StateVisitCallout` component for latest state activity
- export new component from map index
- show callout in `GeoActivityExplorer`
- test new component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c534beabc8324975eb1f5662e493d