### PR TITLE
Simplify RunSoundtrackCard layout

### DIFF
--- a/src/components/dashboard/RunSoundtrackCard.tsx
+++ b/src/components/dashboard/RunSoundtrackCard.tsx
@@ -1,22 +1,21 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import useRunSoundtrack from '@/hooks/useRunSoundtrack'
 import { minutesSince } from '@/lib/utils'
 
-
 export default function RunSoundtrackCard() {
   const data = useRunSoundtrack()
 
-  if (!data) return <Skeleton className="h-40" />
+  if (!data) return <Skeleton className="h-28 max-w-sm rounded-xl" />
 
-  const maxPlays = Math.max(...data.topTracks.map((t) => t.playCount), 1)
-
-  const progressPct = data.nowPlaying?.progress_ms && data.nowPlaying.item?.duration_ms
-    ? Math.min(
-        100,
-        Math.round((data.nowPlaying.progress_ms / data.nowPlaying.item.duration_ms) * 100),
-      )
-    : 0
+  const progressPct =
+    data.nowPlaying?.progress_ms && data.nowPlaying.item?.duration_ms
+      ? Math.min(
+          100,
+          Math.round(
+            (data.nowPlaying.progress_ms / data.nowPlaying.item.duration_ms) * 100,
+          ),
+        )
+      : 0
 
   function formatMs(ms: number) {
     const m = Math.floor(ms / 60000)
@@ -25,108 +24,57 @@ export default function RunSoundtrackCard() {
   }
 
   return (
-    <Card className="text-spotify-primary">
-      <CardHeader className="flex items-center gap-4 p-6">
-        <svg
-          className="w-4 h-4"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
-        </svg>
-        <CardTitle className="font-slab font-bold text-2xl">Run Soundtrack</CardTitle>
-        <span
-          aria-label="listening"
-          className="ml-auto h-2 w-2 rounded-full bg-green-600 animate-pulse"
-        />
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4 p-6 pt-0">
-        {data.nowPlaying ? (
-          <div className="flex gap-4">
-            <div className="flex-shrink-0 w-20 h-20 rounded-xl overflow-hidden shadow-sm">
-              {data.nowPlaying.item?.album?.images?.[0]?.url && (
-                <img
-                  src={data.nowPlaying.item.album.images[0].url}
-                  alt={`Album art for ${data.nowPlaying.item.name}`}
-                  className="w-full h-full object-cover"
+    <div className="max-w-sm rounded-xl bg-white border border-gray-200 shadow-sm p-4 flex items-start gap-3">
+      {data.nowPlaying ? (
+        <>
+          <div className="w-20 h-20 rounded-xl overflow-hidden shadow-sm flex-shrink-0">
+            {data.nowPlaying.item?.album?.images?.[0]?.url && (
+              <img
+                src={data.nowPlaying.item.album.images[0].url}
+                alt={`Album art for ${data.nowPlaying.item.name}`}
+                className="w-full h-full object-cover"
+              />
+            )}
+          </div>
+          <div className="flex-grow">
+            <p
+              className="text-xs font-semibold uppercase"
+              style={{ color: '#1DB954' }}
+            >
+              Now Playing
+            </p>
+            <h3 className="mt-1 text-lg font-semibold leading-tight">
+              {data.nowPlaying.item.name}
+            </h3>
+            <p className="text-xs text-gray-600">
+              {data.nowPlaying.item.artists.map((a: any) => a.name).join(', ')}
+            </p>
+            <div className="mt-3">
+              <div className="flex items-center justify-between text-[10px] text-gray-500">
+                <span>{minutesSince(data.window.start)}m ago</span>
+                {data.nowPlaying.progress_ms && data.nowPlaying.item?.duration_ms && (
+                  <span>
+                    {formatMs(data.nowPlaying.progress_ms)} /{' '}
+                    {formatMs(data.nowPlaying.item.duration_ms)}
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 w-full bg-gray-100 rounded-full h-1 overflow-hidden">
+                <div
+                  role="progressbar"
+                  className="h-full rounded-full"
+                  style={{ width: `${progressPct}%`, backgroundColor: '#1DB954' }}
                 />
-              )}
-            </div>
-            <div className="flex-grow flex flex-col justify-between">
-              <div>
-                <p className="text-xs uppercase font-semibold text-green-600">Now Playing</p>
-                <h3 className="mt-1 text-base font-medium">
-                  {data.nowPlaying.item.name}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  {data.nowPlaying.item.artists.map((a: any) => a.name).join(', ')}
-                </p>
-              </div>
-              <div className="mt-3">
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                  <span>{minutesSince(data.window.start)}m ago</span>
-                  {data.nowPlaying.progress_ms && data.nowPlaying.item?.duration_ms && (
-                    <span>
-                      {formatMs(data.nowPlaying.progress_ms)} /{' '}
-                      {formatMs(data.nowPlaying.item.duration_ms)}
-                    </span>
-                  )}
-                </div>
-                <div className="mt-1 w-full bg-gray-100 rounded-full h-2 overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-spotify-primary"
-                    style={{ width: `${progressPct}%` }}
-                  />
-                </div>
               </div>
             </div>
           </div>
-        ) : (
-          <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
-            Not currently listening
-          </div>
-        )}
-
-        <div className="mt-4">
-          <div className="flex items-center justify-between">
-            <h4 className="text-base font-semibold">Top Tracks</h4>
-            <span className="text-sm text-muted-foreground">Recent</span>
-          </div>
-          <ol className="mt-3 space-y-2">
-            {data.topTracks.map((t, i) => {
-              const widthPct = Math.round((t.playCount / maxPlays) * 100)
-              return (
-                <li key={t.id} className="flex items-center gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex justify-between items-center">
-                      <div className="text-sm font-medium truncate">
-                        {i + 1}. {t.name} – {t.artists}
-                      </div>
-                      <div className="text-xs text-muted-foreground">({t.playCount}x)</div>
-                    </div>
-                    <div className="mt-1 h-1 bg-gray-100 rounded-full overflow-hidden">
-                      <div
-                        className="h-full rounded-full bg-spotify-primary"
-                        style={{ width: `${widthPct}%` }}
-                      />
-                    </div>
-                  </div>
-                  {t.thumbnail && (
-                    <div className="w-10 h-10 flex-shrink-0 rounded-md overflow-hidden">
-                      <img
-                        src={t.thumbnail}
-                        alt={`Artwork for ${t.name}`}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  )}
-                </li>
-              )
-            })}
-          </ol>
+        </>
+      ) : (
+        <div className="flex items-center justify-center h-20 text-sm text-gray-500 w-full">
+          Not currently listening
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </div>
   )
 }
+

--- a/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
+++ b/src/components/dashboard/__tests__/RunSoundtrackCard.test.tsx
@@ -12,24 +12,7 @@ vi.mock('@/hooks/useRunSoundtrack', () => ({
 
 const baseData = {
   window: { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:40:00Z' },
-  topTracks: [
-    {
-      id: '1',
-      name: 'Song A',
-      artists: 'Artist',
-      uri: 'x',
-      playCount: 2,
-      thumbnail: 'https://via.placeholder.com/40',
-    },
-    {
-      id: '2',
-      name: 'Song B',
-      artists: 'Other',
-      uri: 'y',
-      playCount: 1,
-      thumbnail: 'https://via.placeholder.com/40',
-    },
-  ],
+  topTracks: [],
 }
 
 const withNowPlaying = {
@@ -55,22 +38,14 @@ describe('RunSoundtrackCard', () => {
     mockHook.mockReset()
   })
 
-  it('renders now playing and top tracks', () => {
+  it('renders now playing details', () => {
     mockHook.mockReturnValue(withNowPlaying)
-    const { container } = render(<RunSoundtrackCard />)
+    render(<RunSoundtrackCard />)
 
     expect(screen.getByText('Now Playing')).toBeInTheDocument()
-    expect(screen.getAllByText(/Song A/).length).toBeGreaterThan(0)
-    expect(screen.getByText(/Song B/)).toBeInTheDocument()
-
-    const indicator = screen.getByLabelText('listening')
-    expect(indicator).toBeInTheDocument()
-    expect(indicator).toHaveClass('bg-green-600')
-
-    const content = container.querySelector('.flex.flex-col.gap-4.p-6.pt-0')
-    expect(content).toBeInTheDocument()
-    expect(container.firstChild).toHaveClass('text-spotify-primary')
-    expect(container.querySelector('svg')).toBeInTheDocument()
+    expect(screen.getByText('Song A')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toHaveStyle('background-color: #1DB954')
+    expect(screen.queryByText('Top Tracks')).not.toBeInTheDocument()
   })
 
   it('shows placeholder when nothing is playing', () => {


### PR DESCRIPTION
## Summary
- refactor RunSoundtrackCard to use compact div container and remove top tracks list
- tune typography and progress bar with Spotify accent color
- update unit tests for new compact layout

## Testing
- `CI=1 npm test -- --run` *(fails: Dashboard > shows fragility description)*

------
https://chatgpt.com/codex/tasks/task_e_688d7dd3f55c83249bfaf91f7783d6cb