### PR TITLE
Integrate Open Meteo weather API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ use for reference areas.
 
 The mock implementation uses `generateMockRunningStats()` in `src/lib/api.ts` to
 create semi-random demo data each time the app loads. You can replace this
+
 function with real API calls for production data.
+`useCurrentWeather(lat, lon)` resolves to:
+```ts
+{ temperature: number; condition: string }
+```
+
 
 `useInsights()` resolves to:
 

--- a/src/hooks/useCurrentWeather.ts
+++ b/src/hooks/useCurrentWeather.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+import { getCurrentWeather, type CurrentWeather } from '@/lib/weather'
+
+export function useCurrentWeather(lat: number, lon: number): CurrentWeather | null {
+  const [data, setData] = useState<CurrentWeather | null>(null)
+  useEffect(() => {
+    getCurrentWeather(lat, lon)
+      .then(setData)
+      .catch(() => {})
+  }, [lat, lon])
+  return data
+}

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1,0 +1,33 @@
+export interface CurrentWeather {
+  temperature: number
+  condition: string
+}
+
+function mapWeatherCode(code: number): string {
+  if (code === 0) return 'Clear'
+  if (code >= 1 && code <= 3) return 'Cloudy'
+  if (code === 45 || code === 48) return 'Fog'
+  if (code >= 51 && code <= 57) return 'Drizzle'
+  if (code >= 61 && code <= 67) return 'Rain'
+  if (code >= 71 && code <= 77) return 'Snow'
+  if (code >= 80 && code <= 82) return 'Rain'
+  if (code >= 95) return 'Storm'
+  return 'Unknown'
+}
+
+export async function getCurrentWeather(
+  lat: number,
+  lon: number,
+): Promise<CurrentWeather> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true`
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error('Failed to fetch weather')
+  }
+  const data = await res.json()
+  const cw = data.current_weather
+  return {
+    temperature: cw.temperature,
+    condition: mapWeatherCode(cw.weathercode),
+  }
+}


### PR DESCRIPTION
## Summary
- add `getCurrentWeather` helper to call open-meteo
- expose a new `useCurrentWeather` hook
- document the hook in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c52d719888324a47f518906071cc4