### PR TITLE
Improve ReadingStackSplit chart

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -8,6 +8,8 @@ import {
   ChartLegendContent,
 } from "@/components/ui/chart";
 import { Cell } from "recharts";
+
+// We'll display a total minutes label inside the donut chart
 import type { ChartConfig } from "@/components/ui/chart";
 import ChartCard from "./ChartCard";
 import useReadingMediumTotals from "@/hooks/useReadingMediumTotals";
@@ -27,6 +29,8 @@ export default function ReadingStackSplit() {
 
   if (!data) return <Skeleton className="h-64" />;
 
+  const totalMinutes = data.reduce((sum, d) => sum + d.minutes, 0);
+
   const config: ChartConfig = {
     minutes: { label: "Minutes" },
   };
@@ -40,28 +44,35 @@ export default function ReadingStackSplit() {
   return (
     <ChartCard title="Reading Stack Split" description="Time by device">
       <ChartContainer config={config} className="h-64">
-        <PieChart width={200} height={160}>
-          <ChartTooltip />
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign="bottom"
-            height={24}
-          />
-          <Pie
-            data={data}
-            dataKey="minutes"
-            nameKey="medium"
-            innerRadius={50}
-            outerRadius={70}
-            paddingAngle={4}
-            cornerRadius={8}
-            label={({ percent }) => `${Math.round(percent * 100)}%`}
-          >
-            {data.map((entry, idx) => (
-              <Cell key={entry.medium} fill={`hsl(var(--chart-${idx + 1}))`} />
-            ))}
-          </Pie>
-        </PieChart>
+        <div className="relative h-full w-full">
+          <PieChart width={200} height={160}>
+            <ChartTooltip />
+            <ChartLegend
+              content={<ChartLegendContent />}
+              verticalAlign="bottom"
+              height={24}
+            />
+            <Pie
+              data={data}
+              dataKey="minutes"
+              nameKey="medium"
+              innerRadius={50}
+              outerRadius={70}
+              paddingAngle={4}
+              cornerRadius={8}
+              label={({ percent }) => `${Math.round(percent * 100)}%`}
+            >
+              {data.map((entry, idx) => (
+                <Cell key={entry.medium} fill={`hsl(var(--chart-${idx + 1}))`} />
+              ))}
+            </Pie>
+          </PieChart>
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="text-sm font-semibold">
+              {totalMinutes.toLocaleString()} <span className="text-muted-foreground">min</span>
+            </div>
+          </div>
+        </div>
       </ChartContainer>
     </ChartCard>
   );


### PR DESCRIPTION
## Summary
- show total reading minutes in the center of the donut chart
- wrap chart markup in a relative container so overlay text can sit above the chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c99aeb9a083249abcd8272a4223e2