### PR TITLE
fix: ensure select dropdown is visible in fullscreen view

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -77,7 +77,7 @@ export function SimpleSelect({
           </SelectIcon>
         </SelectTrigger>
         <SelectPortal>
-          <SelectContent className="overflow-hidden rounded-md border bg-card">
+          <SelectContent className="overflow-hidden rounded-md border bg-card z-[60]">
             <SelectScrollUpButton className="flex items-center justify-center h-6">
               <ChevronUp className="w-4 h-4" />
             </SelectScrollUpButton>


### PR DESCRIPTION
## Summary
- keep select dropdown above fullscreen dialog overlay by giving it a higher z-index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d7c2071e88324b46139510b887c9c