### PR TITLE
feat: animate ChartPreview dialog close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "d3-geo": "^3.1.1",
         "date-fns": "^4.1.0",
         "events": "^3.3.0",
+        "framer-motion": "^12.23.12",
         "lucide-react": "^0.534.0",
         "maplibre-gl": "^3.6.0",
         "react": "^18.2.0",
@@ -30,6 +31,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^4.7.0",
@@ -2193,6 +2195,20 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3750,6 +3766,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4486,6 +4529,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "d3-geo": "^3.1.1",
     "date-fns": "^4.1.0",
     "events": "^3.3.0",
+    "framer-motion": "^12.23.12",
     "lucide-react": "^0.534.0",
     "maplibre-gl": "^3.6.0",
     "react": "^18.2.0",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^4.7.0",

--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Eye, XCircle } from 'lucide-react'
+import { motion } from 'framer-motion'
 
 import { cn } from '@/lib/utils'
 import {
   Dialog,
   DialogTrigger,
-  DialogContent,
   DialogContentFullscreen,
   DialogClose,
 } from '@/components/ui/dialog'
@@ -18,8 +18,9 @@ export default function ChartPreview({
   children: React.ReactElement
   className?: string
 }) {
+  const [open, setOpen] = React.useState(false)
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <div className={cn("relative overflow-hidden mb-6 break-inside-avoid", className)}>
         <DialogTrigger asChild>
           <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground'>
@@ -30,14 +31,21 @@ export default function ChartPreview({
         {children}
       </div>
       <DialogContentFullscreen>
-        <DialogClose asChild>
-          <button
-            className='absolute right-4 top-4 z-50 rounded-full bg-background/80 p-2 text-muted-foreground shadow transition-transform duration-150 hover:rotate-90 hover:scale-110 hover:text-foreground focus:outline-none focus:ring-2'
-          >
-            <XCircle className='h-4 w-4' />
-            <span className='sr-only'>Close</span>
-          </button>
-        </DialogClose>
+        <motion.div
+          initial={{ opacity: 0, scale: 0 }}
+          animate={{ opacity: open ? 1 : 0, scale: open ? 1 : 0 }}
+          transition={{ duration: 0.2 }}
+          className='absolute right-4 top-4 z-50'
+        >
+          <DialogClose asChild>
+            <button
+              className='rounded-full bg-background/80 p-2 text-muted-foreground shadow transition-transform duration-150 hover:rotate-90 hover:scale-110 hover:text-foreground focus:outline-none focus:ring-2'
+            >
+              <XCircle className='h-4 w-4' />
+              <span className='sr-only'>Close</span>
+            </button>
+          </DialogClose>
+        </motion.div>
         {
           React.isValidElement(children)
             ? React.createElement(children.type, {

--- a/src/components/examples/__tests__/ChartPreview.test.tsx
+++ b/src/components/examples/__tests__/ChartPreview.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import ChartPreview from "../ChartPreview";
+
+describe("ChartPreview", () => {
+  it("allows keyboard navigation to the close button", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChartPreview>
+        <div>chart</div>
+      </ChartPreview>
+    );
+
+    await user.click(screen.getByRole("button", { name: /view larger/i }));
+    const closeButton = await screen.findByRole("button", { name: /close/i });
+
+    await user.tab();
+    expect(closeButton).toHaveFocus();
+  });
+});
+


### PR DESCRIPTION
## Summary
- animate ChartPreview dialog close button with framer-motion, tied to Radix open state
- test keyboard navigation to ensure close button focus works

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d722ed5c0832485701eb7f9a59bb4