### PR TITLE
Fix duplicated exports and clean test

### DIFF
--- a/src/components/examples/__tests__/PieChartDonut.test.tsx
+++ b/src/components/examples/__tests__/PieChartDonut.test.tsx
@@ -40,15 +40,3 @@ describe("PieChartDonut", () => {
     expect(paths.length).toBeGreaterThan(0)
   })
 })
-=======
-import { render, screen } from "@testing-library/react";
-import PieChartDonut from "../PieChartDonut";
-import "@testing-library/jest-dom";
-
-describe("PieChartDonut", () => {
-  it("renders chart title", () => {
-    render(<PieChartDonut />);
-    expect(screen.getByText(/Pie Chart - Donut/)).toBeInTheDocument();
-  });
-});
-

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -991,22 +991,3 @@ export async function getLatestRun(): Promise<RunWindow> {
     setTimeout(() => resolve({ start: start.toISOString(), end: end.toISOString() }), 100)
   })
 }
-
-// ----- Wild schedule -----
-export interface WildGame {
-  gameDate: string
-  opponent: string
-  home: boolean
-}
-
-const mockWildSchedule: WildGame[] = [
-  { gameDate: '2025-10-01T00:00:00Z', opponent: 'Blues', home: true },
-  { gameDate: '2025-10-04T00:00:00Z', opponent: 'Stars', home: false },
-  { gameDate: '2025-10-07T00:00:00Z', opponent: 'Jets', home: true },
-]
-
-export async function getWildSchedule(limit = mockWildSchedule.length): Promise<WildGame[]> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(mockWildSchedule.slice(0, limit)), 100)
-  })
-}


### PR DESCRIPTION
## Summary
- remove duplicate `getWildSchedule` implementation in `api.ts`
- clean merge markers from `PieChartDonut.test.tsx`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688cae556f14832485b11a45440a6fde