### PR TITLE
Handle missing nowPlaying in soundtrack card

### DIFF
--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -55,7 +55,7 @@ export default function RunSoundtrackCard() {
         <CardTitle className="font-slab font-bold text-lg">Run Soundtrack</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6 p-3 pt-0">
-        {data.nowPlaying && (
+        {data.nowPlaying ? (
           <div className="flex gap-4">
             <div className="flex-shrink-0 w-20 h-20 rounded-xl overflow-hidden shadow-sm">
               {data.nowPlaying.item?.album?.images?.[0]?.url && (
@@ -97,6 +97,10 @@ export default function RunSoundtrackCard() {
                 </div>
               </div>
             </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
+            Not currently listening
           </div>
         )}
 

--- a/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
+++ b/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
@@ -3,47 +3,71 @@ import '@testing-library/jest-dom'
 import { vi } from 'vitest'
 import RunSoundtrackCard from '../RunSoundtrackCard'
 
+const mockHook = vi.fn()
+
 vi.mock('@/hooks/useRunSoundtrack', () => ({
   __esModule: true,
-  default: () => ({
-    window: { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:40:00Z' },
-    nowPlaying: {
-      item: {
-        name: 'Song A',
-        artists: [{ name: 'Artist' }],
-        duration_ms: 240000,
-        album: { images: [{ url: 'https://via.placeholder.com/80' }] },
-      },
-      progress_ms: 90000,
-    },
-    topTracks: [
-      {
-        id: '1',
-        name: 'Song A',
-        artists: 'Artist',
-        uri: 'x',
-        playCount: 2,
-        thumbnail: 'https://via.placeholder.com/40',
-      },
-      {
-        id: '2',
-        name: 'Song B',
-        artists: 'Other',
-        uri: 'y',
-        playCount: 1,
-        thumbnail: 'https://via.placeholder.com/40',
-      },
-    ],
-  }),
+  default: () => mockHook(),
 }))
 
+const baseData = {
+  window: { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:40:00Z' },
+  topTracks: [
+    {
+      id: '1',
+      name: 'Song A',
+      artists: 'Artist',
+      uri: 'x',
+      playCount: 2,
+      thumbnail: 'https://via.placeholder.com/40',
+    },
+    {
+      id: '2',
+      name: 'Song B',
+      artists: 'Other',
+      uri: 'y',
+      playCount: 1,
+      thumbnail: 'https://via.placeholder.com/40',
+    },
+  ],
+}
+
+const withNowPlaying = {
+  ...baseData,
+  nowPlaying: {
+    item: {
+      name: 'Song A',
+      artists: [{ name: 'Artist' }],
+      duration_ms: 240000,
+      album: { images: [{ url: 'https://via.placeholder.com/80' }] },
+    },
+    progress_ms: 90000,
+  },
+}
+
+const withoutNowPlaying = {
+  ...baseData,
+  nowPlaying: null,
+}
+
 describe('RunSoundtrackCard', () => {
+  beforeEach(() => {
+    mockHook.mockReset()
+  })
+
   it('renders now playing and top tracks', () => {
+    mockHook.mockReturnValue(withNowPlaying)
     const { container } = render(<RunSoundtrackCard />)
     expect(screen.getByText('Now Playing')).toBeInTheDocument()
     expect(screen.getAllByText(/Song A/).length).toBeGreaterThan(0)
     expect(screen.getByText(/Song B/)).toBeInTheDocument()
     expect(container.firstChild).toHaveClass('text-spotify-primary')
     expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('shows placeholder when nothing is playing', () => {
+    mockHook.mockReturnValue(withoutNowPlaying)
+    render(<RunSoundtrackCard />)
+    expect(screen.getByText('Not currently listening')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- show 'Not currently listening' when `nowPlaying` is missing in `RunSoundtrackCard`
- expand test coverage to include missing `nowPlaying` case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cddb194ac83248da5071faa3dcd36