### PR TITLE
Remove BedToRunGauge demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,6 @@ Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can re
 ### Examples page
 `src/pages/Examples.tsx` shows sample charts. It now renders an interactive area chart with a time-range select next to the bar chart demos.
 
-### BedToRunGauge
-Visualise how many hours of running or cycling you log for each hour spent in bed.
-
-```tsx
-import { BedToRunGauge } from '@/components/dashboard'
-
-<BedToRunGauge />
-```
 
 ## Theming extensions
 If you need new variants—like a "danger" button or a "success" badge—run `pnpm dlx shadcn-ui@latest add button` to scaffold the base component. Then copy or edit `src/components/ui/button.tsx` and register your variant in `tailwind.config.js` under `theme.extend`. See <https://ui.shadcn.com/docs/components> for more details.

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -24,4 +24,3 @@ export { default as WildNextGameCard } from "./WildNextGameCard";
 
 export { default as MovementFingerprint } from "./MovementFingerprint";
 
-export { default as BedToRunGauge } from "./BedToRunGauge";

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -26,7 +26,6 @@ import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironm
 
 import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
 import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilityTimeline";
-import BedToRunGauge from "@/components/dashboard/BedToRunGauge";
 
 
 import ReadingStackSplit from "@/components/dashboard/ReadingStackSplit";
@@ -48,7 +47,6 @@ export default function Examples() {
       <ReadingProbabilityTimeline />
 
       <TimeInBedChart />
-      <BedToRunGauge />
 
       <BarChartInteractive />
 


### PR DESCRIPTION
## Summary
- drop BedToRunGauge demo from Examples page
- clean up dashboard exports
- remove BedToRunGauge snippet from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc51880e883249778011bd475068f