### PR TITLE
feat(dialog): close fullscreen overlay

### DIFF
--- a/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/components/ui/__tests__/dialog.test.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { Dialog, DialogContentFullscreen } from "../dialog";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+
+function TestDialog() {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContentFullscreen>
+        <DialogPrimitive.Title>title</DialogPrimitive.Title>
+        <div>content</div>
+      </DialogContentFullscreen>
+    </Dialog>
+  );
+}
+
+describe("DialogContentFullscreen", () => {
+  it("closes when clicking the overlay", async () => {
+    const user = userEvent.setup();
+    render(<TestDialog />);
+
+    expect(screen.getByText("content")).toBeInTheDocument();
+
+    const overlay = document.querySelector('div[type="button"]') as HTMLElement;
+
+    await user.click(overlay);
+
+    expect(screen.queryByText("content")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -48,7 +48,9 @@ const DialogContentFullscreen = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogClose asChild>
+      <DialogOverlay />
+    </DialogClose>
     <DialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
## Summary
- allow overlay click to close fullscreen dialog
- test overlay click behavior

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688d804b331c83248483f70da68c9394