### PR TITLE
Implement hover tooltip for state map

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -30,6 +30,7 @@ export default function GeoActivityExplorer() {
   const data = useStateVisits();
   const [expandedState, setExpandedState] = useState<string | null>(null);
   const [selectedState, setSelectedState] = useState<string | null>(null);
+  const [hoveredState, setHoveredState] = useState<string | null>(null);
   const [activity, setActivity] = useState("all");
   const [range, setRange] = useState("year");
 
@@ -174,6 +175,7 @@ export default function GeoActivityExplorer() {
       <div className="flex gap-12">
         <div className="w-80 h-60">
           <Map
+            aria-label="state map"
             mapLib={maplibregl}
             mapStyle="https://demotiles.maplibre.org/style.json"
             initialViewState={{ longitude: -98, latitude: 38, zoom: 3 }}
@@ -183,6 +185,12 @@ export default function GeoActivityExplorer() {
               const f = e.features?.[0] as any
               if (f?.properties?.abbr) selectState(f.properties.abbr)
             }}
+            onMouseMove={(e: MapLayerMouseEvent) => {
+              const f = e.features?.[0] as any
+              if (f?.properties?.abbr) setHoveredState(f.properties.abbr)
+              else setHoveredState(null)
+            }}
+            onMouseLeave={() => setHoveredState(null)}
             style={{ width: "100%", height: "100%" }}
           >
             <Source id="states" type="geojson" data={statesGeo as any}>
@@ -225,6 +233,20 @@ export default function GeoActivityExplorer() {
                   </button>
                 </Marker>
               )
+            )}
+            {hoveredState && stateCoords[hoveredState] && (
+              <Popup
+                longitude={stateCoords[hoveredState][0]}
+                latitude={stateCoords[hoveredState][1]}
+                closeButton={false}
+                closeOnClick={false}
+                anchor="top"
+              >
+                <span className="flex gap-2 text-xs">
+                  <Badge>{summaryMap[hoveredState]?.totalDays ?? 0}d</Badge>
+                  <Badge>{summaryMap[hoveredState]?.totalMiles ?? 0}mi</Badge>
+                </span>
+              </Popup>
             )}
             {selectedState && stateCoords[selectedState] && (
               <Popup

--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -3,7 +3,9 @@ import GeoActivityExplorer from "../GeoActivityExplorer";
 import { vi } from "vitest";
 vi.mock("react-map-gl/maplibre", () => ({
   __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children, ...props }: any) => (
+    <div {...props}>{children}</div>
+  ),
   Source: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Layer: () => null,
   Marker: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -81,5 +83,16 @@ describe("GeoActivityExplorer", () => {
     fireEvent.click(state);
     expect(screen.getAllByText("1d").length).toBeGreaterThan(1);
     expect(screen.getAllByText("1mi").length).toBeGreaterThan(1);
+  });
+
+  it("shows tooltip on state hover", async () => {
+    render(<GeoActivityExplorer />);
+    const map = screen.getByLabelText("state map");
+    fireEvent.mouseMove(map, {
+      features: [{ properties: { abbr: "CA" } }],
+    } as any);
+    expect(screen.getByText("1d", { exact: true })).toBeInTheDocument();
+    expect(screen.getByText("1mi", { exact: true })).toBeInTheDocument();
+    fireEvent.mouseLeave(map);
   });
 });

--- a/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
+++ b/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
@@ -3,7 +3,7 @@ import LocationEfficiencyComparison from '../LocationEfficiencyComparison'
 import { vi } from 'vitest'
 vi.mock('react-map-gl/maplibre', () => ({
   __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   Source: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Layer: () => null,
   Marker: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,


### PR DESCRIPTION
## Summary
- show state visit totals when hovering US states
- create `state map` aria-label for easier testing
- forward props on mocked Map component in tests
- add test verifying tooltip on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c52f40b008324811a68a14a5aeee0