### PR TITLE
feat: show session similarity on statistics page

### DIFF
--- a/src/components/statistics/SessionSimilarityMap.tsx
+++ b/src/components/statistics/SessionSimilarityMap.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip as ChartTooltip,
 } from "@/components/ui/chart"
 import ChartCard from "@/components/dashboard/ChartCard"
-import { useRunningSessions } from "@/hooks/useRunningSessions"
+import { SessionPoint } from "@/hooks/useRunningSessions"
 import { Skeleton } from "@/components/ui/skeleton"
 
 const colors = [
@@ -27,9 +27,13 @@ const config = {
   good: { label: "Good Day", color: "hsl(var(--chart-6))" },
 } satisfies Record<string, unknown>
 
-export default function SessionSimilarityMap() {
-  const data = useRunningSessions()
+interface SessionSimilarityMapProps {
+  data: SessionPoint[] | null
+}
 
+export default function SessionSimilarityMap({
+  data,
+}: SessionSimilarityMapProps) {
   if (!data) return <Skeleton className="h-64" />
 
   const clusters = Array.from(new Set(data.map((d) => d.cluster)))
@@ -60,6 +64,34 @@ export default function SessionSimilarityMap() {
           />
         </ScatterChart>
       </ChartContainer>
+      <div className="mt-4 grid grid-cols-3 gap-4">
+        {clusters.map((c) => {
+          const clusterData = data.filter((d) => d.cluster === c)
+          const avgTemp =
+            clusterData.reduce((sum, d) => sum + d.temperature, 0) /
+            clusterData.length
+          const avgStart =
+            clusterData.reduce((sum, d) => sum + d.startHour, 0) /
+            clusterData.length
+          return (
+            <div key={c} className="flex flex-col items-center">
+              <ChartContainer className="h-32 w-full" config={{}}>
+                <ScatterChart>
+                  <XAxis type="number" dataKey="x" hide />
+                  <YAxis type="number" dataKey="y" hide />
+                  <Scatter
+                    data={clusterData}
+                    fill={colors[c % colors.length]}
+                  />
+                </ScatterChart>
+              </ChartContainer>
+              <p className="mt-2 text-xs text-muted-foreground text-center">
+                Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
+              </p>
+            </div>
+          )
+        })}
+      </div>
     </ChartCard>
   )
 }

--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -7,6 +7,8 @@ export interface SessionPoint {
   y: number
   cluster: number
   good: boolean
+  temperature: number
+  startHour: number
 }
 
 function kMeans(data: number[][], k: number, iterations = 10): number[] {
@@ -84,6 +86,8 @@ export function useRunningSessions(): SessionPoint[] | null {
           y,
           cluster: labels[idx],
           good: sessions[idx].pace < expectedPace(sessions[idx]) - 0.2,
+          temperature: sessions[idx].weather.temperature,
+          startHour: new Date(sessions[idx].start).getHours(),
         }),
       )
       setPoints(data)

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -3,14 +3,23 @@
 
 import { ChartSelectionProvider } from "@/components/dashboard"
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters"
-import { HabitConsistencyHeatmap } from "@/components/statistics"
+import { HabitConsistencyHeatmap, SessionSimilarityMap } from "@/components/statistics"
+import { useRunningSessions } from "@/hooks/useRunningSessions"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export default function Statistics() {
+  const sessions = useRunningSessions()
+
   return (
     <DashboardFiltersProvider>
       <ChartSelectionProvider>
-        <div className="p-6">
+        <div className="p-6 space-y-6">
           <HabitConsistencyHeatmap />
+          {sessions ? (
+            <SessionSimilarityMap data={sessions} />
+          ) : (
+            <Skeleton className="h-64" />
+          )}
         </div>
       </ChartSelectionProvider>
     </DashboardFiltersProvider>


### PR DESCRIPTION
## Summary
- display SessionSimilarityMap on statistics page alongside HabitConsistencyHeatmap
- provide temperature and start time context for session similarity points
- add small-multiple scatter previews with weather/time annotations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6f56b9548324b57dd9ccefb9e939