### PR TITLE
Adjust brand card colors

### DIFF
--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -8,7 +8,7 @@ export default function RunSoundtrackCard() {
   if (!data) return <Skeleton className="h-32" />
 
   return (
-    <Card>
+    <Card className="bg-spotify-primary text-spotify-foreground">
       <CardHeader>
         <CardTitle>Run Soundtrack</CardTitle>
       </CardHeader>

--- a/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
+++ b/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
@@ -17,9 +17,10 @@ vi.mock('@/hooks/useRunSoundtrack', () => ({
 
 describe('RunSoundtrackCard', () => {
   it('renders now playing and top tracks', () => {
-    render(<RunSoundtrackCard />)
+    const { container } = render(<RunSoundtrackCard />)
     expect(screen.getByText('Now Playing')).toBeInTheDocument()
     expect(screen.getAllByText(/Song A/).length).toBeGreaterThan(0)
     expect(screen.getByText(/Song B/)).toBeInTheDocument()
+    expect(container.firstChild).toHaveClass('bg-spotify-primary', 'text-spotify-foreground')
   })
 })

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -34,10 +34,12 @@
     --chart-8: 238 90% 60%;
     --chart-9: 242 80% 65%;
     --chart-10: 246 70% 70%;
-    --wild-primary: 157 54% 18%;
-    --wild-secondary: 351 74% 37%;
-    --wild-gold: 44 100% 46%;
-    --wild-wheat: 41 46% 75%;
+    --wild-primary: 157 40% 24%;
+    --wild-secondary: 351 60% 45%;
+    --wild-gold: 44 80% 52%;
+    --wild-wheat: 41 40% 80%;
+    --spotify-primary: 141 60% 50%;
+    --spotify-foreground: 0 0% 0%;
   }
 
   .dark {
@@ -70,10 +72,12 @@
     --chart-8: 238 90% 70%;
     --chart-9: 242 80% 75%;
     --chart-10: 246 70% 80%;
-    --wild-primary: 157 54% 18%;
-    --wild-secondary: 351 74% 37%;
-    --wild-gold: 44 100% 46%;
-    --wild-wheat: 41 46% 75%;
+    --wild-primary: 157 40% 24%;
+    --wild-secondary: 351 60% 45%;
+    --wild-gold: 44 80% 52%;
+    --wild-wheat: 41 40% 80%;
+    --spotify-primary: 141 65% 58%;
+    --spotify-foreground: 0 0% 100%;
   }
 
   html, body {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,7 +26,9 @@ module.exports = {
         "wild-primary": "hsl(var(--wild-primary))",
         "wild-secondary": "hsl(var(--wild-secondary))",
         "wild-gold": "hsl(var(--wild-gold))",
-        "wild-wheat": "hsl(var(--wild-wheat))"
+        "wild-wheat": "hsl(var(--wild-wheat))",
+        "spotify-primary": "hsl(var(--spotify-primary))",
+        "spotify-foreground": "hsl(var(--spotify-foreground))"
       },
       fontFamily: {
         sans: ["Inter", ...fontFamily.sans],


### PR DESCRIPTION
## Summary
- tweak Minnesota Wild theme to be more subtle
- add Spotify brand color variables
- theme RunSoundtrack card with Spotify palette
- update tests for new card classes

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688cbd9e8bb483249ff0c358750f9c2f