### PR TITLE
Fix ReadingProbabilityTimeline tooltip percentages

### DIFF
--- a/src/components/dashboard/ReadingProbabilityTimeline.tsx
+++ b/src/components/dashboard/ReadingProbabilityTimeline.tsx
@@ -43,12 +43,11 @@ export default function ReadingProbabilityTimeline() {
     const end = new Date(start);
     end.setHours(end.getHours() + 1);
     const range = `${start.toLocaleTimeString([], { hour: "numeric" })}–${end.toLocaleTimeString([], { hour: "numeric" })}`;
-    const prob = (payload.find((p) => p.dataKey === "probability")?.value as number) || 0;
     return (
       <ChartTooltipContent
         {...(props as any)}
         nameKey="probability"
-        formatter={() => `${Math.round(prob * 100)}%`}
+        formatter={(value) => `${Math.round((value as number) * 100)}%`}
         labelFormatter={() => range}
       />
     );


### PR DESCRIPTION
## Summary
- fix ReadingTooltip to use formatter argument for percentage display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c9bcac4f0832491d95c127346016a