### PR TITLE
feat: add Mileage Globe dashboard tab

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useGarminData } from "@/hooks/useGarminData";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
 import Statistics from "@/pages/Statistics";
+import MileageGlobePage from "@/pages/MileageGlobe";
 import {
   FragilityGauge,
   RouteNoveltyMap,
@@ -21,6 +22,7 @@ export default function Dashboard() {
     | "novelty"
     | "examples"
     | "statistics"
+    | "globe"
     | "fragility"
     | "sessions"
   >("map");
@@ -45,6 +47,7 @@ export default function Dashboard() {
         <TabsTrigger value="novelty">Route Novelty</TabsTrigger>
         <TabsTrigger value="examples">Analytics fun</TabsTrigger>
         <TabsTrigger value="statistics">Statistics</TabsTrigger>
+        <TabsTrigger value="globe">Mileage Globe</TabsTrigger>
         <TabsTrigger value="fragility">Fragility</TabsTrigger>
         <TabsTrigger value="sessions">Session Similarity</TabsTrigger>
       </TabsList>
@@ -64,6 +67,9 @@ export default function Dashboard() {
       </TabsContent>
       <TabsContent value="statistics">
         <Statistics />
+      </TabsContent>
+      <TabsContent value="globe">
+        <MileageGlobePage />
       </TabsContent>
       <TabsContent value="fragility">
         <div className="space-y-4 p-4">

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import AreaChartInteractive from "@/components/examples/AreaChartInteractive";
 import LineChartInteractive from "@/components/examples/LineChartInteractive";
 import BarChartInteractive from "@/components/examples/BarChartInteractive";
@@ -42,11 +41,6 @@ import RunSoundtrackCardDemo from "@/components/examples/RunSoundtrackCardDemo";
 export default function Examples() {
   return (
     <div>
-      <div className="mb-6">
-        <Link to="/mileage-globe" className="text-blue-600 hover:underline">
-          View Mileage Globe visualization
-        </Link>
-      </div>
       <div className="columns-1 sm:columns-2 lg:columns-3 gap-6">
         <ChartPreview>
           <AreaChartInteractive />


### PR DESCRIPTION
## Summary
- add dedicated Mileage Globe tab in dashboard
- remove inline link from Examples page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d829695888324b9f5430e67db296a