### PR TITLE
feat: add route novelty scoring

### DIFF
--- a/src/lib/__tests__/routeNovelty.test.ts
+++ b/src/lib/__tests__/routeNovelty.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeRouteNovelty,
+  recordRouteRun,
+  getRouteRunHistory,
+  LatLon,
+} from '../api'
+import { computeNoveltyTrend } from '../utils'
+
+describe('computeRouteNovelty', () => {
+  it('returns 1 when no history', () => {
+    const route: LatLon[] = [{ lat: 0, lon: 0 }]
+    expect(computeRouteNovelty(route, [])).toBe(1)
+  })
+})
+
+describe('recordRouteRun', () => {
+  it('stores runs and calculates novelty', () => {
+    const a: LatLon[] = [
+      { lat: 0, lon: 0 },
+      { lat: 1, lon: 1 },
+    ]
+    const b: LatLon[] = [
+      { lat: 0, lon: 0 },
+      { lat: 1.05, lon: 1.05 },
+    ]
+    const c: LatLon[] = [{ lat: 10, lon: 10 }]
+
+    const run1 = recordRouteRun(a)
+    const run2 = recordRouteRun(b)
+    const run3 = recordRouteRun(c)
+
+    expect(run1.novelty).toBe(1)
+    expect(run2.novelty).toBeLessThan(0.05)
+    expect(run3.novelty).toBeGreaterThan(0.8)
+    expect(getRouteRunHistory()).toHaveLength(3)
+  })
+})
+
+describe('computeNoveltyTrend', () => {
+  it('flags prolonged low novelty', () => {
+    const today = new Date()
+    const runs = Array.from({ length: 20 }, (_, i) => {
+      const d = new Date(today)
+      d.setDate(d.getDate() - (19 - i))
+      return {
+        timestamp: d.toISOString(),
+        points: [],
+        novelty: i < 7 ? 0.9 : 0.1,
+      }
+    })
+    const { trend, prolongedLow } = computeNoveltyTrend(runs, 7, 0.2)
+    expect(trend).toHaveLength(20)
+    expect(prolongedLow).toBe(true)
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,32 @@ export function generateTrendMessage(): string {
   return `Trending ${direction} by ${percentage}% this month`
 }
 
+import type { RouteRun, MetricDay } from './api'
+
+export function computeNoveltyTrend(
+  runs: RouteRun[],
+  windowDays = 7,
+  threshold = 0.3,
+): { trend: MetricDay[]; prolongedLow: boolean } {
+  const sorted = [...runs].sort((a, b) =>
+    a.timestamp.localeCompare(b.timestamp),
+  )
+  const trend: MetricDay[] = []
+  for (const run of sorted) {
+    const current = new Date(run.timestamp)
+    const windowStart = new Date(current)
+    windowStart.setDate(current.getDate() - (windowDays - 1))
+    const windowRuns = sorted.filter((r) => {
+      const d = new Date(r.timestamp)
+      return d >= windowStart && d <= current
+    })
+    const avg =
+      windowRuns.reduce((sum, r) => sum + r.novelty, 0) / windowRuns.length
+    trend.push({ date: run.timestamp.slice(0, 10), value: +avg.toFixed(3) })
+  }
+  const prolongedLow =
+    trend.length >= windowDays &&
+    trend.slice(-windowDays).every((t) => t.value < threshold)
+  return { trend, prolongedLow }
+}
+


### PR DESCRIPTION
## Summary
- add dynamic-time-warping novelty scoring for GPS routes
- expose helpers to record runs and compute novelty history
- provide 7-day rolling novelty trend utility with low-novelty flag
- combine DTW and spatial overlap to better judge route similarity

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688d707094708324825553d672ecc6a2