### PR TITLE
Update WeeklyComparison chart color config

### DIFF
--- a/src/components/statistics/WeeklyComparisonChart.tsx
+++ b/src/components/statistics/WeeklyComparisonChart.tsx
@@ -43,9 +43,9 @@ export default function WeeklyComparisonChart({
   const diff = totals.current - totals.lastYear
 
   const config = {
-    current: { label: 'This Week', color: 'var(--chart-1)' },
-    previous: { label: 'Last Week', color: 'var(--chart-2)' },
-    lastYear: { label: 'Same Week Last Year', color: 'var(--chart-3)' },
+    current: { label: 'This Week', color: 'hsl(var(--chart-1))' },
+    previous: { label: 'Last Week', color: 'hsl(var(--chart-2))' },
+    lastYear: { label: 'Same Week Last Year', color: 'hsl(var(--chart-3))' },
   } as const
 
   return (

--- a/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
+++ b/src/components/statistics/__tests__/WeeklyComparisonChart.test.tsx
@@ -47,7 +47,7 @@ describe('WeeklyComparisonChart', () => {
     expect(screen.getByText('This Week')).toBeInTheDocument()
     expect(screen.getByText('Last Week')).toBeInTheDocument()
     expect(screen.getByText('Same Week Last Year')).toBeInTheDocument()
-    const lines = document.querySelectorAll('path[stroke^="var(--chart-"]')
+    const lines = document.querySelectorAll('path[stroke^="hsl(var(--chart-"]')
     expect(lines.length).toBeGreaterThanOrEqual(3)
     expect(
       screen.getByText("You're 9 miles ahead of 2024-you.")


### PR DESCRIPTION
## Summary
- ensure WeeklyComparisonChart uses `hsl(var(--chart-* ))` values
- update test selector accordingly

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688ccdf5a1e88324a9213e698bc04702