### PR TITLE
Fix dialog overlay issue on charts page

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed z-50 grid w-full max-w-lg gap-4 rounded-lg border bg-background p-4 shadow-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-background p-4 shadow-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- center `DialogContent` so dialog content is visible when previewing charts

## Testing
- `npm run build`
- `npm test --silent` *(fails: runs in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_688cce8525c0832497992df9d5db7021