### PR TITLE
Replace SWR schedule fetch

### DIFF
--- a/src/hooks/useWildSchedule.ts
+++ b/src/hooks/useWildSchedule.ts
@@ -1,15 +1,18 @@
-import useSWR from 'swr'
-
-export interface WildGame {
-  gameDate: string
-  opponent: string
-  home: boolean
-  [key: string]: any
-}
-
-const fetcher = (url: string) => fetch(url).then((res) => res.json())
+import { useEffect, useState } from 'react'
+import { getWildSchedule, type WildGame } from '@/lib/api'
 
 export default function useWildSchedule(limit = 1) {
-  const { data } = useSWR<WildGame[]>(`/api/nhl/schedule?limit=${limit}`, fetcher)
-  return data ?? null
+  const [data, setData] = useState<WildGame[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getWildSchedule(limit).then((res) => {
+      if (!cancelled) setData(res)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [limit])
+
+  return data
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -969,3 +969,22 @@ export async function getLatestRun(): Promise<RunWindow> {
     setTimeout(() => resolve({ start: start.toISOString(), end: end.toISOString() }), 100)
   })
 }
+
+// ----- Wild schedule -----
+export interface WildGame {
+  gameDate: string
+  opponent: string
+  home: boolean
+}
+
+const mockWildSchedule: WildGame[] = [
+  { gameDate: '2025-10-01T00:00:00Z', opponent: 'Blues', home: true },
+  { gameDate: '2025-10-04T00:00:00Z', opponent: 'Stars', home: false },
+  { gameDate: '2025-10-07T00:00:00Z', opponent: 'Jets', home: true },
+]
+
+export async function getWildSchedule(limit = mockWildSchedule.length): Promise<WildGame[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockWildSchedule.slice(0, limit)), 100)
+  })
+}


### PR DESCRIPTION
## Summary
- fetch the Wild schedule directly using a React effect
- expose `getWildSchedule` helper with mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cac6abd7483248bdf46c19cba28f6