### PR TITLE
Add last-year data to weekly comparison chart

### DIFF
--- a/src/components/statistics/WeeklyComparisonChart.tsx
+++ b/src/components/statistics/WeeklyComparisonChart.tsx
@@ -27,11 +27,25 @@ export default function WeeklyComparisonChart({
     date: p.date,
     current: p.value,
     previous: data.previous[i]?.value ?? null,
+    lastYear: data.lastYear[i]?.value ?? null,
   }))
+
+  const totals = {
+    current: data.current.reduce((sum, p) => sum + p.value, 0),
+    previous: data.previous.reduce((sum, p) => sum + p.value, 0),
+    lastYear: data.lastYear.reduce((sum, p) => sum + p.value, 0),
+  }
+
+  const lastYearYear = data.lastYear.length
+    ? new Date(data.lastYear[0].date).getFullYear()
+    : new Date().getFullYear() - 1
+
+  const diff = totals.current - totals.lastYear
 
   const config = {
     current: { label: 'This Week', color: 'var(--chart-1)' },
     previous: { label: 'Last Week', color: 'var(--chart-2)' },
+    lastYear: { label: 'Same Week Last Year', color: 'var(--chart-3)' },
   } as const
 
   return (
@@ -47,8 +61,12 @@ export default function WeeklyComparisonChart({
           <ChartLegend content={<ChartLegendContent />} />
           <Line type="monotone" dataKey="current" stroke={config.current.color} dot={false} />
           <Line type="monotone" dataKey="previous" stroke={config.previous.color} dot={false} strokeOpacity={0.5} />
+          <Line type="monotone" dataKey="lastYear" stroke={config.lastYear.color} dot={false} strokeOpacity={0.5} />
         </LineChart>
       </ChartContainer>
+      <p className="mt-2 text-center text-xs text-muted-foreground">
+        You're {Math.abs(diff).toFixed(0)} miles {diff >= 0 ? 'ahead of' : 'behind'} {lastYearYear}-you.
+      </p>
     </ChartCard>
   )
 }

--- a/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
+++ b/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
@@ -27,7 +27,10 @@ vi.mock('@/hooks/useWeeklyComparison', () => ({
       { date: '2025-06-24', value: 8 },
       { date: '2025-06-25', value: 9 },
     ],
-    lastYear: [],
+    lastYear: [
+      { date: '2024-07-03', value: 6 },
+      { date: '2024-07-04', value: 7 },
+    ],
   }),
 }))
 
@@ -39,13 +42,15 @@ beforeAll(() => {
 })
 
 describe('WeeklyComparisonChart', () => {
-  it('shows both series and tooltip labels', () => {
+  it('shows all series and summary text', () => {
     render(<WeeklyComparisonChart metric="steps" />)
     expect(screen.getByText('This Week')).toBeInTheDocument()
     expect(screen.getByText('Last Week')).toBeInTheDocument()
+    expect(screen.getByText('Same Week Last Year')).toBeInTheDocument()
     const lines = document.querySelectorAll('path[stroke^="var(--chart-"]')
-    expect(lines.length).toBeGreaterThanOrEqual(2)
-    expect(screen.getByText('This Week')).toBeInTheDocument()
-    expect(screen.getByText('Last Week')).toBeInTheDocument()
+    expect(lines.length).toBeGreaterThanOrEqual(3)
+    expect(
+      screen.getByText("You're 9 miles ahead of 2024-you.")
+    ).toBeInTheDocument()
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -992,21 +992,3 @@ export async function getLatestRun(): Promise<RunWindow> {
   })
 }
 
-// ----- Wild schedule -----
-export interface WildGame {
-  gameDate: string
-  opponent: string
-  home: boolean
-}
-
-const mockWildSchedule: WildGame[] = [
-  { gameDate: '2025-10-01T00:00:00Z', opponent: 'Blues', home: true },
-  { gameDate: '2025-10-04T00:00:00Z', opponent: 'Stars', home: false },
-  { gameDate: '2025-10-07T00:00:00Z', opponent: 'Jets', home: true },
-]
-
-export async function getWildSchedule(limit = mockWildSchedule.length): Promise<WildGame[]> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(mockWildSchedule.slice(0, limit)), 100)
-  })
-}


### PR DESCRIPTION
## Summary
- include last year series in weekly comparison chart
- show weekly total difference from last year
- differentiate all three series in legend and tooltip
- update unit test for extra series
- remove duplicate Wild schedule mock to keep tests passing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb081c2e883249d7a6f31bcaa5ccb