### PR TITLE
Enable masonry layout for examples grid

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -20,7 +20,7 @@ export default function ChartPreview({
 }) {
   return (
     <Dialog>
-      <div className={cn('relative h-64 overflow-hidden', className)}>
+      <div className={cn("relative overflow-hidden mb-6 break-inside-avoid", className)}>
         <DialogTrigger asChild>
           <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground'>
             <Eye className='h-4 w-4' />

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -41,7 +41,7 @@ import RunSoundtrackCardDemo from "@/components/examples/RunSoundtrackCardDemo";
 
 export default function Examples() {
   return (
-    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="columns-1 sm:columns-2 lg:columns-3 gap-6">
       <ChartPreview>
         <AreaChartInteractive />
       </ChartPreview>


### PR DESCRIPTION
## Summary
- switch examples container to use Tailwind columns utilities
- allow chart previews to expand naturally and avoid column breaks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2d94309c83248fe554e35f8b2751