### PR TITLE
Add legend to ReadingStackSplit chart

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -1,15 +1,17 @@
-"use client"
+"use client";
 import {
   ChartContainer,
   PieChart,
   Pie,
   ChartTooltip,
-} from "@/components/ui/chart"
-import { Cell } from "recharts"
-import type { ChartConfig } from "@/components/ui/chart"
-import ChartCard from "./ChartCard"
-import useReadingMediumTotals from "@/hooks/useReadingMediumTotals"
-import { Skeleton } from "@/components/ui/skeleton"
+  ChartLegend,
+  ChartLegendContent,
+} from "@/components/ui/chart";
+import { Cell } from "recharts";
+import type { ChartConfig } from "@/components/ui/chart";
+import ChartCard from "./ChartCard";
+import useReadingMediumTotals from "@/hooks/useReadingMediumTotals";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const labels: Record<string, string> = {
   phone: "Phone",
@@ -18,28 +20,33 @@ const labels: Record<string, string> = {
   kindle: "Kindle",
   real_book: "Real Book",
   other: "Other",
-}
+};
 
 export default function ReadingStackSplit() {
-  const data = useReadingMediumTotals()
+  const data = useReadingMediumTotals();
 
-  if (!data) return <Skeleton className="h-64" />
+  if (!data) return <Skeleton className="h-64" />;
 
   const config: ChartConfig = {
     minutes: { label: "Minutes" },
-  }
+  };
   data.forEach((d, i) => {
-    ;(config as any)[d.medium] = {
+    (config as any)[d.medium] = {
       label: labels[d.medium],
       color: `hsl(var(--chart-${i + 1}))`,
-    }
-  })
+    };
+  });
 
   return (
     <ChartCard title="Reading Stack Split" description="Time by device">
       <ChartContainer config={config} className="h-64">
         <PieChart width={200} height={160}>
           <ChartTooltip />
+          <ChartLegend
+            content={<ChartLegendContent />}
+            verticalAlign="bottom"
+            height={24}
+          />
           <Pie
             data={data}
             dataKey="minutes"
@@ -57,5 +64,5 @@ export default function ReadingStackSplit() {
         </PieChart>
       </ChartContainer>
     </ChartCard>
-  )
+  );
 }

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -1,32 +1,34 @@
-import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom'
-import { vi, describe, it, expect } from 'vitest'
-import React from 'react'
-import ReadingStackSplit from '../ReadingStackSplit'
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi, describe, it, expect } from "vitest";
+import React from "react";
+import ReadingStackSplit from "../ReadingStackSplit";
 
-vi.mock('recharts', async () => {
-  const actual: any = await vi.importActual('recharts')
+vi.mock("recharts", async () => {
+  const actual: any = await vi.importActual("recharts");
   return {
     ...actual,
     ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
       <div style={{ width: 800, height: 400 }}>
         {React.cloneElement(children, { width: 800, height: 400 })}
       </div>
-    )
-  }
-})
+    ),
+  };
+});
 
-vi.mock('@/hooks/useReadingMediumTotals', () => ({
+vi.mock("@/hooks/useReadingMediumTotals", () => ({
   __esModule: true,
   default: () => [
-    { medium: 'phone', minutes: 30 },
-    { medium: 'kindle', minutes: 60 },
+    { medium: "phone", minutes: 30 },
+    { medium: "kindle", minutes: 60 },
   ],
-}))
+}));
 
-describe('ReadingStackSplit', () => {
-  it('renders chart title', () => {
-    render(<ReadingStackSplit />)
-    expect(screen.getByText(/Reading Stack Split/)).toBeInTheDocument()
-  })
-})
+describe("ReadingStackSplit", () => {
+  it("renders chart title", () => {
+    render(<ReadingStackSplit />);
+    expect(screen.getByText(/Reading Stack Split/)).toBeInTheDocument();
+    expect(screen.getByText("Phone")).toBeInTheDocument();
+    expect(screen.getByText("Kindle")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show pie chart legend for reading mediums
- check legend labels in ReadingStackSplit test

## Testing
- `npx vitest run --silent` *(fails: GeoActivityExplorer.test.tsx unexpected end of file)*

------
https://chatgpt.com/codex/tasks/task_e_688c9481bb6c8324a33b948a77f67744