### PR TITLE
Add NextGameCard components

### DIFF
--- a/src/components/dashboard/CompactNextGameCard.tsx
+++ b/src/components/dashboard/CompactNextGameCard.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+
+export interface CompactNextGameCardProps {
+  homeTeam: string
+  awayTeam: string
+  date: string
+  time: string
+  isHome: boolean
+  countdown: string
+  accentColor?: string
+}
+
+export default function CompactNextGameCard({
+  homeTeam,
+  awayTeam,
+  date,
+  time,
+  isHome,
+  countdown,
+  accentColor = "#006847",
+}: CompactNextGameCardProps) {
+  return (
+    <div className="max-w-sm rounded-xl bg-white border border-gray-200 shadow-sm p-4 flex items-start gap-3">
+      <div className="flex-grow">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold leading-tight">
+              <span style={{ color: accentColor }}>{homeTeam}</span>{" "}
+              <span className="font-normal text-gray-900">vs {awayTeam}</span>
+            </h3>
+            <div className="text-xs text-gray-500 mt-0.5">{countdown}</div>
+          </div>
+          <div className="text-right text-xs">
+            <div>{date}</div>
+            <div>{time}</div>
+          </div>
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          {isHome && (
+            <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded-full bg-green-100 text-green-800">
+              Home
+            </span>
+          )}
+          <span className="text-[10px] text-gray-600">Xcel Energy Center</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/NextGameCard.tsx
+++ b/src/components/dashboard/NextGameCard.tsx
@@ -1,0 +1,78 @@
+import React from "react"
+
+export interface NextGameCardProps {
+  homeTeam: string
+  awayTeam: string
+  date: string
+  time: string
+  location: string
+  isHome: boolean
+  countdown: string
+  logoUrl: string
+  accentColor?: string
+}
+
+export default function NextGameCard({
+  homeTeam,
+  awayTeam,
+  date,
+  time,
+  location,
+  isHome,
+  countdown,
+  logoUrl,
+  accentColor = "#8A1538",
+}: NextGameCardProps) {
+  return (
+    <div className="max-w-md w-full rounded-2xl bg-white border border-gray-200 shadow-md p-6 flex flex-col">
+      <div className="flex items-start gap-4">
+        <div className="flex-shrink-0">
+          <div
+            className="w-12 h-12 rounded-full bg-zinc-50 flex items-center justify-center ring-1 ring-gray-200"
+            aria-label={`${homeTeam} logo`}
+          >
+            <img src={logoUrl} alt={`${homeTeam} logo`} className="w-10 h-10 object-contain" />
+          </div>
+        </div>
+        <div className="flex-grow flex flex-col">
+          <div>
+            <span className="text-xs text-gray-500">Next Game</span>
+            <h2 className="mt-1 text-2xl font-semibold leading-tight">
+              <span style={{ color: accentColor }}>{homeTeam}</span>{" "}
+              <span className="font-normal text-gray-900">vs {awayTeam}</span>
+            </h2>
+          </div>
+          <div className="mt-2">
+            <span className="text-sm text-gray-600">{countdown}</span>
+          </div>
+        </div>
+        <div className="flex flex-col items-end space-y-1 text-right">
+          <div className="text-sm font-medium text-gray-700">
+            {date}, {time}
+          </div>
+          <div className="flex gap-2">
+            {isHome && (
+              <span
+                className="inline-flex items-center px-3 py-1 text-xs font-medium rounded-full"
+                style={{ backgroundColor: "#E6F4EA", color: "#1F4F2A" }}
+              >
+                Home
+              </span>
+            )}
+            <span className="inline-flex items-center px-3 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-800">
+              {location}
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="mt-5">
+        <button className="w-full flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50 transition">
+          <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10m-11 4h12a2 2 0 002-2V7a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
+          </svg>
+          Game Details
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/__tests__/CompactNextGameCard.test.tsx
+++ b/src/components/dashboard/__tests__/CompactNextGameCard.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import CompactNextGameCard from '../CompactNextGameCard'
+
+describe('CompactNextGameCard', () => {
+  it('renders compact card with props', () => {
+    render(
+      <CompactNextGameCard
+        homeTeam="Wild"
+        awayTeam="Blues"
+        date="Sep 30, 2025"
+        time="7:00 PM"
+        isHome={true}
+        countdown="in 2 months"
+        accentColor="#006847"
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: /Wild.*vs.*Blues/ })).toBeInTheDocument()
+    expect(screen.getByText('Home')).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/__tests__/NextGameCard.test.tsx
+++ b/src/components/dashboard/__tests__/NextGameCard.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import NextGameCard from '../NextGameCard'
+
+describe('NextGameCard', () => {
+  it('renders with provided props', () => {
+    render(
+      <NextGameCard
+        homeTeam="Wild"
+        awayTeam="Blues"
+        date="Sep 30, 2025"
+        time="7:00 PM"
+        location="Xcel Energy Center"
+        isHome={true}
+        countdown="in 2 months"
+        logoUrl="https://via.placeholder.com/40"
+        accentColor="#006847"
+      />
+    )
+
+    expect(screen.getByText('Next Game')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Wild.*vs.*Blues/ })).toBeInTheDocument()
+    expect(screen.getByText('Game Details')).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -21,6 +21,8 @@ export { default as ReadingStackSplit } from "./ReadingStackSplit";
 export { default as RunSoundtrackCard } from "./RunSoundtrackCard";
 
 export { default as WildNextGameCard } from "./WildNextGameCard";
+export { default as NextGameCard } from "./NextGameCard";
+export { default as CompactNextGameCard } from "./CompactNextGameCard";
 
 export { default as MovementFingerprint } from "./MovementFingerprint";
 

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -33,6 +33,8 @@ import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilit
 
 import ReadingStackSplit from "@/components/dashboard/ReadingStackSplit";
 import WildNextGameCard from "@/components/dashboard/WildNextGameCard";
+import NextGameCard from "@/components/dashboard/NextGameCard";
+import CompactNextGameCard from "@/components/dashboard/CompactNextGameCard";
 import RunSoundtrackCardDemo from "@/components/examples/RunSoundtrackCardDemo";
 
 
@@ -130,6 +132,30 @@ export default function Examples() {
 
       <ChartPreview>
         <WildNextGameCard />
+      </ChartPreview>
+      <ChartPreview>
+        <NextGameCard
+          homeTeam="Wild"
+          awayTeam="Blues"
+          date="Sep 30, 2025"
+          time="7:00 PM"
+          location="Xcel Energy Center"
+          isHome={true}
+          countdown="in 2 months"
+          logoUrl="https://via.placeholder.com/40?text=W"
+          accentColor="#006847"
+        />
+      </ChartPreview>
+      <ChartPreview>
+        <CompactNextGameCard
+          homeTeam="Wild"
+          awayTeam="Blues"
+          date="Sep 30, 2025"
+          time="7:00 PM"
+          isHome={true}
+          countdown="in 2 months"
+          accentColor="#006847"
+        />
       </ChartPreview>
       <ChartPreview>
         <RunSoundtrackCardDemo />


### PR DESCRIPTION
## Summary
- add flexible `NextGameCard` and `CompactNextGameCard` components
- export them from dashboard index
- include examples of both in the Examples page
- test both new components

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688cd80490e483248bf2cea61f5dd893