### PR TITLE
Use text colors for Wild and Spotify cards

### DIFF
--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -8,8 +8,16 @@ export default function RunSoundtrackCard() {
   if (!data) return <Skeleton className="h-32" />
 
   return (
-    <Card className="bg-spotify-primary text-spotify-foreground">
-      <CardHeader>
+    <Card className="text-spotify-primary">
+      <CardHeader className="flex items-center gap-2">
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+        </svg>
         <CardTitle>Run Soundtrack</CardTitle>
       </CardHeader>
       <CardContent className="space-y-2">

--- a/src/components/dashboard/WildNextGameCard.tsx
+++ b/src/components/dashboard/WildNextGameCard.tsx
@@ -14,9 +14,17 @@ export default function WildNextGameCard() {
   const date = parseISO(game.gameDate)
 
   return (
-    <Card className="bg-wild-primary text-wild-secondary">
-      <CardHeader>
-        <CardTitle>Next Game</CardTitle>
+    <Card className="text-wild-primary">
+      <CardHeader className="flex items-center gap-2">
+        <svg
+          className="w-4 h-4 text-wild-secondary"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M2 20L4.5 4h2L12 16l5.5-12h2L22 20h-2l-3.5-10.5L13 20h-2l-3.5-10.5L4 20H2z" />
+        </svg>
+        <CardTitle className="text-wild-secondary">Next Game</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="text-sm text-muted-foreground">{format(date, 'PPpp')}</p>

--- a/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
+++ b/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
@@ -21,6 +21,7 @@ describe('RunSoundtrackCard', () => {
     expect(screen.getByText('Now Playing')).toBeInTheDocument()
     expect(screen.getAllByText(/Song A/).length).toBeGreaterThan(0)
     expect(screen.getByText(/Song B/)).toBeInTheDocument()
-    expect(container.firstChild).toHaveClass('bg-spotify-primary', 'text-spotify-foreground')
+    expect(container.firstChild).toHaveClass('text-spotify-primary')
+    expect(container.querySelector('svg')).toBeInTheDocument()
   })
 })

--- a/src/components/dashboard/__tests__/WildNextGameCard.test.tsx
+++ b/src/components/dashboard/__tests__/WildNextGameCard.test.tsx
@@ -14,6 +14,7 @@ describe('WildNextGameCard', () => {
   it('renders card title when schedule is loaded', () => {
     const { container } = render(<WildNextGameCard />)
     expect(screen.getByText('Next Game')).toBeInTheDocument()
-    expect(container.firstChild).toHaveClass('bg-wild-primary', 'text-wild-secondary')
+    expect(container.firstChild).toHaveClass('text-wild-primary')
+    expect(container.querySelector('svg')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- update **WildNextGameCard** to remove brand background and use brand text colors
- add simple inline SVG logos to Wild and Spotify cards
- update tests for new markup and colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc3f414288324b138104b1609f6ba