### PR TITLE
Refactor ChartPreview dialog header layout

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -30,22 +30,20 @@ export default function ChartPreview({
         </DialogTrigger>
         {children}
       </div>
-      <DialogContentFullscreen>
-        <motion.div
-          initial={{ opacity: 0, scale: 0 }}
-          animate={{ opacity: open ? 1 : 0, scale: open ? 1 : 0 }}
-          transition={{ duration: 0.2 }}
-          className='absolute right-4 top-4 z-50'
-        >
+      <DialogContentFullscreen className='flex flex-col'>
+        <div className='flex justify-end'>
           <DialogClose asChild>
-            <button
+            <motion.button
+              initial={{ opacity: 0, scale: 0 }}
+              animate={{ opacity: open ? 1 : 0, scale: open ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
               className='rounded-full bg-background/80 p-2 text-muted-foreground shadow transition-transform duration-150 hover:rotate-90 hover:scale-110 hover:text-foreground focus:outline-none focus:ring-2'
             >
               <XCircle className='h-4 w-4' />
               <span className='sr-only'>Close</span>
-            </button>
+            </motion.button>
           </DialogClose>
-        </motion.div>
+        </div>
         {
           React.isValidElement(children)
             ? React.createElement(children.type, {


### PR DESCRIPTION
## Summary
- Rework ChartPreview fullscreen dialog to use a flex column layout with a top bar
- Position the close button in the header instead of overlaying the chart

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d7d1c3bd88324825d2379f490d24c