### PR TITLE
fix: ensure chart preview dialog renders above overlay

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -29,7 +29,7 @@ export default function ChartPreview({
         </DialogTrigger>
         {children}
       </div>
-      <DialogContentFullscreen className="relative">
+      <DialogContentFullscreen>
         <DialogClose asChild>
           <button className="absolute right-4 top-4 z-50 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground">
             <X className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- make fullscreen chart preview content use default fixed positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d69322f888324abc0f9aabd0ef451