### PR TITLE
feat: add weather overlay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,10 @@ SPOTIFY_REFRESH_TOKEN=<refresh token>
 ```
 
 Alternatively provide `SPOTIFY_ACCESS_TOKEN` directly if you already have one. These values are read at runtime by `src/lib/spotify.ts`.
+
+## Weather overlay
+The geographic explorer can display precipitation tiles from OpenWeatherMap. Provide an API key to enable this overlay:
+
+```
+VITE_WEATHER_KEY=<your OpenWeatherMap API key>
+```

--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -31,6 +31,8 @@ import CITY_COORDS from "@/lib/cityCoords";
 import { fipsToAbbr } from "@/lib/stateCodes";
 
 
+const weatherKey = import.meta.env.VITE_WEATHER_KEY;
+
 export default function GeoActivityExplorer() {
   const data = useStateVisits();
   const [expandedState, setExpandedState] = useState<string | null>(null);
@@ -206,7 +208,12 @@ export default function GeoActivityExplorer() {
         />
 
         <label className="flex items-center gap-1 text-xs">
-          <input type="checkbox" checked={showWeather} onChange={() => setShowWeather(!showWeather)} />
+          <input
+            type="checkbox"
+            checked={showWeather}
+            onChange={() => setShowWeather(!showWeather)}
+            disabled={!weatherKey}
+          />
           Weather
         </label>
 
@@ -257,12 +264,12 @@ export default function GeoActivityExplorer() {
                 }}
               />
             </Source>
-            {showWeather && (
+            {showWeather && weatherKey && (
               <Source
                 id="wx"
                 type="raster"
                 tiles={[
-                  `https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=YOUR_API_KEY`,
+                  `https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=${weatherKey}`,
                 ]}
                 tileSize={256}
               >


### PR DESCRIPTION
## Summary
- read OpenWeatherMap key from `VITE_WEATHER_KEY`
- disable precipitation overlay when the key isn't set
- document the weather key environment variable

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688d69a558688324b4110fc007c49a6a