### PR TITLE
Update dashboard tab labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ helpers so components can consume the values asynchronously:
 
 The reading focus heatmap displays one of three labels—"Deep Dive," "Skim," or
 "Page Turn Panic"—based on intensity calculated from these snapshots. It
-appears on the Map tab below the geographic explorer.
+appears on the Map playground tab below the geographic explorer.
 
 Replace these stubs with real API calls when connecting to live Garmin data.
 
@@ -148,7 +148,7 @@ Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can re
 { x: number; y: number; cluster: number }[]
 ```
 
-### Examples page
+### Analytics fun page
 `src/pages/Examples.tsx` shows sample charts. It now renders an interactive area chart with a time-range select next to the bar chart demos.
 
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,8 +26,8 @@ export default function Dashboard() {
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <TabsList>
-        <TabsTrigger value="map">Map</TabsTrigger>
-        <TabsTrigger value="examples">Examples</TabsTrigger>
+        <TabsTrigger value="map">Map playground</TabsTrigger>
+        <TabsTrigger value="examples">Analytics fun</TabsTrigger>
       </TabsList>
       <TabsContent value="map">
         <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- rename Map tab to "Map playground"
- rename Examples tab to "Analytics fun"
- update references in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ccb1d93748324a01830a1c0a8121c