### PR TITLE
Replace blink animation with subtle scale effect

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -23,7 +23,7 @@ export default function ChartPreview({
     <Dialog open={open} onOpenChange={setOpen}>
       <div className={cn("relative overflow-hidden mb-6 break-inside-avoid", className)}>
         <DialogTrigger asChild>
-          <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground hover:text-foreground hover:animate-blink'>
+          <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground transition-transform hover:scale-110 hover:text-foreground'>
             <Eye className='h-4 w-4' />
             <span className='sr-only'>View larger</span>
           </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,15 +34,6 @@ module.exports = {
         sans: ["Inter", ...fontFamily.sans],
         slab: ["var(--font-slab)", ...fontFamily.serif],
       },
-      keyframes: {
-        blink: {
-          "0%, 100%": { opacity: "1" },
-          "50%": { opacity: "0" },
-        },
-      },
-      animation: {
-        blink: "blink 1s steps(2, start) infinite",
-      },
     }
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
## Summary
- soften ChartPreview preview button behavior by switching from blinking to a scale transform
- remove unused `blink` animation and keyframes from Tailwind config

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d784f8730832490bd11c0a36b23b1