### PR TITLE
feat: add mileage timeline hook

### DIFF
--- a/src/hooks/__tests__/useMileageTimeline.test.ts
+++ b/src/hooks/__tests__/useMileageTimeline.test.ts
@@ -1,0 +1,27 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import useMileageTimeline from "../useMileageTimeline";
+import { getMileageTimeline } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  __esModule: true,
+  getMileageTimeline: vi.fn(),
+}));
+
+describe("useMileageTimeline", () => {
+  it("accumulates weekly mileage", async () => {
+    const weeks = [
+      { week: "2025-W30", miles: 10, path: "a" },
+      { week: "2025-W31", miles: 20, path: "b" },
+      { week: "2025-W32", miles: 15, path: "c" },
+    ];
+    (getMileageTimeline as any).mockResolvedValue(weeks);
+    const { result } = renderHook(() => useMileageTimeline());
+    await waitFor(() => result.current !== null);
+    expect(result.current).toEqual([
+      { week: "2025-W30", cumulativeMiles: 10, path: "a" },
+      { week: "2025-W31", cumulativeMiles: 30, path: "b" },
+      { week: "2025-W32", cumulativeMiles: 45, path: "c" },
+    ]);
+  });
+});

--- a/src/hooks/useMileageTimeline.ts
+++ b/src/hooks/useMileageTimeline.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import { getMileageTimeline, MileageTimelinePoint } from "@/lib/api";
+
+export interface CumulativeMileagePoint {
+  week: string;
+  cumulativeMiles: number;
+  path: string;
+}
+
+export default function useMileageTimeline(): CumulativeMileagePoint[] | null {
+  const [data, setData] = useState<CumulativeMileagePoint[] | null>(null);
+  useEffect(() => {
+    getMileageTimeline().then((points: MileageTimelinePoint[]) => {
+      let total = 0;
+      const cumulative = points.map((p) => {
+        total += p.miles;
+        return { week: p.week, cumulativeMiles: total, path: p.path };
+      });
+      setData(cumulative);
+    });
+  }, []);
+  return data;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -650,6 +650,18 @@ export async function getRunBikeVolume(): Promise<RunBikeVolumePoint[]> {
   });
 }
 
+export interface MileageTimelinePoint {
+  week: string;
+  miles: number;
+  path: string;
+}
+
+export async function getMileageTimeline(): Promise<MileageTimelinePoint[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve([]), 200);
+  });
+}
+
 // ----- Weekly comparison metrics -----
 function startOfWeek(date: Date): Date {
   const d = new Date(date);


### PR DESCRIPTION
## Summary
- add `useMileageTimeline` hook to compute cumulative weekly mileage
- expose `getMileageTimeline` API stub
- test mileage accumulation using mocked data

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688d7b87a4b88324aee76cc1687d40fd