### PR TITLE
Return raw reading probability values

### DIFF
--- a/src/hooks/useReadingProbability.ts
+++ b/src/hooks/useReadingProbability.ts
@@ -23,8 +23,8 @@ export function computeReadingProbability(
     const intensity = b.count ? b.total / b.count : 0
     return {
       time: d.toISOString(),
-      probability: +probability.toFixed(2),
-      intensity: +intensity.toFixed(2),
+      probability,
+      intensity,
     }
   })
 }


### PR DESCRIPTION
## Summary
- compute reading probability without rounding
- keep chart formatting via existing tooltip and axis formatters

## Testing
- `npm test` *(fails: GeoActivityExplorer.test.tsx missing EOF)*

------
https://chatgpt.com/codex/tasks/task_e_688c9544b1dc832489001a38c116cdcc