### PR TITLE
Add TrainingEntropyHeatmap to examples page

### DIFF
--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -29,6 +29,7 @@ import GhostSelfRivalChart from "@/components/examples/GhostSelfRivalChart";
 
 import WeeklyVolumeHistoryChart from "@/components/examples/WeeklyVolumeHistoryChart";
 import ReadingProbabilityTimeline from "@/components/dashboard/ReadingProbabilityTimeline";
+import TrainingEntropyHeatmap from "@/components/dashboard/TrainingEntropyHeatmap";
 
 
 import ReadingStackSplit from "@/components/dashboard/ReadingStackSplit";
@@ -61,6 +62,9 @@ export default function Examples() {
       </ChartPreview>
       <ChartPreview>
         <ReadingProbabilityTimeline />
+      </ChartPreview>
+      <ChartPreview>
+        <TrainingEntropyHeatmap />
       </ChartPreview>
 
       <ChartPreview>


### PR DESCRIPTION
## Summary
- showcase TrainingEntropyHeatmap in Examples page for easy access

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d6d7bddcc8324be0c40bc2fc20e1d