### PR TITLE
Add BedToRunGauge component and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can re
 ### Examples page
 `src/pages/Examples.tsx` shows sample charts. It now renders an interactive area chart with a time-range select next to the bar chart demos.
 
+### BedToRunGauge
+Visualise how many hours of running or cycling you log for each hour spent in bed.
+
+```tsx
+import { BedToRunGauge } from '@/components/dashboard'
+
+<BedToRunGauge />
+```
+
 ## Theming extensions
 If you need new variants—like a "danger" button or a "success" badge—run `pnpm dlx shadcn-ui@latest add button` to scaffold the base component. Then copy or edit `src/components/ui/button.tsx` and register your variant in `tailwind.config.js` under `theme.extend`. See <https://ui.shadcn.com/docs/components> for more details.
 

--- a/src/components/dashboard/BedToRunGauge.tsx
+++ b/src/components/dashboard/BedToRunGauge.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from "react";
+import { getSleepSessions, getRunBikeVolume, SleepSession, RunBikeVolumePoint } from "@/lib/api";
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export interface BedToRunGaugeProps {
+  /** Diameter of the gauge in pixels */
+  size?: number;
+  /** Stroke width for gauge arcs */
+  strokeWidth?: number;
+  /** Safe range for the ratio [min, max] */
+  safeRange?: [number, number];
+}
+
+/**
+ * Semicircular gauge displaying hours of running/cycling per hour in bed.
+ */
+export default function BedToRunGauge({
+  size = 160,
+  strokeWidth = 12,
+  safeRange = [0.1, 0.25],
+}: BedToRunGaugeProps) {
+  const [ratio, setRatio] = useState<number | null>(null);
+
+  useEffect(() => {
+    Promise.all([getSleepSessions(), getRunBikeVolume()]).then(
+      ([sleep, volume]: [SleepSession[], RunBikeVolumePoint[]]) => {
+        const sleepHours = sleep
+          .slice(0, 7)
+          .reduce((sum, s) => sum + s.timeInBed, 0);
+        const lastWeek = volume[volume.length - 1];
+        const runHours = (lastWeek.runTime + lastWeek.bikeTime) / 60;
+        const r = sleepHours === 0 ? 0 : runHours / sleepHours;
+        setRatio(r);
+      },
+    );
+  }, []);
+
+  if (ratio === null) return <Skeleton className="h-32" />;
+
+  const normalized = Math.min(Math.max(ratio, 0), 1); // cap at 1
+  const radius = size / 2 - strokeWidth / 2;
+  const circumference = Math.PI * radius; // half circle
+  const offset = circumference - normalized * circumference;
+
+  let color = "hsl(var(--chart-3))";
+  if (ratio < safeRange[0]) {
+    color = "hsl(var(--chart-8))";
+  } else if (ratio > safeRange[1]) {
+    color = "hsl(var(--destructive))";
+  }
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center"
+            role="img"
+            aria-label={`Bed to run ${ratio.toFixed(2)}`}
+          >
+            <svg
+              width={size}
+              height={size / 2}
+              viewBox={`0 0 ${size} ${size / 2}`}
+            >
+              <path
+                d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${
+                  size - strokeWidth / 2
+                } ${size / 2 - strokeWidth / 2}`}
+                stroke="hsl(var(--muted))"
+                strokeWidth={strokeWidth}
+                fill="none"
+              />
+              <path
+                d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${
+                  size - strokeWidth / 2
+                } ${size / 2 - strokeWidth / 2}`}
+                stroke={color}
+                strokeWidth={strokeWidth}
+                fill="none"
+                strokeDasharray={circumference}
+                strokeDashoffset={offset}
+                strokeLinecap="round"
+              />
+            </svg>
+            <span className="mt-2 text-lg font-bold tabular-nums">
+              {ratio.toFixed(2)}
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          Hours run or biked per hour in bed (last 7 days)
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/dashboard/__tests__/BedToRunGauge.test.tsx
+++ b/src/components/dashboard/__tests__/BedToRunGauge.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi, describe, it, expect } from "vitest";
+import BedToRunGauge from "../BedToRunGauge";
+import { getSleepSessions, getRunBikeVolume } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  __esModule: true,
+  getSleepSessions: vi.fn(),
+  getRunBikeVolume: vi.fn(),
+}));
+
+describe("BedToRunGauge", () => {
+  it("renders ratio once data loads", async () => {
+    (getSleepSessions as any).mockResolvedValue(
+      Array.from({ length: 7 }, (_, i) => ({ date: `d${i}`, timeInBed: 8 }))
+    );
+    (getRunBikeVolume as any).mockResolvedValue([
+      { week: "w", runMiles: 0, bikeMiles: 0, runTime: 300, bikeTime: 60 },
+    ]);
+
+    render(<BedToRunGauge />);
+    expect(await screen.findByText("0.11")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -23,3 +23,5 @@ export { default as RunSoundtrackCard } from "./RunSoundtrackCard";
 export { default as WildNextGameCard } from "./WildNextGameCard";
 
 export { default as MovementFingerprint } from "./MovementFingerprint";
+
+export { default as BedToRunGauge } from "./BedToRunGauge";


### PR DESCRIPTION
## Summary
- add BedToRunGauge gauge component
- export from dashboard index
- document usage in README
- test new gauge behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb499b0408324bf2aa80aea1352b4