### PR TITLE
Add reference zone to AC ratio chart

### DIFF
--- a/src/components/examples/AreaChartLoadRatio.tsx
+++ b/src/components/examples/AreaChartLoadRatio.tsx
@@ -11,6 +11,8 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
   ChartTooltipContent,
+  ReferenceArea,
+  ReferenceLine,
 } from '@/components/ui/chart'
 import {
   Card,
@@ -53,6 +55,14 @@ export default function AreaChartLoadRatio() {
               tickFormatter={(d) => new Date(d).toLocaleDateString()}
             />
             <YAxis domain={[0, 2]} />
+            <ReferenceArea
+              y1={0.8}
+              y2={1.3}
+              strokeOpacity={0}
+              fill='var(--color-ratio)'
+              fillOpacity={0.1}
+            />
+            <ReferenceLine y={1} stroke='var(--color-ratio)' strokeDasharray='4 4' />
             <ChartTooltip
               content={
                 <ChartTooltipContent


### PR DESCRIPTION
## Summary
- update AreaChartLoadRatio example
- shade the 0.8–1.3 safe zone with `ReferenceArea`
- draw a target line at AC ratio 1

## Testing
- `npx vitest run` *(fails: mockWildSchedule already declared)*

------
https://chatgpt.com/codex/tasks/task_e_688cae59f258832481b282de37c7852d