### PR TITLE
Fix Recharts warnings in tests

### DIFF
--- a/src/components/dashboard/__tests__/CommuteRank.test.tsx
+++ b/src/components/dashboard/__tests__/CommuteRank.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
+import React from 'react'
 import '@testing-library/jest-dom'
 import CommuteRank from '../CommuteRank'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    ),
+  }
+})
 
 vi.mock('@/hooks/useCommuteRank', () => ({
   __esModule: true,

--- a/src/components/dashboard/__tests__/ReadingFocusHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingFocusHeatmap.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
 import '@testing-library/jest-dom'
 import ReadingFocusHeatmap from '../ReadingFocusHeatmap'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
 
 vi.mock('@/hooks/useReadingHeatmap', () => ({
   __esModule: true,

--- a/src/components/dashboard/__tests__/ReadingProbabilityTimeline.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingProbabilityTimeline.test.tsx
@@ -3,7 +3,20 @@ import ReadingProbabilityTimeline from "../ReadingProbabilityTimeline"
 import useReadingProbability from "@/hooks/useReadingProbability"
 import { getReadingSessions } from "@/lib/api"
 import { vi, describe, it, expect } from "vitest"
+import React from "react"
 import "@testing-library/jest-dom"
+
+vi.mock("recharts", async () => {
+  const actual: any = await vi.importActual("recharts")
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    ),
+  }
+})
 
 vi.mock("@/lib/api", () => ({
   __esModule: true,

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { vi, describe, it, expect } from 'vitest'
+import React from 'react'
 import ReadingStackSplit from '../ReadingStackSplit'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
 
 vi.mock('@/hooks/useReadingMediumTotals', () => ({
   __esModule: true,

--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
 import GeoActivityExplorer from "../GeoActivityExplorer";
 import { vi } from "vitest";
 vi.mock("react-map-gl/maplibre", () => ({
@@ -10,6 +11,18 @@ vi.mock("react-map-gl/maplibre", () => ({
   Popup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 import "@testing-library/jest-dom";
+
+vi.mock("recharts", async () => {
+  const actual: any = await vi.importActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    ),
+  };
+});
 
 vi.mock("@/hooks/useStateVisits", () => ({
   useStateVisits: () => [

--- a/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
+++ b/src/components/map/__tests__/LocationEfficiencyComparison.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import LocationEfficiencyComparison from '../LocationEfficiencyComparison'
 import { vi } from 'vitest'
+import React from 'react'
 vi.mock('react-map-gl/maplibre', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -9,6 +10,18 @@ vi.mock('react-map-gl/maplibre', () => ({
   Marker: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 import '@testing-library/jest-dom'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
 
 vi.mock('@/hooks/useLocationEfficiency', () => ({
   __esModule: true,

--- a/src/components/statistics/__tests__/RouteComparison.test.tsx
+++ b/src/components/statistics/__tests__/RouteComparison.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen } from '@testing-library/react'
 import RouteComparison from '../RouteComparison'
 import { vi } from 'vitest'
+import React from 'react'
 import '@testing-library/jest-dom'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
 
 vi.mock('@/hooks/useRouteSessions', () => ({
   __esModule: true,

--- a/src/components/statistics/__tests__/RunBikeVolumeComparison.test.tsx
+++ b/src/components/statistics/__tests__/RunBikeVolumeComparison.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import RunBikeVolumeComparison from '../RunBikeVolumeComparison'
 import { vi } from 'vitest'
+import React from 'react'
 import '@testing-library/jest-dom'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
 
 vi.mock('@/hooks/useRunBikeVolume', () => ({
   __esModule: true,

--- a/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
+++ b/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
@@ -1,7 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import WeeklyComparisonChart from '../WeeklyComparisonChart'
 import { vi } from 'vitest'
+import React from 'react'
 import '@testing-library/jest-dom'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
 
 vi.mock('@/hooks/useWeeklyComparison', () => ({
   __esModule: true,


### PR DESCRIPTION
## Summary
- mock `ResponsiveContainer` in map, statistics, and dashboard tests so charts
  render with dimensions
- remove `width(0) height(0)` warnings during test runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c536520e48324b3a64d983db578cb