### PR TITLE
Add fullscreen dialog content variant

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Eye } from 'lucide-react'
-import { Dialog, DialogTrigger, DialogContent } from '@/components/ui/dialog'
+import { Dialog, DialogTrigger, DialogContentFullscreen } from '@/components/ui/dialog'
 
 export default function ChartPreview({ children }: { children: React.ReactElement }) {
   return (
@@ -14,9 +14,9 @@ export default function ChartPreview({ children }: { children: React.ReactElemen
         </DialogTrigger>
         {children}
       </div>
-      <DialogContent className='inset-0 h-screen w-screen translate-x-0 translate-y-0 max-w-none rounded-none p-4'>
+      <DialogContentFullscreen>
         {React.cloneElement(children)}
-      </DialogContent>
+      </DialogContentFullscreen>
     </Dialog>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -42,4 +42,24 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-export { Dialog, DialogTrigger, DialogContent };
+const DialogContentFullscreen = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-0 z-50 grid h-screen w-screen overflow-y-auto bg-background p-4 shadow-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContentFullscreen.displayName = DialogPrimitive.Content.displayName;
+
+export { Dialog, DialogTrigger, DialogContent, DialogContentFullscreen };


### PR DESCRIPTION
## Summary
- create `DialogContentFullscreen` for dialogs needing full viewport
- use the fullscreen variant in `ChartPreview`

## Testing
- `npx vitest run --reporter=dot`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_688cd35bdd4c832496f8ecca340cf968