### PR TITLE
feat: add blink animation to preview eye

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -22,7 +22,7 @@ export default function ChartPreview({
     <Dialog>
       <div className={cn("relative overflow-hidden mb-6 break-inside-avoid", className)}>
         <DialogTrigger asChild>
-          <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground'>
+          <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground hover:animate-blink'>
             <Eye className='h-4 w-4' />
             <span className='sr-only'>View larger</span>
           </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,7 +33,16 @@ module.exports = {
       fontFamily: {
         sans: ["Inter", ...fontFamily.sans],
         slab: ["var(--font-slab)", ...fontFamily.serif],
-      }
+      },
+      keyframes: {
+        blink: {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0" },
+        },
+      },
+      animation: {
+        blink: "blink 1s steps(2, start) infinite",
+      },
     }
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
## Summary
- add blink keyframe and animation to Tailwind config
- blink the chart preview eye icon on hover

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d74a0280c83248674a838412aca02