### PR TITLE
Add modal preview for example charts

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Eye } from 'lucide-react'
+import { Dialog, DialogTrigger, DialogContent } from '@/components/ui/dialog'
+
+export default function ChartPreview({ children }: { children: React.ReactElement }) {
+  return (
+    <Dialog>
+      <div className='relative'>
+        <DialogTrigger asChild>
+          <button className='absolute right-2 top-2 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground'>
+            <Eye className='h-4 w-4' />
+            <span className='sr-only'>View larger</span>
+          </button>
+        </DialogTrigger>
+        {children}
+      </div>
+      <DialogContent className='w-[90vw] max-w-3xl p-4'>
+        {React.cloneElement(children)}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -21,6 +21,7 @@ import TreadmillVsOutdoorExample from "@/components/examples/TreadmillVsOutdoor"
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
 import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
+import ChartPreview from "@/components/examples/ChartPreview";
 
 import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironmentMatrix";
 
@@ -39,48 +40,100 @@ import RunSoundtrackCardDemo from "@/components/examples/RunSoundtrackCardDemo";
 export default function Examples() {
   return (
     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      <AreaChartInteractive />
+      <ChartPreview>
+        <AreaChartInteractive />
+      </ChartPreview>
 
-      <StepsTrendWithGoal data={mockDailySteps} />
+      <ChartPreview>
+        <StepsTrendWithGoal data={mockDailySteps} />
+      </ChartPreview>
 
-      <PeerBenchmarkBands />
+      <ChartPreview>
+        <PeerBenchmarkBands />
+      </ChartPreview>
 
-      <GhostSelfRivalChart />
+      <ChartPreview>
+        <GhostSelfRivalChart />
+      </ChartPreview>
 
-      <WeeklyVolumeHistoryChart />
-      <ReadingProbabilityTimeline />
+      <ChartPreview>
+        <WeeklyVolumeHistoryChart />
+      </ChartPreview>
+      <ChartPreview>
+        <ReadingProbabilityTimeline />
+      </ChartPreview>
 
-      <TimeInBedChart />
+      <ChartPreview>
+        <TimeInBedChart />
+      </ChartPreview>
 
-      <BarChartInteractive />
+      <ChartPreview>
+        <BarChartInteractive />
+      </ChartPreview>
 
-      <LineChartInteractive />
-
-
-      <ChartRadarDefault />
-      <RadarChartWorkoutByTime />
-
-      <ChartRadialLabel />
-
-      <ChartRadialText />
-
-      <ChartBarDefault />
-      <ChartRadialGrid />
-      <ChartBarHorizontal />
-      <ChartRadarDots />
-      <ChartBarMixed />
-      <ChartBarLabelCustom />
-      <ShoeUsageChart />
-      <TreadmillVsOutdoorExample />
-
-      <PerfVsEnvironmentMatrixExample />
+      <ChartPreview>
+        <LineChartInteractive />
+      </ChartPreview>
 
 
-      <ScatterChartPaceHeartRate />
-      <AreaChartLoadRatio />
+      <ChartPreview>
+        <ChartRadarDefault />
+      </ChartPreview>
+      <ChartPreview>
+        <RadarChartWorkoutByTime />
+      </ChartPreview>
 
-      <WildNextGameCard />
-      <RunSoundtrackCardDemo />
+      <ChartPreview>
+        <ChartRadialLabel />
+      </ChartPreview>
+
+      <ChartPreview>
+        <ChartRadialText />
+      </ChartPreview>
+
+      <ChartPreview>
+        <ChartBarDefault />
+      </ChartPreview>
+      <ChartPreview>
+        <ChartRadialGrid />
+      </ChartPreview>
+      <ChartPreview>
+        <ChartBarHorizontal />
+      </ChartPreview>
+      <ChartPreview>
+        <ChartRadarDots />
+      </ChartPreview>
+      <ChartPreview>
+        <ChartBarMixed />
+      </ChartPreview>
+      <ChartPreview>
+        <ChartBarLabelCustom />
+      </ChartPreview>
+      <ChartPreview>
+        <ShoeUsageChart />
+      </ChartPreview>
+      <ChartPreview>
+        <TreadmillVsOutdoorExample />
+      </ChartPreview>
+
+      <ChartPreview>
+        <PerfVsEnvironmentMatrixExample />
+      </ChartPreview>
+
+
+      <ChartPreview>
+        <ScatterChartPaceHeartRate />
+      </ChartPreview>
+      <ChartPreview>
+        <AreaChartLoadRatio />
+      </ChartPreview>
+
+      <ChartPreview>
+        <WildNextGameCard />
+      </ChartPreview>
+      <ChartPreview>
+        <RunSoundtrackCardDemo />
+      </ChartPreview>
 
     </div>
   );


### PR DESCRIPTION
## Summary
- create `ChartPreview` component wrapping charts with an eye button and dialog
- wrap each chart on `Examples` page in `ChartPreview` so users can open a larger view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc4e6ff3c832492d1d9258aeb9f02