### PR TITLE
Add training consistency heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can re
 { x: number; y: number; cluster: number }[]
 ```
 
+`useTrainingConsistency()` powers the `TrainingEntropyHeatmap` chart showing start-time
+frequency and a weekly entropy trendline.
+
 ### Analytics fun page
 `src/pages/Examples.tsx` shows sample charts. It now renders an interactive area chart with a time-range select next to the bar chart demos.
 

--- a/src/components/dashboard/TrainingEntropyHeatmap.tsx
+++ b/src/components/dashboard/TrainingEntropyHeatmap.tsx
@@ -1,0 +1,64 @@
+"use client";
+import ChartCard from "./ChartCard";
+import { ChartContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip as ChartTooltip } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
+import useTrainingConsistency from "@/hooks/useTrainingConsistency";
+
+const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export default function TrainingEntropyHeatmap() {
+  const data = useTrainingConsistency();
+
+  if (!data) return <Skeleton className="h-64" />;
+
+  const grid = Array.from({ length: 24 }, () =>
+    Array.from({ length: 7 }, () => ({ count: 0 }))
+  );
+  let max = 0;
+  data.heatmap.forEach((c) => {
+    grid[c.hour][c.day] = c;
+    if (c.count > max) max = c.count;
+  });
+
+  const entropySeries = data.weeklyEntropy.map((e, i) => ({ week: i + 1, entropy: e }));
+  const entropyMax = Math.log2(168);
+
+  return (
+    <ChartCard
+      title="Training Consistency"
+      description="Low entropy + steady volume indicates a robust routine; spikes signal schedule disruption."
+    >
+      <ChartContainer config={{}} className="h-64">
+        <div className="grid gap-2 h-full" style={{ gridTemplateRows: "1fr auto" }}>
+          <div className="grid gap-px text-center text-[10px] overflow-y-auto">
+            <div className="grid grid-cols-7 text-xs font-medium">
+              {dayLabels.map((d) => (
+                <div key={d}>{d}</div>
+              ))}
+            </div>
+            {grid.map((row, hour) => (
+              <div key={hour} className="grid grid-cols-7">
+                {row.map((cell, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-center border bg-accent text-accent-foreground h-4"
+                    style={{ opacity: max ? cell.count / max : 0 }}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+          <div className="h-24 w-full">
+            <LineChart data={entropySeries} margin={{ top: 0, right: 20, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="week" tick={{ fontSize: 10 }} />
+              <YAxis domain={[0, entropyMax]} hide />
+              <ChartTooltip />
+              <Line type="monotone" dataKey="entropy" stroke="hsl(var(--chart-1))" dot={false} />
+            </LineChart>
+          </div>
+        </div>
+      </ChartContainer>
+    </ChartCard>
+  );
+}

--- a/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import '@testing-library/jest-dom'
+import TrainingEntropyHeatmap from '../TrainingEntropyHeatmap'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    ),
+  }
+})
+
+vi.mock('@/hooks/useTrainingConsistency', () => ({
+  __esModule: true,
+  default: () => ({
+    heatmap: [{ day: 0, hour: 0, count: 1 }],
+    weeklyEntropy: [0.2],
+  }),
+}))
+
+describe('TrainingEntropyHeatmap', () => {
+  it('renders chart title', () => {
+    render(<TrainingEntropyHeatmap />)
+    expect(screen.getByText(/Training Consistency/)).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -24,3 +24,5 @@ export { default as CompactNextGameCard } from "./CompactNextGameCard";
 
 export { default as MovementFingerprint } from "./MovementFingerprint";
 
+export { default as TrainingEntropyHeatmap } from "./TrainingEntropyHeatmap";
+

--- a/src/hooks/useTrainingConsistency.ts
+++ b/src/hooks/useTrainingConsistency.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getRunningSessions, type RunningSession } from '@/lib/api'
+
+export interface TrainingHeatmapCell {
+  day: number
+  hour: number
+  count: number
+}
+
+export interface TrainingConsistency {
+  heatmap: TrainingHeatmapCell[]
+  weeklyEntropy: number[]
+}
+
+function computeHeatmap(sessions: RunningSession[]): TrainingHeatmapCell[] {
+  const bins = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0))
+  sessions.forEach((s) => {
+    const d = new Date((s as any).start || s.date)
+    const day = d.getDay()
+    const hour = d.getHours()
+    bins[day][hour] += 1
+  })
+  const result: TrainingHeatmapCell[] = []
+  for (let day = 0; day < 7; day++) {
+    for (let hour = 0; hour < 24; hour++) {
+      result.push({ day, hour, count: bins[day][hour] })
+    }
+  }
+  return result
+}
+
+function shannonEntropy(counts: number[]): number {
+  const total = counts.reduce((a, b) => a + b, 0)
+  if (!total) return 0
+  return -counts.reduce((sum, c) => {
+    if (!c) return sum
+    const p = c / total
+    return sum + p * Math.log2(p)
+  }, 0)
+}
+
+function computeWeeklyEntropy(sessions: RunningSession[]): number[] {
+  const weeks: Record<string, number[]> = {}
+  sessions.forEach((s) => {
+    const d = new Date((s as any).start || s.date)
+    const weekStart = new Date(d)
+    weekStart.setDate(d.getDate() - d.getDay())
+    weekStart.setHours(0, 0, 0, 0)
+    const key = weekStart.toISOString().slice(0, 10)
+    if (!weeks[key]) weeks[key] = Array(168).fill(0)
+    const idx = d.getDay() * 24 + d.getHours()
+    weeks[key][idx] += 1
+  })
+  return Object.keys(weeks)
+    .sort()
+    .map((k) => shannonEntropy(weeks[k]))
+}
+
+export default function useTrainingConsistency(): TrainingConsistency | null {
+  const [sessions, setSessions] = useState<RunningSession[] | null>(null)
+
+  useEffect(() => {
+    getRunningSessions().then(setSessions)
+  }, [])
+
+  return useMemo(() => {
+    if (!sessions) return null
+    return {
+      heatmap: computeHeatmap(sessions),
+      weeklyEntropy: computeWeeklyEntropy(sessions),
+    }
+  }, [sessions])
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -769,6 +769,8 @@ export interface RunningSession {
   duration: number;
   heartRate: number;
   date: string;
+  /** ISO timestamp when the session started */
+  start: string;
 }
 
 export function generateMockRunningSessions(): RunningSession[] {
@@ -777,7 +779,15 @@ export function generateMockRunningSessions(): RunningSession[] {
     pace: +(5 + Math.random() * 3).toFixed(2),
     duration: Math.round(25 + Math.random() * 35),
     heartRate: Math.round(120 + Math.random() * 40),
-    date: new Date(Date.now() - i * 86400000).toISOString().slice(0, 10),
+    ...(() => {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      d.setHours(Math.floor(Math.random() * 24), 0, 0, 0);
+      return {
+        date: d.toISOString().slice(0, 10),
+        start: d.toISOString(),
+      };
+    })(),
   }));
 }
 


### PR DESCRIPTION
## Summary
- generate running session timestamps
- compute weekly session entropy and bin sessions by hour
- visualise training entropy heatmap with trendline
- export component and add tests
- document the new chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d629e49ec83249f362e45dc004b53