### PR TITLE
Unify scatter chart colors

### DIFF
--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -1,6 +1,6 @@
-'use client'
+"use client";
 
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo } from "react";
 import {
   ChartContainer,
   ScatterChart,
@@ -11,26 +11,23 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
   ChartTooltipContent,
-} from '@/components/ui/chart'
-import ChartCard from '@/components/dashboard/ChartCard'
-import { Cell } from 'recharts'
-import { SimpleSelect } from '@/components/ui/select'
+} from "@/components/ui/chart";
+import ChartCard from "@/components/dashboard/ChartCard";
+import { SimpleSelect } from "@/components/ui/select";
 
 interface PerfPoint {
-  pace: number
-  power: number
-  temperature: number
-  humidity: number
-  wind: number
-  elevation: number
-  fill: string
+  pace: number;
+  power: number;
+  temperature: number;
+  humidity: number;
+  wind: number;
+  elevation: number;
 }
 
 function generateData(count = 50): PerfPoint[] {
   return Array.from({ length: count }, () => {
-    const pace = 6 + Math.random() * 2 // 6-8 min/mi
-    const power = 250 - pace * 20 + Math.random() * 10
-    const colorIndex = Math.min(5, Math.max(0, Math.floor((power - 90) / 10)))
+    const pace = 6 + Math.random() * 2; // 6-8 min/mi
+    const power = 250 - pace * 20 + Math.random() * 10;
     return {
       pace: +pace.toFixed(2),
       power: Math.round(power),
@@ -38,90 +35,83 @@ function generateData(count = 50): PerfPoint[] {
       humidity: Math.round(40 + Math.random() * 50),
       wind: +(Math.random() * 20).toFixed(1),
       elevation: Math.round(Math.random() * 300),
-      fill: `var(--chart-${colorIndex + 5})`,
-    }
-  })
+    };
+  });
 }
 
 function regression(
   data: PerfPoint[],
   xKey: keyof PerfPoint,
-  yKey: keyof PerfPoint
+  yKey: keyof PerfPoint,
 ): { [k in keyof PerfPoint]?: number }[] {
-  const xs = data.map((d) => d[xKey] as number)
-  const ys = data.map((d) => d[yKey] as number)
-  const xMean = xs.reduce((a, b) => a + b, 0) / xs.length
-  const yMean = ys.reduce((a, b) => a + b, 0) / ys.length
-  let num = 0
-  let den = 0
+  const xs = data.map((d) => d[xKey] as number);
+  const ys = data.map((d) => d[yKey] as number);
+  const xMean = xs.reduce((a, b) => a + b, 0) / xs.length;
+  const yMean = ys.reduce((a, b) => a + b, 0) / ys.length;
+  let num = 0;
+  let den = 0;
   for (let i = 0; i < xs.length; i++) {
-    num += (xs[i] - xMean) * (ys[i] - yMean)
-    den += (xs[i] - xMean) ** 2
+    num += (xs[i] - xMean) * (ys[i] - yMean);
+    den += (xs[i] - xMean) ** 2;
   }
-  const slope = num / den
-  const intercept = yMean - slope * xMean
-  const minX = Math.min(...xs)
-  const maxX = Math.max(...xs)
+  const slope = num / den;
+  const intercept = yMean - slope * xMean;
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
   return [
     { [xKey]: minX, [yKey]: intercept + slope * minX },
     { [xKey]: maxX, [yKey]: intercept + slope * maxX },
-  ]
+  ];
 }
 
-const DATA = generateData()
+const DATA = generateData();
 
 const config = {
-  pace: { label: 'Pace', color: 'hsl(var(--chart-1))' },
-  trend: { label: 'Trend', color: 'hsl(var(--chart-2))' },
-} as const
+  points: { color: "hsl(var(--chart-4))" },
+  pace: { label: "Pace" },
+  trend: { label: "Trend", color: "hsl(var(--chart-2))" },
+} as const;
 
 export default function PerfVsEnvironmentMatrixExample() {
   const [variable, setVariable] = useState(
-    'temperature' as 'temperature' | 'humidity' | 'wind' | 'elevation',
-  )
+    "temperature" as "temperature" | "humidity" | "wind" | "elevation",
+  );
 
   const axisLabels = {
-    temperature: 'Temp (F)',
-    humidity: 'Humidity (%)',
-    wind: 'Wind (mph)',
-    elevation: 'Elevation (ft)',
-  }
+    temperature: "Temp (F)",
+    humidity: "Humidity (%)",
+    wind: "Wind (mph)",
+    elevation: "Elevation (ft)",
+  };
 
