### PR TITLE
Add Run Soundtrack feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,14 @@ npm run dev
 npm run build
 npm test
 ```
+
+## Spotify integration
+The Run Soundtrack card uses the Spotify Web API. Set the following environment variables so the helpers can obtain an access token:
+
+```
+SPOTIFY_CLIENT_ID=<your client id>
+SPOTIFY_CLIENT_SECRET=<your client secret>
+SPOTIFY_REFRESH_TOKEN=<refresh token>
+```
+
+Alternatively provide `SPOTIFY_ACCESS_TOKEN` directly if you already have one. These values are read at runtime by `src/lib/spotify.ts`.

--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import useRunSoundtrack from '@/hooks/useRunSoundtrack'
+
+export default function RunSoundtrackCard() {
+  const data = useRunSoundtrack()
+
+  if (!data) return <Skeleton className="h-32" />
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Run Soundtrack</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {data.nowPlaying && (
+          <div className="text-sm">
+            <p className="font-medium">Now Playing</p>
+            <p>{data.nowPlaying.item.name} –{' '}{data.nowPlaying.item.artists.map((a: any) => a.name).join(', ')}</p>
+          </div>
+        )}
+        <div>
+          <p className="font-medium text-sm">Top Tracks</p>
+          <ol className="mt-1 space-y-1 text-sm list-decimal list-inside">
+            {data.topTracks.map((t) => (
+              <li key={t.id}>
+                {t.name} – {t.artists} ({t.playCount}x)
+              </li>
+            ))}
+          </ol>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
+++ b/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+import RunSoundtrackCard from '../RunSoundtrackCard'
+
+vi.mock('@/hooks/useRunSoundtrack', () => ({
+  __esModule: true,
+  default: () => ({
+    window: { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:40:00Z' },
+    nowPlaying: { item: { name: 'Song A', artists: [{ name: 'Artist' }] } },
+    topTracks: [
+      { id: '1', name: 'Song A', artists: 'Artist', uri: 'x', playCount: 2 },
+      { id: '2', name: 'Song B', artists: 'Other', uri: 'y', playCount: 1 },
+    ],
+  }),
+}))
+
+describe('RunSoundtrackCard', () => {
+  it('renders now playing and top tracks', () => {
+    render(<RunSoundtrackCard />)
+    expect(screen.getByText('Now Playing')).toBeInTheDocument()
+    expect(screen.getAllByText(/Song A/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/Song B/)).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -19,4 +19,4 @@ export { default as ReadingFocusHeatmap } from "./ReadingFocusHeatmap";
 export { default as BooksVsCalories } from "./BooksVsCalories";
 
 export { default as ReadingStackSplit } from "./ReadingStackSplit";
->
+export { default as RunSoundtrackCard } from './RunSoundtrackCard'

--- a/src/hooks/useRunSoundtrack.ts
+++ b/src/hooks/useRunSoundtrack.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import { getLatestRun, type RunWindow } from '@/lib/api'
+import {
+  getSpotifyRecentPlays,
+  getSpotifyNowPlaying,
+  getAudioFeatures,
+  type SpotifyTrack,
+} from '@/lib/spotify'
+
+export interface RunTrack extends SpotifyTrack {
+  playCount: number
+  tempo?: number | null
+}
+
+export interface RunSoundtrackState {
+  window: RunWindow
+  nowPlaying: any | null
+  topTracks: RunTrack[]
+}
+
+export default function useRunSoundtrack(): RunSoundtrackState | null {
+  const [state, setState] = useState<RunSoundtrackState | null>(null)
+
+  useEffect(() => {
+    let active = true
+    async function fetchData() {
+      const window = await getLatestRun()
+      const [recent, now] = await Promise.all([
+        getSpotifyRecentPlays(),
+        getSpotifyNowPlaying(),
+      ])
+      const start = new Date(window.start).getTime()
+      const end = new Date(window.end).getTime()
+      const plays = recent.items.filter((p: any) => {
+        const t = new Date(p.played_at).getTime()
+        return t >= start && t <= end
+      })
+      const counts: Record<string, { track: any; count: number }> = {}
+      plays.forEach((p: any) => {
+        const id = p.track.id
+        if (!counts[id]) counts[id] = { track: p.track, count: 0 }
+        counts[id].count++
+      })
+      const top = Object.values(counts)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 5)
+
+      const withFeatures: RunTrack[] = []
+      for (const item of top) {
+        let tempo: number | null = null
+        try {
+          const features = await getAudioFeatures(item.track.id)
+          tempo = features?.tempo ?? null
+        } catch {}
+        withFeatures.push({
+          id: item.track.id,
+          name: item.track.name,
+          artists: item.track.artists.map((a: any) => a.name).join(', '),
+          uri: item.track.uri,
+          playCount: item.count,
+          tempo,
+        })
+      }
+
+      if (active) {
+        setState({ window, nowPlaying: now?.item ?? null, topTracks: withFeatures })
+      }
+    }
+    fetchData()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return state
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -916,3 +916,18 @@ export async function getReadingProgress(): Promise<ReadingProgress> {
 
   })
 }
+
+// ----- Recent run window -----
+export interface RunWindow {
+  start: string
+  end: string
+}
+
+export async function getLatestRun(): Promise<RunWindow> {
+  return new Promise((resolve) => {
+    const end = new Date()
+    const duration = 30 + Math.floor(Math.random() * 30)
+    const start = new Date(end.getTime() - duration * 60000)
+    setTimeout(() => resolve({ start: start.toISOString(), end: end.toISOString() }), 100)
+  })
+}

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,0 +1,85 @@
+export interface SpotifyTrack {
+  id: string
+  name: string
+  artists: string
+  uri: string
+}
+
+let accessToken: string | null = null
+let tokenExpiry = 0
+
+async function refreshAccessToken(): Promise<string> {
+  if (process.env.SPOTIFY_ACCESS_TOKEN) {
+    accessToken = process.env.SPOTIFY_ACCESS_TOKEN
+    tokenExpiry = Date.now() + 3600_000
+    return accessToken
+  }
+
+  const refresh = process.env.SPOTIFY_REFRESH_TOKEN
+  const id = process.env.SPOTIFY_CLIENT_ID
+  const secret = process.env.SPOTIFY_CLIENT_SECRET
+
+  if (!refresh || !id || !secret) {
+    accessToken = 'mock-token'
+    tokenExpiry = Date.now() + 3600_000
+    return accessToken
+  }
+
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      Authorization:
+        'Basic ' + Buffer.from(`${id}:${secret}`).toString('base64'),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refresh,
+    }),
+  })
+  const data = (await res.json()) as { access_token: string; expires_in: number }
+  accessToken = data.access_token
+  tokenExpiry = Date.now() + data.expires_in * 1000
+  return accessToken
+}
+
+async function ensureToken() {
+  if (!accessToken || Date.now() >= tokenExpiry) {
+    await refreshAccessToken()
+  }
+}
+
+async function fetchSpotify<T>(endpoint: string): Promise<T> {
+  await ensureToken()
+  const res = await fetch(`https://api.spotify.com/v1${endpoint}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+  if (!res.ok) throw new Error('Spotify request failed')
+  return res.json() as Promise<T>
+}
+
+export async function getSpotifyRecentPlays(limit = 50) {
+  type Response = { items: { track: any; played_at: string }[] }
+  return fetchSpotify<Response>(
+    `/me/player/recently-played?limit=${limit}`,
+  )
+}
+
+export async function getSpotifyNowPlaying() {
+  try {
+    return fetchSpotify<any>('/me/player/currently-playing')
+  } catch {
+    return null
+  }
+}
+
+export async function getAudioFeatures(trackId: string) {
+  return fetchSpotify<any>(`/audio-features/${trackId}`)
+}
+
+export function setSpotifyAccessToken(token: string, expiresIn = 3600) {
+  accessToken = token
+  tokenExpiry = Date.now() + expiresIn * 1000
+}


### PR DESCRIPTION
## Summary
- add Spotify helper library with token handling
- expose `getLatestRun()` mock in API
- create `useRunSoundtrack` hook for computing run playlist
- show soundtrack info in new `RunSoundtrackCard` component
- export card from dashboard index
- document Spotify setup in README
- test `RunSoundtrackCard` rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c54817fe083249fd8086940468e90