### PR TITLE
Add Wild schedule mock API

### DIFF
--- a/src/hooks/useWildSchedule.ts
+++ b/src/hooks/useWildSchedule.ts
@@ -1,15 +1,12 @@
-import useSWR from 'swr'
-
-export interface WildGame {
-  gameDate: string
-  opponent: string
-  home: boolean
-  [key: string]: any
-}
-
-const fetcher = (url: string) => fetch(url).then((res) => res.json())
+import { useState, useEffect } from 'react'
+import { getWildSchedule, type WildGame } from '@/lib/api'
 
 export default function useWildSchedule(limit = 1) {
-  const { data } = useSWR<WildGame[]>(`/api/nhl/schedule?limit=${limit}`, fetcher)
-  return data ?? null
+  const [data, setData] = useState<WildGame[] | null>(null)
+
+  useEffect(() => {
+    getWildSchedule(limit).then(setData)
+  }, [limit])
+
+  return data
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -955,6 +955,28 @@ export async function getReadingProgress(): Promise<ReadingProgress> {
   })
 }
 
+// ----- Wild schedule -----
+export interface WildGame {
+  gameDate: string
+  opponent: string
+  home: boolean
+  [key: string]: any
+}
+
+export const mockWildSchedule: WildGame[] = [
+  { gameDate: '2025-10-01T00:00:00Z', opponent: 'Blues', home: true },
+  { gameDate: '2025-10-03T00:00:00Z', opponent: 'Blackhawks', home: false },
+  { gameDate: '2025-10-05T00:00:00Z', opponent: 'Avalanche', home: true },
+]
+
+export async function getWildSchedule(
+  limit = 1,
+): Promise<WildGame[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockWildSchedule.slice(0, limit)), 200)
+  })
+}
+
 // ----- Recent run window -----
 export interface RunWindow {
   start: string


### PR DESCRIPTION
## Summary
- add `WildGame` type and schedule mocks to api lib
- add `getWildSchedule` helper
- update `useWildSchedule` hook to use the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cac674e4483248c53b393986fc32c