### PR TITLE
Replace swimming with walking

### DIFF
--- a/src/components/examples/BarChartMixed.tsx
+++ b/src/components/examples/BarChartMixed.tsx
@@ -25,7 +25,7 @@ export const description = 'A mixed bar chart'
 const chartData = [
   { activity: 'run', sessions: 45, fill: 'var(--color-run)' },
   { activity: 'bike', sessions: 30, fill: 'var(--color-bike)' },
-  { activity: 'swim', sessions: 12, fill: 'var(--color-swim)' },
+  { activity: 'walk', sessions: 12, fill: 'var(--color-walk)' },
   { activity: 'hike', sessions: 8, fill: 'var(--color-hike)' },
   { activity: 'other', sessions: 6, fill: 'var(--color-other)' },
 ]
@@ -34,7 +34,7 @@ const chartConfig = {
   sessions: { label: 'Sessions' },
   run: { label: 'Run', color: 'hsl(var(--chart-1))' },
   bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
-  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  walk: { label: 'Walk', color: 'hsl(var(--chart-3))' },
   hike: { label: 'Hike', color: 'hsl(var(--chart-4))' },
   other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig
@@ -44,7 +44,7 @@ export default function ChartBarMixed() {
     <Card>
       <CardHeader>
         <CardTitle>Activity Type Breakdown</CardTitle>
-        <CardDescription>Total sessions or volume by type (Run / Bike / Swim / Other)</CardDescription>
+        <CardDescription>Total sessions or volume by type (Run / Bike / Walk / Other)</CardDescription>
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig} className='h-60'>

--- a/src/components/examples/RadialChartLabel.tsx
+++ b/src/components/examples/RadialChartLabel.tsx
@@ -25,7 +25,7 @@ export const description = 'A radial chart with a label'
 const chartData = [
   { activity: 'Run', minutes: 520, fill: 'var(--color-run)' },
   { activity: 'Bike', minutes: 340, fill: 'var(--color-bike)' },
-  { activity: 'Swim', minutes: 120, fill: 'var(--color-swim)' },
+  { activity: 'Walk', minutes: 120, fill: 'var(--color-walk)' },
   { activity: 'Strength', minutes: 220, fill: 'var(--color-strength)' },
   { activity: 'Other', minutes: 90, fill: 'var(--color-other)' },
 ]
@@ -34,7 +34,7 @@ const chartConfig = {
   minutes: { label: 'Minutes' },
   run: { label: 'Run', color: 'hsl(var(--chart-1))' },
   bike: { label: 'Bike', color: 'hsl(var(--chart-2))' },
-  swim: { label: 'Swim', color: 'hsl(var(--chart-3))' },
+  walk: { label: 'Walk', color: 'hsl(var(--chart-3))' },
   strength: { label: 'Strength', color: 'hsl(var(--chart-4))' },
   other: { label: 'Other', color: 'hsl(var(--chart-5))' },
 } satisfies ChartConfig

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -118,7 +118,7 @@ export interface ActivityMinutes {
 export const mockActivityMinutes: ActivityMinutes[] = [
   { activity: "Run", minutes: 520, fill: "var(--color-run)" },
   { activity: "Bike", minutes: 340, fill: "var(--color-bike)" },
-  { activity: "Swim", minutes: 120, fill: "var(--color-swim)" },
+  { activity: "Walk", minutes: 120, fill: "var(--color-walk)" },
   { activity: "Strength", minutes: 220, fill: "var(--color-strength)" },
   { activity: "Other", minutes: 90, fill: "var(--color-other)" },
 ];


### PR DESCRIPTION
## Summary
- use "walk" in chart data and config
- update chart description text
- sync API mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5fef632c8324aa0aa4dd08cf377a