### PR TITLE
Implement Good Day session clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ All charts should be wrapped in Shadcn’s `<ChartContainer>` so they inherit CS
 
 Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can reference shared styling from `ui/...`.
 
-`useRunningSessions()` returns t-SNE coordinates for recent runs and is visualised with the `SessionSimilarityMap` scatter chart.
+`useRunningSessions()` returns t-SNE coordinates for recent runs and is visualised with the `SessionSimilarityMap` scatter chart. A `good` flag marks sessions where pace beat the expected baseline.
 
 ```ts
-{ x: number; y: number; cluster: number }[]
+{ x: number; y: number; cluster: number; good: boolean }[]
 ```
 
 ### Analytics fun page

--- a/src/components/statistics/SessionSimilarityMap.tsx
+++ b/src/components/statistics/SessionSimilarityMap.tsx
@@ -24,6 +24,7 @@ const config = {
   0: { label: "Cluster 1", color: colors[0] },
   1: { label: "Cluster 2", color: colors[1] },
   2: { label: "Cluster 3", color: colors[2] },
+  good: { label: "Good Day", color: "hsl(var(--chart-6))" },
 } satisfies Record<string, unknown>
 
 export default function SessionSimilarityMap() {
@@ -52,6 +53,11 @@ export default function SessionSimilarityMap() {
               animationDuration={300}
             />
           ))}
+          <Scatter
+            data={data.filter((d) => d.good)}
+            fill="hsl(var(--chart-6))"
+            shape="star"
+          />
         </ScatterChart>
       </ChartContainer>
     </ChartCard>

--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -6,6 +6,7 @@ export interface SessionPoint {
   x: number
   y: number
   cluster: number
+  good: boolean
 }
 
 function kMeans(data: number[][], k: number, iterations = 10): number[] {
@@ -53,9 +54,24 @@ export function useRunningSessions(): SessionPoint[] | null {
   const [points, setPoints] = useState<SessionPoint[] | null>(null)
 
   useEffect(() => {
+    function expectedPace(s: RunningSession): number {
+      const hour = new Date(s.start).getHours()
+      const tempAdj = (s.weather.temperature - 55) * 0.02
+      const humidAdj = (s.weather.humidity - 50) * 0.01
+      const timeAdj = Math.abs(hour - 8) * 0.03
+      const hrAdj = (s.heartRate - 140) * 0.015
+      return 6.5 + tempAdj + humidAdj + timeAdj + hrAdj
+    }
+
     getRunningSessions().then((sessions: RunningSession[]) => {
       const model = new TSNE({ dim: 2, perplexity: 5 })
-      const input = sessions.map((s) => [s.pace, s.duration, s.heartRate])
+      const input = sessions.map((s) => [
+        s.weather.temperature,
+        s.weather.humidity,
+        new Date(s.start).getHours(),
+        s.heartRate,
+        s.pace,
+      ])
       model.init({ data: input, type: 'dense' })
       for (let i = 0; i < 250; i++) {
         model.step()
@@ -67,6 +83,7 @@ export function useRunningSessions(): SessionPoint[] | null {
           x,
           y,
           cluster: labels[idx],
+          good: sessions[idx].pace < expectedPace(sessions[idx]) - 0.2,
         }),
       )
       setPoints(data)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -769,16 +769,40 @@ export interface RunningSession {
   duration: number;
   heartRate: number;
   date: string;
+  /** ISO timestamp for session start */
+  start: string;
+  weather: {
+    temperature: number;
+    humidity: number;
+    wind: number;
+    condition: string;
+  };
 }
 
 export function generateMockRunningSessions(): RunningSession[] {
-  return Array.from({ length: 30 }, (_, i) => ({
-    id: i + 1,
-    pace: +(5 + Math.random() * 3).toFixed(2),
-    duration: Math.round(25 + Math.random() * 35),
-    heartRate: Math.round(120 + Math.random() * 40),
-    date: new Date(Date.now() - i * 86400000).toISOString().slice(0, 10),
-  }));
+  return Array.from({ length: 30 }, (_, i) => {
+    const pace = +(5 + Math.random() * 3).toFixed(2);
+    const base = new Date();
+    base.setDate(base.getDate() - i);
+    const startHour = 5 + Math.round(Math.random() * 14); // 5 AM - 7 PM
+    base.setHours(startHour, 0, 0, 0);
+    return {
+      id: i + 1,
+      pace,
+      duration: Math.round(25 + Math.random() * 35),
+      heartRate: Math.round(120 + Math.random() * 40),
+      date: base.toISOString().slice(0, 10),
+      start: base.toISOString(),
+      weather: {
+        temperature: Math.round(40 + pace * 5 + Math.random() * 10),
+        humidity: Math.round(40 + Math.random() * 50),
+        wind: +(Math.random() * 20).toFixed(1),
+        condition: ["Sunny", "Cloudy", "Rain", "Snow"][
+          Math.floor(Math.random() * 4)
+        ],
+      },
+    };
+  });
 }
 
 export async function getRunningSessions(): Promise<RunningSession[]> {


### PR DESCRIPTION
## Summary
- extend mock `RunningSession` data with weather and start time
- compute context-aware session clusters and flag "good" sessions
- highlight good sessions in `SessionSimilarityMap`
- document new `good` flag in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d615726b48324a3b8036f13366aa0