### PR TITLE
Update RunSoundtrackCard spacing and header

### DIFF
--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -26,7 +26,7 @@ export default function RunSoundtrackCard() {
 
   return (
     <Card className="text-spotify-primary">
-      <CardHeader className="flex items-center gap-2 p-3">
+      <CardHeader className="flex items-center gap-4 p-6">
         <svg
           className="w-4 h-4"
           viewBox="0 0 24 24"
@@ -35,9 +35,13 @@ export default function RunSoundtrackCard() {
         >
           <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
         </svg>
-        <CardTitle className="font-slab font-bold text-lg">Run Soundtrack</CardTitle>
+        <CardTitle className="font-slab font-bold text-2xl">Run Soundtrack</CardTitle>
+        <span
+          aria-label="listening"
+          className="ml-auto h-2 w-2 rounded-full bg-green-600 animate-pulse"
+        />
       </CardHeader>
-      <CardContent className="space-y-6 p-3 pt-0">
+      <CardContent className="flex flex-col gap-4 p-6 pt-0">
         {data.nowPlaying ? (
           <div className="flex gap-4">
             <div className="flex-shrink-0 w-20 h-20 rounded-xl overflow-hidden shadow-sm">
@@ -52,7 +56,7 @@ export default function RunSoundtrackCard() {
             <div className="flex-grow flex flex-col justify-between">
               <div>
                 <p className="text-xs uppercase font-semibold text-green-600">Now Playing</p>
-                <h3 className="mt-1 text-lg font-semibold">
+                <h3 className="mt-1 text-base font-medium">
                   {data.nowPlaying.item.name}
                 </h3>
                 <p className="text-sm text-muted-foreground">
@@ -84,7 +88,7 @@ export default function RunSoundtrackCard() {
           </div>
         )}
 
-        <div>
+        <div className="mt-4">
           <div className="flex items-center justify-between">
             <h4 className="text-base font-semibold">Top Tracks</h4>
             <span className="text-sm text-muted-foreground">Recent</span>


### PR DESCRIPTION
## Summary
- follow spacing guidance for RunSoundtrackCard
- show live dot indicator in header
- tweak typography hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cdfff5fec83249622c34c72070f43