### PR TITLE
Make ChartPreview dialogs full screen

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -14,7 +14,7 @@ export default function ChartPreview({ children }: { children: React.ReactElemen
         </DialogTrigger>
         {children}
       </div>
-      <DialogContent className='w-[90vw] max-w-3xl p-4'>
+      <DialogContent className='inset-0 h-screen w-screen translate-x-0 translate-y-0 max-w-none rounded-none p-4'>
         {React.cloneElement(children)}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- display Analytics dialogs in full-screen mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cd03de1448324894de2d2daad41a5