### PR TITLE
feat: add session start entropy chart

### DIFF
--- a/src/components/statistics/SessionStartEntropy.tsx
+++ b/src/components/statistics/SessionStartEntropy.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import ChartCard from "@/components/dashboard/ChartCard"
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ChartTooltip,
+} from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import { getRunningSessions, type RunningSession } from "@/lib/api"
+
+function shannonEntropy(counts: number[]): number {
+  const total = counts.reduce((a, b) => a + b, 0)
+  if (!total) return 0
+  return -counts.reduce((sum, c) => {
+    if (!c) return sum
+    const p = c / total
+    return sum + p * Math.log2(p)
+  }, 0)
+}
+
+export default function SessionStartEntropy() {
+  const [data, setData] = useState<{ date: string; entropy: number }[] | null>(null)
+
+  useEffect(() => {
+    getRunningSessions().then((sessions: RunningSession[]) => {
+      const sorted = [...sessions].sort(
+        (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+      )
+      const windowDays = 7
+      const counts = Array(24).fill(0)
+      const result: { date: string; entropy: number }[] = []
+      let startIdx = 0
+      for (let i = 0; i < sorted.length; i++) {
+        const current = new Date(sorted[i].start)
+        counts[current.getHours()]++
+        const windowStart = new Date(current)
+        windowStart.setDate(current.getDate() - (windowDays - 1))
+        while (
+          startIdx <= i &&
+          new Date(sorted[startIdx].start) < windowStart
+        ) {
+          const h = new Date(sorted[startIdx].start).getHours()
+          counts[h]--
+          startIdx++
+        }
+        result.push({
+          date: current.toISOString().slice(0, 10),
+          entropy: shannonEntropy(counts),
+        })
+      }
+      setData(result)
+    })
+  }, [])
+
+  if (!data) return <Skeleton className="h-64" />
+
+  const config = {
+    entropy: { label: "Entropy", color: "hsl(var(--chart-1))" },
+  }
+
+  return (
+    <ChartCard
+      title="Start Time Entropy"
+      description="Rolling 7-day entropy of session start times"
+    >
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="date"
+            tickFormatter={(d) => new Date(d).toLocaleDateString()}
+          />
+          <YAxis domain={[0, Math.log2(24)]} />
+          <ChartTooltip />
+          <Line
+            type="monotone"
+            dataKey="entropy"
+            stroke="var(--color-entropy)"
+            dot={false}
+          />
+        </LineChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}
+

--- a/src/components/statistics/__tests__/SessionStartEntropy.test.tsx
+++ b/src/components/statistics/__tests__/SessionStartEntropy.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import SessionStartEntropy from '../SessionStartEntropy'
+import { vi } from 'vitest'
+import React from 'react'
+import '@testing-library/jest-dom'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 800, height: 400 }}>
+        {React.cloneElement(children, { width: 800, height: 400 })}
+      </div>
+    )
+  }
+})
+
+vi.mock('@/lib/api', () => ({
+  getRunningSessions: () =>
+    Promise.resolve([
+      {
+        id: 1,
+        pace: 0,
+        duration: 0,
+        heartRate: 0,
+        date: '2025-01-01',
+        start: '2025-01-01T10:00:00Z',
+        weather: { temperature: 0, humidity: 0, wind: 0, condition: 'Sunny' }
+      },
+      {
+        id: 2,
+        pace: 0,
+        duration: 0,
+        heartRate: 0,
+        date: '2025-01-02',
+        start: '2025-01-02T12:00:00Z',
+        weather: { temperature: 0, humidity: 0, wind: 0, condition: 'Sunny' }
+      }
+    ])
+}))
+
+describe('SessionStartEntropy', () => {
+  it('renders chart title', async () => {
+    render(<SessionStartEntropy />)
+    expect(await screen.findByText(/start time entropy/i)).toBeInTheDocument()
+  })
+})
+

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -9,6 +9,7 @@ export { default as PaceVsHR } from "./PaceVsHR";
 export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
+export { default as SessionStartEntropy } from "./SessionStartEntropy";
 
 export { default as RunBikeVolumeComparison } from "./RunBikeVolumeComparison";
 export { default as WeeklyComparisonChart } from "./WeeklyComparisonChart";

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -3,7 +3,11 @@
 
 import { ChartSelectionProvider } from "@/components/dashboard"
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters"
-import { HabitConsistencyHeatmap, SessionSimilarityMap } from "@/components/statistics"
+import {
+  HabitConsistencyHeatmap,
+  SessionSimilarityMap,
+  SessionStartEntropy,
+} from "@/components/statistics"
 import { useRunningSessions } from "@/hooks/useRunningSessions"
 import { Skeleton } from "@/components/ui/skeleton"
 
@@ -15,6 +19,7 @@ export default function Statistics() {
       <ChartSelectionProvider>
         <div className="p-6 space-y-6">
           <HabitConsistencyHeatmap />
+          <SessionStartEntropy />
           {sessions ? (
             <SessionSimilarityMap data={sessions} />
           ) : (


### PR DESCRIPTION
## Summary
- calculate session start entropy over a 7-day rolling window
- visualize entropy trend with a line chart
- expose component and include on statistics page

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688d7753dbec832498bf48e71268b9d8