### PR TITLE
Fix scatter chart colors

### DIFF
--- a/src/components/statistics/PaceVsHR.tsx
+++ b/src/components/statistics/PaceVsHR.tsx
@@ -19,13 +19,13 @@ const scatterData = Array.from({ length: 200 }, () => {
   return {
     pace,
     hr,
-    fill: `var(--chart-${zone + 5})`,
+    fill: `hsl(var(--chart-${zone + 5}))`,
   }
 })
 
 const config = {
-  pace: { label: "Pace", color: "var(--chart-9)" },
-  hr: { label: "Heart Rate", color: "var(--chart-10)" },
+  pace: { label: "Pace", color: "hsl(var(--chart-9))" },
+  hr: { label: "Heart Rate", color: "hsl(var(--chart-10))" },
 } satisfies Record<string, unknown>
 
 export default function PaceVsHR() {

--- a/src/components/statistics/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/statistics/PerfVsEnvironmentMatrix.tsx
@@ -33,7 +33,7 @@ function mapPoint(pace: number, temperature: number, humidity: number, wind: num
     humidity,
     wind,
     elevation,
-    fill: `var(--chart-${colorIndex + 5})`,
+    fill: `hsl(var(--chart-${colorIndex + 5}))`,
   }
 }
 
@@ -72,8 +72,8 @@ export default function PerfVsEnvironmentMatrix() {
   }, [stats])
 
   const config = {
-    pace: { label: "Pace", color: "var(--chart-8)" },
-    trend: { label: "Trend", color: "var(--chart-3)" },
+    pace: { label: "Pace", color: "hsl(var(--chart-8))" },
+    trend: { label: "Trend", color: "hsl(var(--chart-3))" },
   } as const
 
   const tempReg = regression(DATA, "temperature", "pace")


### PR DESCRIPTION
## Summary
- wrap CSS variables with `hsl()` when assigning colors in statistics scatter charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c5746b1c4832483412e362dd02888