-  const trend = useMemo(
-    () => regression(DATA, variable, 'pace'),
-    [variable],
-  )
+  const trend = useMemo(() => regression(DATA, variable, "pace"), [variable]);
 
   return (
     <ChartCard
-      title='Performance vs Environment'
-      description='How pace varies with conditions like temperature, wind, or elevation'
-      className='space-y-4'
+      title="Performance vs Environment"
+      description="How pace varies with conditions like temperature, wind, or elevation"
+      className="space-y-4"
     >
       <SimpleSelect
         value={variable}
         onValueChange={(v) => setVariable(v as typeof variable)}
         options={[
-          { value: 'temperature', label: 'Temperature' },
-          { value: 'humidity', label: 'Humidity' },
-          { value: 'wind', label: 'Wind' },
-          { value: 'elevation', label: 'Elevation' },
+          { value: "temperature", label: "Temperature" },
+          { value: "humidity", label: "Humidity" },
+          { value: "wind", label: "Wind" },
+          { value: "elevation", label: "Elevation" },
         ]}
       />
-      <ChartContainer config={config} className='h-60'>
+      <ChartContainer config={config} className="h-60">
         <ScatterChart>
-          <CartesianGrid strokeDasharray='3 3' />
+          <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey={variable} name={axisLabels[variable]} />
-          <YAxis dataKey='pace' name='Pace (min/mi)' />
+          <YAxis dataKey="pace" name="Pace (min/mi)" />
           <ChartTooltip content={<ChartTooltipContent />} />
-          <Scatter data={DATA}>
-            {DATA.map((point, idx) => (
-              <Cell key={idx} fill={point.fill} />
-            ))}
-          </Scatter>
-          <Line data={trend} stroke='var(--color-trend)' dot={false} />
+          <Scatter data={DATA} fill="var(--color-points)" />
+          <Line data={trend} stroke="var(--color-trend)" dot={false} />
         </ScatterChart>
       </ChartContainer>
     </ChartCard>
-  )
+  );
 }

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -1,7 +1,7 @@
-'use client'
+"use client";
 
-import { TrendingUp } from 'lucide-react'
-import { generateTrendMessage } from '@/lib/utils'
+import { TrendingUp } from "lucide-react";
+import { generateTrendMessage } from "@/lib/utils";
 import {
   ChartContainer,
   ScatterChart,
@@ -11,7 +11,7 @@ import {
   CartesianGrid,
   Tooltip as ChartTooltip,
   ChartTooltipContent,
-} from '@/components/ui/chart'
+} from "@/components/ui/chart";
 import {
   Card,
   CardHeader,
@@ -19,50 +19,48 @@ import {
   CardDescription,
   CardContent,
   CardFooter,
-} from '@/components/ui/card'
-import { Cell } from 'recharts'
+} from "@/components/ui/card";
 
+// Generate demo data without per-point colouring
 const scatterData = Array.from({ length: 200 }, () => {
-  const pace = 6 + Math.random() * 2
-  const hr = 120 + Math.random() * 40
-  const zone = Math.min(5, Math.max(0, Math.floor((hr - 120) / 8)))
+  const pace = 6 + Math.random() * 2;
+  const hr = 120 + Math.random() * 40;
   return {
     pace,
     hr,
-    fill: `var(--chart-${zone + 5})`,
-  }
-})
+  };
+});
 
+// Provide a single series colour matching the other demo charts
 const chartConfig = {
-  pace: { label: 'Pace', color: 'hsl(var(--chart-9))' },
-  hr: { label: 'Heart Rate', color: 'hsl(var(--chart-10))' },
-} as const
+  points: { color: "hsl(var(--chart-4))" },
+  pace: { label: "Pace" },
+  hr: { label: "Heart Rate" },
+} as const;
 
 export default function ScatterChartPaceHeartRate() {
   return (
     <Card>
       <CardHeader>
         <CardTitle>Pace vs Heart Rate</CardTitle>
-        <CardDescription>Correlation of effort and speed from recent runs</CardDescription>
+        <CardDescription>
+          Correlation of effort and speed from recent runs
+        </CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-64'>
+        <ChartContainer config={chartConfig} className="h-64">
           <ScatterChart>
-            <CartesianGrid strokeDasharray='3 3' />
-            <XAxis dataKey='pace' name='Pace (min/mi)' />
-            <YAxis dataKey='hr' name='Heart Rate (bpm)' />
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="pace" name="Pace (min/mi)" />
+            <YAxis dataKey="hr" name="Heart Rate (bpm)" />
             <ChartTooltip content={<ChartTooltipContent />} />
-            <Scatter data={scatterData}>
-              {scatterData.map((pt, idx) => (
-                <Cell key={idx} fill={pt.fill} />
-              ))}
-            </Scatter>
+            <Scatter data={scatterData} fill="var(--color-points)" />
           </ScatterChart>
         </ChartContainer>
       </CardContent>
-      <CardFooter className='flex items-center gap-2 text-sm'>
-        {generateTrendMessage()} <TrendingUp className='h-4 w-4' />
+      <CardFooter className="flex items-center gap-2 text-sm">
+        {generateTrendMessage()} <TrendingUp className="h-4 w-4" />
       </CardFooter>
     </Card>
-  )
+  );
 }

