### PR TITLE
feat: add route similarity index

### DIFF
--- a/src/components/dashboard/RouteSimilarity.tsx
+++ b/src/components/dashboard/RouteSimilarity.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Card } from '@/components/ui/card'
+import useRouteSimilarity from '@/hooks/useRouteSimilarity'
+
+export default function RouteSimilarity() {
+  const result = useRouteSimilarity()
+
+  if (!result) {
+    return <Card className="p-4">Calculating...</Card>
+  }
+
+  const { routeA, routeB, similarity } = result
+
+  return (
+    <Card className="p-4 space-y-2">
+      <h2 className="font-semibold">Route Similarity</h2>
+      <p>
+        Comparing <span className="font-medium">{routeA.name}</span> with{' '}
+        <span className="font-medium">{routeB.name}</span>.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Jaccard similarity: {(similarity * 100).toFixed(1)}%
+      </p>
+    </Card>
+  )
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -28,4 +28,6 @@ export { default as FragilityGauge } from "./FragilityGauge";
 
 export { default as TrainingEntropyHeatmap } from "./TrainingEntropyHeatmap";
 
+export { default as RouteSimilarity } from "./RouteSimilarity";
+
 

--- a/src/hooks/useRouteSimilarity.ts
+++ b/src/hooks/useRouteSimilarity.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import { getMockRoutes, calculateRouteSimilarity, Route } from '@/lib/api'
+
+export interface RouteSimilarityResult {
+  routeA: Route
+  routeB: Route
+  similarity: number
+}
+
+export function useRouteSimilarity(): RouteSimilarityResult | null {
+  const [result, setResult] = useState<RouteSimilarityResult | null>(null)
+
+  useEffect(() => {
+    getMockRoutes().then((routes) => {
+      if (routes.length < 2) return
+      const [routeA, routeB] = routes
+      const similarity = calculateRouteSimilarity(routeA.points, routeB.points)
+      setResult({ routeA, routeB, similarity })
+    })
+  }, [])
+
+  return result
+}
+
+export default useRouteSimilarity

--- a/src/lib/__tests__/routeSimilarity.test.ts
+++ b/src/lib/__tests__/routeSimilarity.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { calculateRouteSimilarity, LatLon } from '../api'
+
+describe('calculateRouteSimilarity', () => {
+  it('returns 1 for identical routes', () => {
+    const route: LatLon[] = [
+      { lat: 0, lon: 0 },
+      { lat: 1, lon: 1 },
+    ]
+    expect(calculateRouteSimilarity(route, route)).toBe(1)
+  })
+
+  it('returns 0 for disjoint routes', () => {
+    const a: LatLon[] = [{ lat: 0, lon: 0 }]
+    const b: LatLon[] = [{ lat: 10, lon: 10 }]
+    expect(calculateRouteSimilarity(a, b)).toBe(0)
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -851,6 +851,59 @@ export async function getRouteSessions(route: string): Promise<RouteSession[]> {
   });
 }
 
+// ----- Route similarity -----
+
+export interface LatLon {
+  lat: number;
+  lon: number;
+}
+
+export interface Route {
+  name: string;
+  points: LatLon[];
+}
+
+const mockMadisonRoutes: Route[] = [
+  {
+    name: "Lake Mendota Loop",
+    points: [
+      { lat: 43.079, lon: -89.4 },
+      { lat: 43.083, lon: -89.392 },
+      { lat: 43.079, lon: -89.392 },
+      { lat: 43.075, lon: -89.398 },
+    ],
+  },
+  {
+    name: "Capitol Square Loop",
+    points: [
+      { lat: 43.074, lon: -89.384 },
+      { lat: 43.079, lon: -89.392 },
+      { lat: 43.076, lon: -89.399 },
+      { lat: 43.072, lon: -89.391 },
+    ],
+  },
+];
+
+export async function getMockRoutes(): Promise<Route[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockMadisonRoutes), 200);
+  });
+}
+
+export function calculateRouteSimilarity(
+  a: LatLon[],
+  b: LatLon[],
+  precision = 3,
+): number {
+  const toKey = ({ lat, lon }: LatLon) =>
+    `${lat.toFixed(precision)},${lon.toFixed(precision)}`;
+  const setA = new Set(a.map(toKey));
+  const setB = new Set(b.map(toKey));
+  const intersection = [...setA].filter((p) => setB.has(p));
+  const union = new Set([...setA, ...setB]);
+  return union.size === 0 ? 0 : intersection.length / union.size;
+}
+
 // ----- Sleep sessions -----
 
 export interface SleepSession {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useGarminData } from "@/hooks/useGarminData";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
+import RouteSimilarity from "@/components/dashboard/RouteSimilarity";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
@@ -26,6 +27,7 @@ export default function Dashboard() {
     <Tabs value={activeTab} onValueChange={setActiveTab}>
       <TabsList>
         <TabsTrigger value="map">Map playground</TabsTrigger>
+        <TabsTrigger value="route">Route similarity</TabsTrigger>
         <TabsTrigger value="examples">Analytics fun</TabsTrigger>
       </TabsList>
       <TabsContent value="map">
@@ -58,6 +60,9 @@ export default function Dashboard() {
             quantify novelty.
           </p>
         </div>
+      </TabsContent>
+      <TabsContent value="route">
+        <RouteSimilarity />
       </TabsContent>
       <TabsContent value="examples">
         <Examples />


### PR DESCRIPTION
## Summary
- compute Jaccard-based route similarity on mock Madison GPS tracks
- expose similarity via hook and dashboard Route Similarity tab
- test Jaccard helper for identical and disjoint routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6176fe248324ad6e657babc11f5b