### PR TITLE
Add Wild color variables and styling

### DIFF
--- a/src/components/dashboard/WildNextGameCard.tsx
+++ b/src/components/dashboard/WildNextGameCard.tsx
@@ -14,7 +14,7 @@ export default function WildNextGameCard() {
   const date = parseISO(game.gameDate)
 
   return (
-    <Card>
+    <Card className="bg-wild-primary text-wild-secondary">
       <CardHeader>
         <CardTitle>Next Game</CardTitle>
       </CardHeader>

--- a/src/components/dashboard/__tests__/WildNextGameCard.test.tsx
+++ b/src/components/dashboard/__tests__/WildNextGameCard.test.tsx
@@ -12,7 +12,8 @@ vi.mock('@/hooks/useWildSchedule', () => ({
 
 describe('WildNextGameCard', () => {
   it('renders card title when schedule is loaded', () => {
-    render(<WildNextGameCard />)
+    const { container } = render(<WildNextGameCard />)
     expect(screen.getByText('Next Game')).toBeInTheDocument()
+    expect(container.firstChild).toHaveClass('bg-wild-primary', 'text-wild-secondary')
   })
 })

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -34,6 +34,10 @@
     --chart-8: 238 90% 60%;
     --chart-9: 242 80% 65%;
     --chart-10: 246 70% 70%;
+    --wild-primary: 157 54% 18%;
+    --wild-secondary: 351 74% 37%;
+    --wild-gold: 44 100% 46%;
+    --wild-wheat: 41 46% 75%;
   }
 
   .dark {
@@ -66,6 +70,10 @@
     --chart-8: 238 90% 70%;
     --chart-9: 242 80% 75%;
     --chart-10: 246 70% 80%;
+    --wild-primary: 157 54% 18%;
+    --wild-secondary: 351 74% 37%;
+    --wild-gold: 44 100% 46%;
+    --wild-wheat: 41 46% 75%;
   }
 
   html, body {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,11 @@ module.exports = {
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))"
-        }
+        },
+        "wild-primary": "hsl(var(--wild-primary))",
+        "wild-secondary": "hsl(var(--wild-secondary))",
+        "wild-gold": "hsl(var(--wild-gold))",
+        "wild-wheat": "hsl(var(--wild-wheat))"
       },
       fontFamily: {
         sans: ["Inter", ...fontFamily.sans],


### PR DESCRIPTION
## Summary
- define Wild team CSS variables in `globals.css`
- expose Wild colors via Tailwind config
- style `WildNextGameCard` with Wild colours
- verify card styling in unit test

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb88c6b488324a0cef28699512bde