### PR TITLE
docs: explain fragility index

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -49,7 +49,26 @@ export default function Dashboard() {
         <Statistics />
       </TabsContent>
       <TabsContent value="fragility">
-        <FragilityGauge />
+        <div className="space-y-4 p-4">
+          <h3 className="text-lg font-semibold">Fragility index</h3>
+          <p className="text-sm text-muted-foreground">
+            The fragility index blends training consistency with load spikes to
+            estimate injury risk. Lower scores signal resilience, while higher
+            scores call for caution.
+          </p>
+          <ul className="text-sm text-muted-foreground list-disc pl-4">
+            <li>
+              <span className="text-green-600">0–0.33</span>: stable
+            </li>
+            <li>
+              <span className="text-yellow-600">0.34–0.66</span>: monitor
+            </li>
+            <li>
+              <span className="text-red-600">0.67–1.00</span>: high risk
+            </li>
+          </ul>
+          <FragilityGauge />
+        </div>
       </TabsContent>
     </Tabs>
   );

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+import React from "react";
+import Dashboard from "../Dashboard";
+
+vi.mock("@/hooks/useGarminData", () => ({
+  __esModule: true,
+  useGarminData: () => ({ lastSync: new Date().toISOString() }),
+}));
+
+describe("Dashboard", () => {
+  it("shows fragility description", () => {
+    render(<Dashboard />);
+    expect(
+      screen.getByRole("heading", { name: /fragility index/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/blends training consistency/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add descriptive heading and legend around Fragility Gauge
- test for fragility description on dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d7892c9dc83248dba189341409a87