### PR TITLE
Fix chart preview dialogs

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Eye } from 'lucide-react'
+import { Eye, X } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import {
@@ -7,6 +7,7 @@ import {
   DialogTrigger,
   DialogContent,
   DialogContentFullscreen,
+  DialogClose,
 } from '@/components/ui/dialog'
 
 
@@ -19,7 +20,7 @@ export default function ChartPreview({
 }) {
   return (
     <Dialog>
-      <div className={cn('relative h-64', className)}>
+      <div className={cn('relative h-64 overflow-hidden', className)}>
         <DialogTrigger asChild>
           <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground'>
             <Eye className='h-4 w-4' />
@@ -28,7 +29,13 @@ export default function ChartPreview({
         </DialogTrigger>
         {children}
       </div>
-      <DialogContentFullscreen>
+      <DialogContentFullscreen className="relative">
+        <DialogClose asChild>
+          <button className="absolute right-4 top-4 z-50 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </button>
+        </DialogClose>
         {React.cloneElement(children)}
       </DialogContentFullscreen>
     </Dialog>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
 
 const DialogPortal = DialogPrimitive.Portal;
 
@@ -62,4 +63,10 @@ const DialogContentFullscreen = React.forwardRef<
 ));
 DialogContentFullscreen.displayName = DialogPrimitive.Content.displayName;
 
-export { Dialog, DialogTrigger, DialogContent, DialogContentFullscreen };
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogContentFullscreen,
+  DialogClose,
+};


### PR DESCRIPTION
## Summary
- add DialogClose to dialog utilities
- hide overflow in ChartPreview containers
- include a close button in fullscreen chart previews

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_688d242a1be48324bbee76adcbf6bca4