### PR TITLE
feat: add animated circular close button

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Eye, X } from 'lucide-react'
+import { Eye, XCircle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import {
@@ -31,9 +31,11 @@ export default function ChartPreview({
       </div>
       <DialogContentFullscreen>
         <DialogClose asChild>
-          <button className="absolute right-4 top-4 z-50 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground">
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
+          <button
+            className='absolute right-4 top-4 z-50 rounded-full bg-background/80 p-2 text-muted-foreground shadow transition-transform duration-150 hover:rotate-90 hover:scale-110 hover:text-foreground focus:outline-none focus:ring-2'
+          >
+            <XCircle className='h-4 w-4' />
+            <span className='sr-only'>Close</span>
           </button>
         </DialogClose>
         {


### PR DESCRIPTION
## Summary
- enhance ChartPreview dialog close button with circular styling and animated hover effects

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d6f1d094c8324a33674a69aed70e0