### PR TITLE
Fix chart gradient IDs in fullscreen previews

### DIFF
--- a/src/components/dashboard/StepsTrendWithGoal.tsx
+++ b/src/components/dashboard/StepsTrendWithGoal.tsx
@@ -14,7 +14,7 @@ import {
 import ChartCard from "./ChartCard";
 import type { ChartConfig } from "@/components/ui/chart";
 import type { GarminDay } from "@/lib/api";
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import { useSeasonalBaseline } from "@/hooks/useGarminData";
 import { useRunningStats } from "@/hooks/useRunningStats";
 import { Info } from "lucide-react";
@@ -34,6 +34,8 @@ export function StepsTrendWithGoal({
   goal = 10000,
   window = 7,
 }: StepsTrendWithGoalProps) {
+  const uid = React.useId().replace(/:/g, '')
+  const fillStepsId = `fillSteps-${uid}`
   const dataWithAvg = useMemo(() => {
     return data.map((d, idx) => {
       const start = Math.max(0, idx - window + 1)
@@ -139,7 +141,7 @@ export function StepsTrendWithGoal({
       <ChartContainer config={chartConfig} className="h-60">
         <AreaChart data={dataWithAvg} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <defs>
-            <linearGradient id="fillSteps" x1="0" y1="0" x2="0" y2="1">
+            <linearGradient id={fillStepsId} x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.8} />
               <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0.1} />
             </linearGradient>
@@ -175,7 +177,7 @@ export function StepsTrendWithGoal({
             dataKey="steps"
             type="monotone"
             stroke={chartConfig.steps.color}
-            fill="url(#fillSteps)"
+            fill={`url(#${fillStepsId})`}
             animationDuration={300}
           />
         <Line dataKey="avg" type="monotone" stroke={chartConfig.avg.color} dot={false} animationDuration={300} />

--- a/src/components/examples/AreaChartInteractive.tsx
+++ b/src/components/examples/AreaChartInteractive.tsx
@@ -125,6 +125,9 @@ const chartConfig = {
 
 export default function AreaChartInteractive() {
   const [range, setRange] = React.useState('90d')
+  const uid = React.useId().replace(/:/g, '')
+  const fillRunId = `fillRun-${uid}`
+  const fillBikeId = `fillBike-${uid}`
 
   const filtered = React.useMemo(() => {
     const lastDataDate = new Date(chartData.at(-1)!.date)
@@ -155,11 +158,11 @@ export default function AreaChartInteractive() {
         <ChartContainer config={chartConfig} className="h-60">
           <AreaChart data={filtered}>
             <defs>
-            <linearGradient id="fillRun" x1="0" y1="0" x2="0" y2="1">
+            <linearGradient id={fillRunId} x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.8} />
               <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0.1} />
             </linearGradient>
-            <linearGradient id="fillBike" x1="0" y1="0" x2="0" y2="1">
+            <linearGradient id={fillBikeId} x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor="hsl(var(--chart-2))" stopOpacity={1} />
               <stop offset="95%" stopColor="hsl(var(--chart-2))" stopOpacity={0.1} />
             </linearGradient>
@@ -186,8 +189,8 @@ export default function AreaChartInteractive() {
               }
             />
             <ChartLegend content={<ChartLegendContent />} />
-            <Area dataKey="run" type="natural" fill="url(#fillRun)" stroke="hsl(var(--chart-1))" stackId="a" />
-            <Area dataKey="bike" type="natural" fill="url(#fillBike)" stroke="hsl(var(--chart-2))" stackId="a" />
+            <Area dataKey="run" type="natural" fill={`url(#${fillRunId})`} stroke="hsl(var(--chart-1))" stackId="a" />
+            <Area dataKey="bike" type="natural" fill={`url(#${fillBikeId})`} stroke="hsl(var(--chart-2))" stackId="a" />
           </AreaChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -36,7 +36,14 @@ export default function ChartPreview({
             <span className="sr-only">Close</span>
           </button>
         </DialogClose>
-        {React.cloneElement(children)}
+        {
+          React.isValidElement(children)
+            ? React.createElement(children.type, {
+                ...children.props,
+                key: 'dialog',
+              })
+            : children
+        }
       </DialogContentFullscreen>
     </Dialog>
   )

--- a/src/components/examples/TimeInBedChart.tsx
+++ b/src/components/examples/TimeInBedChart.tsx
@@ -39,6 +39,8 @@ const chartConfig = {
 } satisfies ChartConfig
 
 export default function TimeInBedChart() {
+  const uid = React.useId().replace(/:/g, '')
+  const fillHoursId = `fillHours-${uid}`
   const dataWithAvg = React.useMemo(() => {
     return sleepData.map((d, idx) => {
       const start = Math.max(0, idx - 6)
@@ -58,7 +60,7 @@ export default function TimeInBedChart() {
         <ChartContainer config={chartConfig} className='h-60'>
           <AreaChart data={dataWithAvg} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
             <defs>
-              <linearGradient id='fillHours' x1='0' y1='0' x2='0' y2='1'>
+              <linearGradient id={fillHoursId} x1='0' y1='0' x2='0' y2='1'>
                 <stop offset='5%' stopColor='hsl(var(--chart-1))' stopOpacity={0.8} />
                 <stop offset='95%' stopColor='hsl(var(--chart-1))' stopOpacity={0.1} />
               </linearGradient>
@@ -83,7 +85,7 @@ export default function TimeInBedChart() {
                 />
               }
             />
-            <Area type='monotone' dataKey='hours' stroke={chartConfig.hours.color} fill='url(#fillHours)' />
+            <Area type='monotone' dataKey='hours' stroke={chartConfig.hours.color} fill={`url(#${fillHoursId})`} />
             <Line type='monotone' dataKey='avg' stroke={chartConfig.avg.color} dot={false} />
           </AreaChart>
         </ChartContainer>


### PR DESCRIPTION
## Summary
- generate unique gradient IDs in AreaChartInteractive, TimeInBedChart, and StepsTrendWithGoal to avoid conflicts when charts are cloned in ChartPreview
- ensure ChartPreview re-renders children so gradients remain unique in dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d312ea7a483249f81d97c0cc12417