--- a/src/components/statistics/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/statistics/PerfVsEnvironmentMatrix.tsx
@@ -10,23 +10,26 @@ import {
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart";
 import ChartCard from "@/components/dashboard/ChartCard";
-import { Cell } from "recharts";
 import { useRunningStats } from "@/hooks/useRunningStats";
 import { SimpleSelect } from "@/components/ui/select";
 
 interface PerfPoint {
-  pace: number
-  power: number
-  temperature: number
-  humidity: number
-  wind: number
-  elevation: number
-  fill: string
+  pace: number;
+  power: number;
+  temperature: number;
+  humidity: number;
+  wind: number;
+  elevation: number;
 }
 
-function mapPoint(pace: number, temperature: number, humidity: number, wind: number, elevation: number): PerfPoint {
-  const power = 250 - pace * 20 + Math.random() * 10
-  const colorIndex = Math.min(5, Math.max(0, Math.floor((power - 90) / 10)))
+function mapPoint(
+  pace: number,
+  temperature: number,
+  humidity: number,
+  wind: number,
+  elevation: number,
+): PerfPoint {
+  const power = 250 - pace * 20 + Math.random() * 10;
   return {
     pace: +pace.toFixed(2),
     power: Math.round(power),
@@ -34,14 +37,13 @@ function mapPoint(pace: number, temperature: number, humidity: number, wind: num
     humidity,
     wind,
     elevation,
-    fill: `hsl(var(--chart-${colorIndex + 5}))`,
-  }
+  };
 }
 
 function regression(
   data: PerfPoint[],
   xKey: keyof PerfPoint,
-  yKey: keyof PerfPoint
+  yKey: keyof PerfPoint,
 ): { [k in keyof PerfPoint]?: number }[] {
   const xs = data.map((d) => d[xKey] as number);
   const ys = data.map((d) => d[yKey] as number);
@@ -64,30 +66,34 @@ function regression(
 }
 
 export default function PerfVsEnvironmentMatrix() {
-  const stats = useRunningStats()
+  const stats = useRunningStats();
   const [variable, setVariable] = useState(
     "temperature" as "temperature" | "humidity" | "wind" | "elevation",
-  )
+  );
   const DATA = useMemo(() => {
-    if (!stats) return []
+    if (!stats) return [];
     return stats.paceEnvironment.map((p) =>
       mapPoint(p.pace, p.temperature, p.humidity, p.wind, p.elevation),
-    )
-  }, [stats])
+    );
+  }, [stats]);
 
   const config = {
-    pace: { label: "Pace", color: "hsl(var(--chart-8))" },
+    points: { color: "hsl(var(--chart-4))" },
+    pace: { label: "Pace" },
     trend: { label: "Trend", color: "hsl(var(--chart-3))" },
-  } as const
+  } as const;
 
   const axisLabels = {
     temperature: "Temp (F)",
     humidity: "Humidity (%)",
     wind: "Wind (mph)",
     elevation: "Elevation (ft)",
-  }
+  };
 
-  const trend = useMemo(() => regression(DATA, variable, "pace"), [DATA, variable])
+  const trend = useMemo(
+    () => regression(DATA, variable, "pace"),
+    [DATA, variable],
+  );
 
   return (
     <ChartCard
@@ -111,11 +117,7 @@ export default function PerfVsEnvironmentMatrix() {
           <XAxis dataKey={variable} name={axisLabels[variable]} />
           <YAxis dataKey="pace" name="Pace (min/mi)" />
           <ChartTooltip />
-          <Scatter data={DATA}>
-            {DATA.map((point, idx) => (
-              <Cell key={idx} fill={point.fill} />
-            ))}
-          </Scatter>
+          <Scatter data={DATA} fill="var(--color-points)" />
           <Line data={trend} stroke={config.trend.color} dot={false} />
         </ScatterChart>
       </ChartContainer>


### PR DESCRIPTION
## Summary
- use a single series color for the Pace vs Heart Rate scatter
- use a single series color for the Performance vs Environment scatter
- apply the same style in the statistics component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ccab2af3483248106eb62b680016f