### PR TITLE
Add WildNextGameCard to Examples page

### DIFF
--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -27,6 +27,7 @@ import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironm
 import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
 import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilityTimeline";
 import ReadingStackSplit from "@/components/dashboard/ReadingStackSplit";
+import WildNextGameCard from "@/components/dashboard/WildNextGameCard";
 
 
 export default function Examples() {
@@ -70,6 +71,8 @@ export default function Examples() {
 
       <ScatterChartPaceHeartRate />
       <AreaChartLoadRatio />
+
+      <WildNextGameCard />
 
     </div>
   );


### PR DESCRIPTION
## Summary
- expose Minnesota Wild card on the examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ca0abe3548324be607522aab0c9c2