### PR TITLE
Add Ghost Self Rival example

### DIFF
--- a/src/components/examples/GhostSelfRivalChart.tsx
+++ b/src/components/examples/GhostSelfRivalChart.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import WeeklyComparisonChart from '@/components/statistics/WeeklyComparisonChart'
+
+export const description = 'Compare this week with the same week last year'
+
+export default function GhostSelfRivalChart() {
+  return <WeeklyComparisonChart metric="steps" />
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -24,6 +24,8 @@ import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
 
 import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironmentMatrix";
 
+import GhostSelfRivalChart from "@/components/examples/GhostSelfRivalChart";
+
 import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
 import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilityTimeline";
 import BedToRunGauge from "@/components/dashboard/BedToRunGauge";
@@ -43,6 +45,8 @@ export default function Examples() {
       <StepsTrendWithGoal data={mockDailySteps} />
 
       <PeerBenchmarkBands />
+
+      <GhostSelfRivalChart />
 
       <WeeklyVolumeHistoryChart />
       <ReadingProbabilityTimeline />


### PR DESCRIPTION
## Summary
- create `GhostSelfRivalChart` example component that renders the existing weekly comparison chart
- show the new example on the examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688caf56ba588324b2be4e3bf06cf91f