### PR TITLE
Use spotify token for playback progress

### DIFF
--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -88,11 +88,8 @@ export default function RunSoundtrackCard() {
                 </div>
                 <div className="mt-1 w-full bg-gray-100 rounded-full h-2 overflow-hidden">
                   <div
-                    className="h-full rounded-full"
-                    style={{
-                      width: `${progressPct}%`,
-                      background: 'linear-gradient(90deg,#1DB954,#1ED760)',
-                    }}
+                    className="h-full rounded-full bg-spotify-primary"
+                    style={{ width: `${progressPct}%` }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- use `bg-spotify-primary` for the RunSoundtrack playback bar
- keep mini track bars using the same spotify color token

## Testing
- `npm run dev` *(verify dev server starts)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cddac490883248e641a03a5ca8fe7