### PR TITLE
Add statistics tab and simplify map content

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useGarminData } from "@/hooks/useGarminData";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
+import Statistics from "@/pages/Statistics";
 import RouteSimilarity from "@/components/dashboard/RouteSimilarity";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -29,36 +30,11 @@ export default function Dashboard() {
         <TabsTrigger value="map">Map playground</TabsTrigger>
         <TabsTrigger value="route">Route similarity</TabsTrigger>
         <TabsTrigger value="examples">Analytics fun</TabsTrigger>
+        <TabsTrigger value="statistics">Statistics</TabsTrigger>
       </TabsList>
       <TabsContent value="map">
-        <div className="p-6 text-muted-foreground space-y-4">
-          <p>Habit Consistency Heatmap</p>
-          <p>
-            X-axis: day of week, Y-axis: hour-of-day; cell intensity = frequency
-            of activity.
-          </p>
-          <p>
-            Overlay changes over rolling windows to show when a user’s routine
-            drifts
-          </p>
-
-          <p>“Good Day” Contextual Cluster Explorer</p>
-          <p>
-            Cluster sessions based on weather, time of day, and physiological
-            state; highlight clusters where pace/performance exceeded
-            expectation. Could be a small multiple of scatter plots annotated
-            with context.
-          </p>
-
-          <p>
-            Entropy of session start times (habit strength) — low entropy =
-            strong routine.
-          </p>
-
-          <p>
-            Route similarity index (e.g., Jaccard on GPS track clusters) to
-            quantify novelty.
-          </p>
+        <div className="p-6 text-muted-foreground">
+          Map playground details coming soon.
         </div>
       </TabsContent>
       <TabsContent value="route">
@@ -66,6 +42,9 @@ export default function Dashboard() {
       </TabsContent>
       <TabsContent value="examples">
         <Examples />
+      </TabsContent>
+      <TabsContent value="statistics">
+        <Statistics />
       </TabsContent>
     </Tabs>
   );


### PR DESCRIPTION
## Summary
- add Statistics tab on dashboard
- streamline map tab with concise placeholder

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d6b68526c8324beba7789edc46e5b