### PR TITLE
Add fragility index gauge

### DIFF
--- a/src/components/dashboard/FragilityGauge.tsx
+++ b/src/components/dashboard/FragilityGauge.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import useFragilityIndex from '@/hooks/useFragilityIndex'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export interface FragilityGaugeProps {
+  /** Diameter of the gauge in pixels */
+  size?: number
+  /** Stroke width for gauge arcs */
+  strokeWidth?: number
+}
+
+/**
+ * Semicircular gauge displaying the behavioral fragility index.
+ */
+export default function FragilityGauge({ size = 160, strokeWidth = 12 }: FragilityGaugeProps) {
+  const index = useFragilityIndex()
+
+  if (index === null) return <Skeleton className="h-32" />
+
+  const radius = size / 2 - strokeWidth / 2
+  const circumference = Math.PI * radius
+  const offset = circumference - index * circumference
+
+  let color = 'hsl(var(--chart-3))'
+  if (index > 0.66) {
+    color = 'hsl(var(--destructive))'
+  } else if (index > 0.33) {
+    color = 'hsl(var(--chart-8))'
+  }
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex flex-col items-center" role="img" aria-label={`Fragility ${index.toFixed(2)}`}> 
+            <svg width={size} height={size / 2} viewBox={`0 0 ${size} ${size / 2}`}>
+              <path
+                d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2 - strokeWidth / 2}`}
+                stroke="hsl(var(--muted))"
+                strokeWidth={strokeWidth}
+                fill="none"
+              />
+              <path
+                d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2 - strokeWidth / 2}`}
+                stroke={color}
+                strokeWidth={strokeWidth}
+                fill="none"
+                strokeDasharray={circumference}
+                strokeDashoffset={offset}
+                strokeLinecap="round"
+              />
+            </svg>
+            <span className="mt-2 text-lg font-bold tabular-nums">{index.toFixed(2)}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          Higher values indicate disrupted routine or sudden load increases
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/dashboard/__tests__/FragilityGauge.test.tsx
+++ b/src/components/dashboard/__tests__/FragilityGauge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import '@testing-library/jest-dom'
+import FragilityGauge from '../FragilityGauge'
+
+vi.mock('@/hooks/useFragilityIndex', () => ({
+  __esModule: true,
+  default: () => 0.42,
+}))
+
+describe('FragilityGauge', () => {
+  it('renders fragility value', () => {
+    render(<FragilityGauge />)
+    expect(screen.getByText('0.42')).toBeInTheDocument()
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -24,3 +24,5 @@ export { default as CompactNextGameCard } from "./CompactNextGameCard";
 
 export { default as MovementFingerprint } from "./MovementFingerprint";
 
+export { default as FragilityGauge } from "./FragilityGauge";
+

--- a/src/hooks/__tests__/useFragilityIndex.test.ts
+++ b/src/hooks/__tests__/useFragilityIndex.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { computeFragilityIndex } from '../useFragilityIndex'
+import type { WeeklyVolumePoint, HourlySteps } from '@/lib/api'
+
+const weekly: WeeklyVolumePoint[] = Array.from({ length: 28 }, (_, i) => ({
+  week: `2025-W${i}`,
+  miles: i === 27 ? 20 : 10,
+}))
+
+const baselineDay: HourlySteps[] = Array.from({ length: 24 }, (_, h) => ({
+  timestamp: `2025-07-29T${String(h).padStart(2,'0')}:00:00Z`,
+  steps: 100,
+}))
+const todayDay: HourlySteps[] = Array.from({ length: 24 }, (_, h) => ({
+  timestamp: `2025-07-30T${String(h).padStart(2,'0')}:00:00Z`,
+  steps: 200,
+}))
+
+const hours = [...baselineDay, ...todayDay]
+
+describe('computeFragilityIndex', () => {
+  it('combines disruption and acwr', () => {
+    const idx = computeFragilityIndex(weekly, hours)
+    expect(idx).toBeCloseTo(0.55, 1)
+  })
+})

--- a/src/hooks/useFragilityIndex.ts
+++ b/src/hooks/useFragilityIndex.ts
@@ -1,0 +1,63 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getHourlySteps, getWeeklyVolume, type HourlySteps, type WeeklyVolumePoint } from '@/lib/api'
+import { computeMovementFingerprint } from './useMovementFingerprint'
+
+function computeAcwr(loads: number[]): number {
+  if (!loads.length) return 0
+  const last7 = loads.slice(-7)
+  const last28 = loads.slice(-28)
+  const recent7 = last7.reduce((s, v) => s + v, 0) / last7.length
+  const recent28 = last28.reduce((s, v) => s + v, 0) / last28.length
+  if (recent28 === 0) return 0
+  return recent7 / recent28
+}
+
+export function computeFragilityIndex(
+  weekly: WeeklyVolumePoint[],
+  hours: HourlySteps[],
+): number {
+  if (!weekly.length || !hours.length) return 0
+
+  const loads = weekly.map((w) => w.miles)
+  const acwr = computeAcwr(loads)
+
+  const byDay: Record<string, HourlySteps[]> = {}
+  hours.forEach((h) => {
+    const day = h.timestamp.slice(0, 10)
+    if (!byDay[day]) byDay[day] = []
+    byDay[day].push(h)
+  })
+  const dates = Object.keys(byDay).sort()
+  if (dates.length < 2) return 0
+  const baselineData = dates.slice(0, -1).flatMap((d) => byDay[d])
+  const todayData = byDay[dates[dates.length - 1]]
+
+  const baseline = computeMovementFingerprint(baselineData)
+  const today = computeMovementFingerprint(todayData)
+
+  let diff = 0
+  let total = 0
+  for (let i = 0; i < 24; i++) {
+    diff += Math.abs(today[i].steps - baseline[i].steps)
+    total += baseline[i].steps
+  }
+  const disruption = total === 0 ? 0 : diff / total
+
+  const index = (disruption + Math.max(0, acwr - 1)) / 2
+  return Math.min(Math.max(index, 0), 1)
+}
+
+export default function useFragilityIndex(): number | null {
+  const [weekly, setWeekly] = useState<WeeklyVolumePoint[] | null>(null)
+  const [hours, setHours] = useState<HourlySteps[] | null>(null)
+
+  useEffect(() => {
+    getWeeklyVolume().then(setWeekly)
+    getHourlySteps().then(setHours)
+  }, [])
+
+  return useMemo(() => {
+    if (!weekly || !hours) return null
+    return computeFragilityIndex(weekly, hours)
+  }, [weekly, hours])
+}


### PR DESCRIPTION
## Summary
- implement `useFragilityIndex` hook and helper
- add `FragilityGauge` component
- export new gauge from dashboard index
- unit tests for fragility index and gauge

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688d611a8bac8324ac5324b412c09f8a