### PR TITLE
feat: make charts responsive

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -53,7 +53,7 @@ export function ActivitiesChart() {
       className="md:col-span-2"
       lastSync={data.lastSync}
     >
-      <ChartContainer config={chartConfig} className="h-60">
+      <ChartContainer config={chartConfig} className="h-60 md:h-80 lg:h-96">
         <LineChart data={activities} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/dashboard/ChartCard.tsx
+++ b/src/components/dashboard/ChartCard.tsx
@@ -12,7 +12,7 @@ export interface ChartCardProps {
 
 export function ChartCard({ title, description, className, children, lastSync }: ChartCardProps) {
   return (
-    <Card className={cn(className)}>
+    <Card className={cn("flex h-full flex-col", className)}>
       {(title || description) && (
         <CardHeader>
           {title && <CardTitle>{title}</CardTitle>}
@@ -22,7 +22,7 @@ export function ChartCard({ title, description, className, children, lastSync }:
           )}
         </CardHeader>
         )}
-      <CardContent className="pt-0">{children}</CardContent>
+      <CardContent className="flex-1 pt-0">{children}</CardContent>
     </Card>
   );
 }

--- a/src/components/dashboard/DailyStepsChart.tsx
+++ b/src/components/dashboard/DailyStepsChart.tsx
@@ -31,7 +31,7 @@ export function DailyStepsChart({ data }: DailyStepsChartProps) {
       description="Historical daily step totals"
       className="md:col-span-2"
     >
-      <ChartContainer config={chartConfig} className="h-60">
+      <ChartContainer config={chartConfig} className="h-60 md:h-80 lg:h-96">
       <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis

--- a/src/components/dashboard/MovementFingerprint.tsx
+++ b/src/components/dashboard/MovementFingerprint.tsx
@@ -13,7 +13,7 @@ export default function MovementFingerprint() {
 
   return (
     <ChartCard title="Movement Fingerprint" description="Average steps by hour">
-      <ChartContainer config={{}} className="h-24">
+      <ChartContainer config={{}} className="h-24 md:h-32 lg:h-40">
         <div
           className="grid gap-px h-full text-[10px]"
           style={{ gridTemplateColumns: "repeat(24, minmax(0, 1fr))" }}

--- a/src/components/dashboard/ReadingFocusHeatmap.tsx
+++ b/src/components/dashboard/ReadingFocusHeatmap.tsx
@@ -30,7 +30,7 @@ export default function ReadingFocusHeatmap() {
 
   return (
     <ChartCard title="Reading Focus" description="When you read most intently">
-      <ChartContainer config={{}} className="h-64">
+      <ChartContainer config={{}} className="h-64 md:h-80 lg:h-96">
         <div className="grid gap-px text-center text-[10px] h-full">
           <div className="grid grid-cols-7 text-xs font-medium">
             {dayLabels.map((d) => (

--- a/src/components/dashboard/ReadingProbabilityTimeline.tsx
+++ b/src/components/dashboard/ReadingProbabilityTimeline.tsx
@@ -55,7 +55,7 @@ export default function ReadingProbabilityTimeline() {
 
   return (
     <ChartCard title="Reading Probability" description="Likelihood of reading throughout the day">
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <AreaChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="time" tickFormatter={(t) => String(new Date(t).getHours())} />

--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -39,7 +39,7 @@ export default function ReadingStackSplit() {
 
   return (
     <ChartCard title="Reading Stack Split" description="Time by device">
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <PieChart width={200} height={160}>
           <ChartTooltip />
           <ChartLegend

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -103,7 +103,7 @@ export function StepsChart({ active = true }: StepsChartProps = {}) {
 
       <ChartContainer
         config={chartConfig}
-        className="h-60 md:col-span-2"
+        className="h-60 md:h-80 lg:h-96 md:col-span-2"
         title="Daily Steps"
       >
 
@@ -119,7 +119,7 @@ export function StepsChart({ active = true }: StepsChartProps = {}) {
 
     <ChartContainer
       config={chartConfig}
-      className="h-60 md:col-span-2"
+      className="h-60 md:h-80 lg:h-96 md:col-span-2"
       title="Daily Steps"
     >
       <BarChart data={enriched} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/dashboard/StepsTrendWithGoal.tsx
+++ b/src/components/dashboard/StepsTrendWithGoal.tsx
@@ -138,7 +138,7 @@ export function StepsTrendWithGoal({
       description="How your pace changes over time (e.g., affected by weather or effort)"
       className="md:col-span-2"
     >
-      <ChartContainer config={chartConfig} className="h-60">
+      <ChartContainer config={chartConfig} className="h-60 md:h-80 lg:h-96">
         <AreaChart data={dataWithAvg} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <defs>
             <linearGradient id={fillStepsId} x1="0" y1="0" x2="0" y2="1">

--- a/src/components/dashboard/TimeInBedChart.tsx
+++ b/src/components/dashboard/TimeInBedChart.tsx
@@ -29,7 +29,7 @@ export default function TimeInBedChart() {
 
   return (
     <ChartCard title="Time in Bed" description="Hours spent in bed each night">
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/dashboard/TrainingEntropyHeatmap.tsx
+++ b/src/components/dashboard/TrainingEntropyHeatmap.tsx
@@ -28,7 +28,7 @@ export default function TrainingEntropyHeatmap() {
       title="Training Consistency"
       description="Low entropy + steady volume indicates a robust routine; spikes signal schedule disruption."
     >
-      <ChartContainer config={{}} className="h-64">
+      <ChartContainer config={{}} className="h-64 md:h-80 lg:h-96">
         <div className="grid gap-2 h-full" style={{ gridTemplateRows: "1fr auto" }}>
           <div className="grid gap-px text-center text-[10px] overflow-y-auto">
             <div className="grid grid-cols-7 text-xs font-medium">
@@ -48,7 +48,7 @@ export default function TrainingEntropyHeatmap() {
               </div>
             ))}
           </div>
-          <div className="h-24 w-full">
+          <div className="h-24 md:h-32 lg:h-40 w-full">
             <LineChart data={entropySeries} margin={{ top: 0, right: 20, bottom: 0, left: 0 }}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="week" tick={{ fontSize: 10 }} />

--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -33,7 +33,7 @@ export default function WeeklyVolumeChart() {
 
   return (
     <ChartCard title="Weekly Volume" description="Historical weekly mileage totals">
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/examples/AreaChartInteractive.tsx
+++ b/src/components/examples/AreaChartInteractive.tsx
@@ -155,7 +155,7 @@ export default function AreaChartInteractive() {
         />
       </CardHeader>
       <CardContent className="pt-0">
-        <ChartContainer config={chartConfig} className="h-60">
+        <ChartContainer config={chartConfig} className="h-60 md:h-80 lg:h-96">
           <AreaChart data={filtered}>
             <defs>
             <linearGradient id={fillRunId} x1="0" y1="0" x2="0" y2="1">

--- a/src/components/examples/AreaChartLoadRatio.tsx
+++ b/src/components/examples/AreaChartLoadRatio.tsx
@@ -47,7 +47,7 @@ export default function AreaChartLoadRatio() {
         <CardDescription>Short-term load compared to longer-term training baseline (last 4 weeks)</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-64'>
+        <ChartContainer config={chartConfig} className='h-64 md:h-80 lg:h-96'>
           <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis

--- a/src/components/examples/BarChartDefault.tsx
+++ b/src/components/examples/BarChartDefault.tsx
@@ -46,7 +46,7 @@ export default function ChartBarDefault() {
         <CardDescription>Total mileage per month (January – June 2024)</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-60'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis

--- a/src/components/examples/BarChartExamples.tsx
+++ b/src/components/examples/BarChartExamples.tsx
@@ -77,7 +77,7 @@ const negativeConfig = {
 export default function BarChartExamples() {
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      <ChartContainer config={simpleConfig} className="h-60" title="Simple Bar">
+      <ChartContainer config={simpleConfig} className="h-60 md:h-80 lg:h-96" title="Simple Bar">
         <BarChart data={simpleData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
@@ -89,7 +89,7 @@ export default function BarChartExamples() {
 
       <ChartContainer
         config={stackedConfig}
-        className="h-60"
+        className="h-60 md:h-80 lg:h-96"
         title="Stacked Bar"
       >
         <BarChart data={stackedData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
@@ -106,7 +106,7 @@ export default function BarChartExamples() {
 
       <ChartContainer
         config={groupedConfig}
-        className="h-60"
+        className="h-60 md:h-80 lg:h-96"
         title="Grouped Bar"
       >
         <BarChart data={groupedData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
@@ -123,7 +123,7 @@ export default function BarChartExamples() {
 
       <ChartContainer
         config={horizontalConfig}
-        className="h-60"
+        className="h-60 md:h-80 lg:h-96"
         title="Horizontal Bar"
       >
         <BarChart
@@ -141,7 +141,7 @@ export default function BarChartExamples() {
 
       <ChartContainer
         config={negativeConfig}
-        className="h-60"
+        className="h-60 md:h-80 lg:h-96"
         title="Negative Bar"
       >
         <BarChart data={negativeData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>

--- a/src/components/examples/BarChartHorizontal.tsx
+++ b/src/components/examples/BarChartHorizontal.tsx
@@ -45,7 +45,7 @@ export default function ChartBarHorizontal() {
         <CardDescription>Distribution of run/bike session distances (e.g., how often you do short vs long efforts)</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-60'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
           <BarChart
             accessibilityLayer
             data={chartData}

--- a/src/components/examples/BarChartInteractive.tsx
+++ b/src/components/examples/BarChartInteractive.tsx
@@ -94,7 +94,7 @@ export default function BarChartInteractive() {
         </div>
       </CardHeader>
       <CardContent className='px-2 sm:p-6'>
-        <ChartContainer config={chartConfig} className='aspect-auto h-[250px] w-full'>
+        <ChartContainer config={chartConfig} className='aspect-auto h-[250px] md:h-[300px] lg:h-[350px] w-full'>
           <BarChart
             accessibilityLayer
             data={chartData}

--- a/src/components/examples/BarChartLabelCustom.tsx
+++ b/src/components/examples/BarChartLabelCustom.tsx
@@ -45,7 +45,7 @@ export default function ChartBarLabelCustom() {
         <CardDescription>Mileage or sessions per custom category (e.g., favorite routes, segments, or surfaces)</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-60'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
           <BarChart accessibilityLayer data={chartData} layout='vertical' margin={{ right: 16 }}>
             <CartesianGrid horizontal={false} />
             <YAxis

--- a/src/components/examples/BarChartMixed.tsx
+++ b/src/components/examples/BarChartMixed.tsx
@@ -47,7 +47,7 @@ export default function ChartBarMixed() {
         <CardDescription>Total sessions or volume by type (Run / Bike / Walk / Other)</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-60'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
           <BarChart accessibilityLayer data={chartData} layout='vertical' margin={{ left: 0 }}>
             <YAxis
               dataKey='activity'

--- a/src/components/examples/LineChartInteractive.tsx
+++ b/src/components/examples/LineChartInteractive.tsx
@@ -132,7 +132,7 @@ export default function LineChartInteractive() {
   )
 
   return (
-    <Card className="py-4 sm:py-0">
+    <Card className="flex h-full flex-col py-4 sm:py-0">
       <CardHeader className="flex flex-col items-stretch border-b !p-0 sm:flex-row">
         <div className="flex flex-1 flex-col justify-center gap-1 px-6 pb-3 sm:pb-0">
           <CardTitle>Average Pace / Speed</CardTitle>
@@ -154,8 +154,8 @@ export default function LineChartInteractive() {
           ))}
         </div>
       </CardHeader>
-      <CardContent className="px-2 sm:p-6">
-        <ChartContainer config={chartConfig} className="aspect-auto h-[250px] w-full">
+      <CardContent className="flex-1 px-2 sm:p-6">
+        <ChartContainer config={chartConfig} className="aspect-auto h-[250px] md:h-[300px] lg:h-[350px] w-full">
           <LineChart accessibilityLayer data={chartData} margin={{ left: 12, right: 12 }}>
             <CartesianGrid vertical={false} />
             <XAxis

--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -102,7 +102,7 @@ export default function PerfVsEnvironmentMatrixExample() {
           { value: "elevation", label: "Elevation" },
         ]}
       />
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <ScatterChart>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey={variable} name={axisLabels[variable]} />

--- a/src/components/examples/RadarChartDefault.tsx
+++ b/src/components/examples/RadarChartDefault.tsx
@@ -47,7 +47,7 @@ export default function ChartRadarDefault() {
       <CardContent className='pb-0'>
         <ChartContainer
           config={chartConfig}
-          className='mx-auto aspect-square max-h-[250px]'
+          className='mx-auto aspect-square max-h-[250px] md:max-h-[300px] lg:max-h-[350px]'
         >
           <RadarChart data={chartData}>
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />

--- a/src/components/examples/RadarChartDots.tsx
+++ b/src/components/examples/RadarChartDots.tsx
@@ -46,7 +46,7 @@ export default function ChartRadarDots() {
         <CardDescription>Mileage consistency and variation by month over the last 6 months</CardDescription>
       </CardHeader>
       <CardContent className='pb-0'>
-        <ChartContainer config={chartConfig} className='mx-auto aspect-square max-h-[250px]'>
+        <ChartContainer config={chartConfig} className='mx-auto aspect-square max-h-[250px] md:max-h-[300px] lg:max-h-[350px]'>
           <RadarChart data={chartData}>
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
             <PolarAngleAxis dataKey='month' />

--- a/src/components/examples/RadarChartWorkoutByTime.tsx
+++ b/src/components/examples/RadarChartWorkoutByTime.tsx
@@ -53,7 +53,7 @@ export default function RadarChartWorkoutByTime() {
       <CardContent className='pb-0'>
         <ChartContainer
           config={chartConfig}
-          className='mx-auto aspect-square max-h-[250px]'
+          className='mx-auto aspect-square max-h-[250px] md:max-h-[300px] lg:max-h-[350px]'
         >
           <RadarChart data={chartData}>
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />

--- a/src/components/examples/RadialChartGrid.tsx
+++ b/src/components/examples/RadialChartGrid.tsx
@@ -61,7 +61,7 @@ export default function ChartRadialGrid() {
       <CardContent className='flex-1 pb-0'>
         <ChartContainer
           config={chartConfig}
-          className='mx-auto aspect-square max-h-[250px]'
+          className='mx-auto aspect-square max-h-[250px] md:max-h-[300px] lg:max-h-[350px]'
         >
           <RadialBarChart
             data={labelledData}

--- a/src/components/examples/RadialChartLabel.tsx
+++ b/src/components/examples/RadialChartLabel.tsx
@@ -49,7 +49,7 @@ export default function ChartRadialLabel() {
       <CardContent className='flex-1 pb-0'>
         <ChartContainer
           config={chartConfig}
-          className='mx-auto aspect-square max-h-[250px]'
+          className='mx-auto aspect-square max-h-[250px] md:max-h-[300px] lg:max-h-[350px]'
         >
           <RadialBarChart
             data={chartData}

--- a/src/components/examples/RadialChartText.tsx
+++ b/src/components/examples/RadialChartText.tsx
@@ -48,7 +48,7 @@ export default function ChartRadialText() {
       <CardContent className='flex-1 pb-0'>
         <ChartContainer
           config={chartConfig}
-          className='mx-auto aspect-square max-h-[250px]'
+          className='mx-auto aspect-square max-h-[250px] md:max-h-[300px] lg:max-h-[350px]'
         >
           <RadialBarChart
             data={chartData}

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -48,7 +48,7 @@ export default function ScatterChartPaceHeartRate() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-64">
+        <ChartContainer config={chartConfig} className="h-64 md:h-80 lg:h-96">
           <ScatterChart>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="pace" name="Pace (min/mi)" />

--- a/src/components/examples/ShoeUsageChart.tsx
+++ b/src/components/examples/ShoeUsageChart.tsx
@@ -39,7 +39,7 @@ export default function ShoeUsageChart() {
         <CardDescription>Miles logged per shoe model (wear tracking)</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-60'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
           <BarChart accessibilityLayer data={chartData}>
             <CartesianGrid vertical={false} />
             <XAxis dataKey='model' tickLine={false} tickMargin={10} axisLine={false} />

--- a/src/components/examples/TimeInBedChart.tsx
+++ b/src/components/examples/TimeInBedChart.tsx
@@ -57,7 +57,7 @@ export default function TimeInBedChart() {
         <CardDescription>Nightly sleep duration with 7‑day average</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className='h-60'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
           <AreaChart data={dataWithAvg} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
             <defs>
               <linearGradient id={fillHoursId} x1='0' y1='0' x2='0' y2='1'>

--- a/src/components/examples/TreadmillVsOutdoor.tsx
+++ b/src/components/examples/TreadmillVsOutdoor.tsx
@@ -49,7 +49,7 @@ export default function TreadmillVsOutdoorExample() {
         </CardDescription>
       </CardHeader>
       <CardContent className='flex flex-1 items-center pb-0'>
-        <ChartContainer config={chartConfig} className='h-60 w-full'>
+        <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96 w-full'>
           <BarChart data={monthlyData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='month' tickLine={false} tickMargin={10} axisLine={false} tickFormatter={(v) => v.slice(0, 3)} />

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -39,7 +39,7 @@ export default function WeeklyVolumeHistoryChart() {
       title="Weekly Training Volume"
       description="Historical weekly mileage totals (run + bike)"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <BarChart data={filtered} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -182,7 +182,7 @@ export default function GeoActivityExplorer() {
       <ChartContainer
         config={legendConfig}
         title="State Visits"
-        className="h-60 space-y-6"
+        className="h-60 md:h-80 lg:h-96 space-y-6"
       >
       <>
       <div className="flex gap-4 mb-4">

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -73,7 +73,7 @@ export default function LocationEfficiencyComparison() {
           </Map>
         </div>
         <div className="flex-1">
-          <ChartContainer config={config} className="h-40">
+          <ChartContainer config={config} className="h-40 md:h-56 lg:h-72">
             <BarChart data={sorted} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="city" />

--- a/src/components/statistics/ActivityByTime.tsx
+++ b/src/components/statistics/ActivityByTime.tsx
@@ -36,7 +36,7 @@ export default function ActivityByTime() {
       title="Workout Activity by Time"
       description="Sessions by time of day"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <RadarChart data={activityByTimeData}>
           <PolarGrid />
           <PolarAngleAxis dataKey="time" />

--- a/src/components/statistics/AnnualMileage.tsx
+++ b/src/components/statistics/AnnualMileage.tsx
@@ -34,7 +34,7 @@ export default function AnnualMileage() {
       title="Annual Mileage"
       description="Mileage totals by month"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <BarChart data={annualData}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" tickLine={false} axisLine={false} />

--- a/src/components/statistics/AvgDailyMileageRadar.tsx
+++ b/src/components/statistics/AvgDailyMileageRadar.tsx
@@ -31,7 +31,7 @@ export default function AvgDailyMileageRadar() {
       title="Average Daily Mileage"
       description="Average mileage by day of week"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <RadarChart data={dailyMileage}>
           <PolarGrid />
           <PolarAngleAxis dataKey="day" />

--- a/src/components/statistics/EquipmentUsageTimeline.tsx
+++ b/src/components/statistics/EquipmentUsageTimeline.tsx
@@ -34,7 +34,7 @@ export default function EquipmentUsageTimeline() {
       title="Equipment Usage"
       description="Bike and shoe usage over time"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <BarChart data={usageData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" tickLine={false} axisLine={false} />

--- a/src/components/statistics/HabitConsistencyHeatmap.tsx
+++ b/src/components/statistics/HabitConsistencyHeatmap.tsx
@@ -26,7 +26,7 @@ export default function HabitConsistencyHeatmap() {
       title="Habit Consistency"
       description="Session count by weekday and hour"
     >
-      <ChartContainer config={{}} className="h-64">
+      <ChartContainer config={{}} className="h-64 md:h-80 lg:h-96">
         <div className="grid gap-px text-center text-[10px]">
           <div className="grid grid-cols-7 text-xs font-medium">
             {dayLabels.map((d) => (

--- a/src/components/statistics/HeartRateZones.tsx
+++ b/src/components/statistics/HeartRateZones.tsx
@@ -28,7 +28,7 @@ export default function HeartRateZones() {
       title="Heart Rate Zones"
       description="Percent of time per zone"
     >
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <BarChart data={stats.heartRateZones}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="zone" tickLine={false} axisLine={false} />

--- a/src/components/statistics/PaceDistribution.tsx
+++ b/src/components/statistics/PaceDistribution.tsx
@@ -28,7 +28,7 @@ export default function PaceDistribution() {
       title="Pace Distribution"
       description="Distribution of paces across runs"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <AreaChart data={stats.paceDistribution}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="pace" tickLine={false} axisLine={false} />

--- a/src/components/statistics/PaceVsHR.tsx
+++ b/src/components/statistics/PaceVsHR.tsx
@@ -83,7 +83,7 @@ export default function PaceVsHR() {
       title="Pace vs Heart Rate"
       description="Correlation between pace and heart rate"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <ScatterChart>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="pace" name="Pace (min/mi)" />

--- a/src/components/statistics/PaceVsTemperature.tsx
+++ b/src/components/statistics/PaceVsTemperature.tsx
@@ -26,7 +26,7 @@ export default function PaceVsTemperature() {
   }))
   return (
     <ChartCard title="Pace vs Temperature" description="Average pace per day">
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="temperature" name="Temp (F)" />

--- a/src/components/statistics/PeerBenchmarkBands.tsx
+++ b/src/components/statistics/PeerBenchmarkBands.tsx
@@ -45,7 +45,7 @@ export default function PeerBenchmarkBands() {
       title="Pace Benchmark vs Peers"
       description="Your percentile rank compared to similar runs/cycles"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <AreaChart data={paceData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/statistics/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/statistics/PerfVsEnvironmentMatrix.tsx
@@ -111,7 +111,7 @@ export default function PerfVsEnvironmentMatrix() {
           { value: "elevation", label: "Elevation" },
         ]}
       />
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <ScatterChart>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey={variable} name={axisLabels[variable]} />

--- a/src/components/statistics/RunBikeVolumeComparison.tsx
+++ b/src/components/statistics/RunBikeVolumeComparison.tsx
@@ -50,7 +50,7 @@ export default function RunBikeVolumeComparison() {
           Time
         </button>
       </div>
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />

--- a/src/components/statistics/RunDistances.tsx
+++ b/src/components/statistics/RunDistances.tsx
@@ -33,7 +33,7 @@ export default function RunDistances() {
       title="Run Distances"
       description="Popular run distance buckets"
     >
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <BarChart layout="vertical" data={runDistanceData}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" tickLine={false} axisLine={false} />

--- a/src/components/statistics/SessionSimilarityMap.tsx
+++ b/src/components/statistics/SessionSimilarityMap.tsx
@@ -39,7 +39,7 @@ export default function SessionSimilarityMap() {
       title="Session Similarity"
       description="Similarity of recent runs"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <ScatterChart>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" dataKey="x" name="X" />

--- a/src/components/statistics/TrainingLoadRatio.tsx
+++ b/src/components/statistics/TrainingLoadRatio.tsx
@@ -33,7 +33,7 @@ export default function TrainingLoadRatio() {
       title="Acute vs Chronic Load Ratio"
       description="Acute vs chronic training load"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <AreaChart data={loadData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis

--- a/src/components/statistics/TreadmillVsOutdoor.tsx
+++ b/src/components/statistics/TreadmillVsOutdoor.tsx
@@ -27,7 +27,7 @@ export default function TreadmillVsOutdoor() {
       title="Treadmill vs Outdoor"
       description="Indoor vs outdoor mileage split"
     >
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <PieChart width={200} height={160}>
           <ChartTooltip />
 

--- a/src/components/statistics/WeatherConditionBar.tsx
+++ b/src/components/statistics/WeatherConditionBar.tsx
@@ -21,7 +21,7 @@ export default function WeatherConditionBar() {
   if (!stats) return <Skeleton className="h-60" />
   return (
     <ChartCard title="Runs by Weather" description="Frequency by condition">
-      <ChartContainer config={config} className="h-60">
+      <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
         <BarChart data={stats.weatherConditions}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="label" />

--- a/src/components/statistics/WeeklyComparisonChart.tsx
+++ b/src/components/statistics/WeeklyComparisonChart.tsx
@@ -53,7 +53,7 @@ export default function WeeklyComparisonChart({
       title="Weekly Comparison"
       description="Compare this week to last week"
     >
-      <ChartContainer config={config} className="h-64">
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
         <LineChart data={merged} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString('en-US', { weekday: 'short' })} />


### PR DESCRIPTION
## Summary
- replace fixed chart heights with responsive classes across components
- ensure ChartCard and interactive examples stretch charts via flex layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6fabcd808324a9b5e8f119e057b7