### PR TITLE
feat: visualize route similarity index

### DIFF
--- a/src/components/statistics/RouteSimilarityIndex.tsx
+++ b/src/components/statistics/RouteSimilarityIndex.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import ChartCard from "@/components/dashboard/ChartCard"
+import { ChartContainer } from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import { getMockRoutes, calculateRouteSimilarity, Route } from "@/lib/api"
+
+interface SimilarityEdge {
+  source: number
+  target: number
+  similarity: number
+}
+
+export default function RouteSimilarityIndex() {
+  const [routes, setRoutes] = useState<Route[] | null>(null)
+
+  useEffect(() => {
+    getMockRoutes().then(setRoutes)
+  }, [])
+
+  if (!routes) return <Skeleton className="h-64" />
+
+  const edges: SimilarityEdge[] = []
+  for (let i = 0; i < routes.length; i++) {
+    for (let j = i + 1; j < routes.length; j++) {
+      const similarity = calculateRouteSimilarity(
+        routes[i].points,
+        routes[j].points,
+      )
+      edges.push({ source: i, target: j, similarity })
+    }
+  }
+
+  const radius = 40
+  const center = 50
+  const nodes = routes.map((r, i) => {
+    const angle = (2 * Math.PI * i) / routes.length
+    return {
+      ...r,
+      x: center + radius * Math.cos(angle),
+      y: center + radius * Math.sin(angle),
+    }
+  })
+
+  return (
+    <ChartCard
+      title="Route Similarity Index"
+      description="Jaccard similarity between routes"
+    >
+      <ChartContainer config={{}} className="h-64 md:h-80 lg:h-96">
+        <svg viewBox="0 0 100 100" className="w-full h-full">
+          {edges.map((e, idx) => (
+            <line
+              key={idx}
+              data-testid="similarity-edge"
+              x1={nodes[e.source].x}
+              y1={nodes[e.source].y}
+              x2={nodes[e.target].x}
+              y2={nodes[e.target].y}
+              stroke="hsl(var(--chart-1))"
+              strokeWidth={1 + e.similarity * 2}
+              strokeOpacity={e.similarity}
+            />
+          ))}
+          {nodes.map((n) => (
+            <g key={n.name}>
+              <circle cx={n.x} cy={n.y} r={3} fill="hsl(var(--chart-2))" />
+              <text
+                x={n.x}
+                y={n.y - 6}
+                textAnchor="middle"
+                fontSize="3"
+                fill="currentColor"
+              >
+                {n.name}
+              </text>
+            </g>
+          ))}
+        </svg>
+      </ChartContainer>
+    </ChartCard>
+  )
+}
+

--- a/src/components/statistics/__tests__/RouteSimilarityIndex.test.tsx
+++ b/src/components/statistics/__tests__/RouteSimilarityIndex.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import RouteSimilarityIndex from '../RouteSimilarityIndex'
+import { vi } from 'vitest'
+import React from 'react'
+import '@testing-library/jest-dom'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  getMockRoutes: () =>
+    Promise.resolve([
+      { name: 'A', points: [] },
+      { name: 'B', points: [] },
+      { name: 'C', points: [] },
+    ]),
+  calculateRouteSimilarity: vi.fn(() => 0.5),
+}))
+
+describe('RouteSimilarityIndex', () => {
+  it('renders edges for each route pair', async () => {
+    render(<RouteSimilarityIndex />)
+    const edges = await screen.findAllByTestId('similarity-edge')
+    expect(edges).toHaveLength(3)
+  })
+})
+

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -21,3 +21,4 @@ export { default as WeatherConditionBar } from "./WeatherConditionBar";
 export { default as PaceVsTemperature } from "./PaceVsTemperature";
 
 export { default as RouteComparison } from './RouteComparison'
+export { default as RouteSimilarityIndex } from "./RouteSimilarityIndex";

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -3,7 +3,7 @@
 
 import { ChartSelectionProvider } from "@/components/dashboard"
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters"
-import { HabitConsistencyHeatmap, SessionSimilarityMap } from "@/components/statistics"
+import { HabitConsistencyHeatmap, SessionSimilarityMap, RouteSimilarityIndex } from "@/components/statistics"
 import { useRunningSessions } from "@/hooks/useRunningSessions"
 import { Skeleton } from "@/components/ui/skeleton"
 
@@ -20,6 +20,7 @@ export default function Statistics() {
           ) : (
             <Skeleton className="h-64" />
           )}
+          <RouteSimilarityIndex />
         </div>
       </ChartSelectionProvider>
     </DashboardFiltersProvider>


### PR DESCRIPTION
## Summary
- add RouteSimilarityIndex component to compute Jaccard similarity across routes and render network chart
- expose RouteSimilarityIndex from statistics index and show in Statistics page
- test rendering of similarity edges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d77b07f548324afc8f6a07e81a690