### PR TITLE
feat: add habit consistency heatmap

### DIFF
--- a/src/components/statistics/HabitConsistencyHeatmap.tsx
+++ b/src/components/statistics/HabitConsistencyHeatmap.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import ChartCard from "@/components/dashboard/ChartCard"
+import { ChartContainer } from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import useTrainingConsistency from "@/hooks/useTrainingConsistency"
+
+const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+export default function HabitConsistencyHeatmap() {
+  const data = useTrainingConsistency()
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const grid = Array.from({ length: 24 }, () =>
+    Array.from({ length: 7 }, () => ({ count: 0 })),
+  )
+  let max = 0
+  data.heatmap.forEach((c) => {
+    grid[c.hour][c.day] = c
+    if (c.count > max) max = c.count
+  })
+
+  return (
+    <ChartCard
+      title="Habit Consistency"
+      description="Session count by weekday and hour"
+    >
+      <ChartContainer config={{}} className="h-64">
+        <div className="grid gap-px text-center text-[10px]">
+          <div className="grid grid-cols-7 text-xs font-medium">
+            {dayLabels.map((d) => (
+              <div key={d}>{d}</div>
+            ))}
+          </div>
+          {grid.map((row, hour) => (
+            <div key={hour} className="grid grid-cols-7">
+              {row.map((cell, idx) => (
+                <div
+                  key={idx}
+                  className="flex items-center justify-center border bg-accent text-accent-foreground h-4"
+                  style={{ opacity: max ? cell.count / max : 0 }}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </ChartContainer>
+    </ChartCard>
+  )
+}
+

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -8,6 +8,7 @@ export { default as HeartRateZones } from "./HeartRateZones";
 export { default as PaceVsHR } from "./PaceVsHR";
 export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
+export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 
 export { default as RunBikeVolumeComparison } from "./RunBikeVolumeComparison";
 export { default as WeeklyComparisonChart } from "./WeeklyComparisonChart";

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -3,13 +3,14 @@
 
 import { ChartSelectionProvider } from "@/components/dashboard"
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters"
+import { HabitConsistencyHeatmap } from "@/components/statistics"
 
 export default function Statistics() {
   return (
     <DashboardFiltersProvider>
       <ChartSelectionProvider>
-        <div className="p-6 text-center text-muted-foreground">
-          Statistics charts coming soon...
+        <div className="p-6">
+          <HabitConsistencyHeatmap />
         </div>
       </ChartSelectionProvider>
     </DashboardFiltersProvider>


### PR DESCRIPTION
## Summary
- add HabitConsistencyHeatmap component to visualize session counts by weekday and hour
- export new heatmap and render it on the Statistics page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d6b81c7888324b8b95ef77dbed6e5