### PR TITLE
docs: clarify route novelty map legend

### DIFF
--- a/src/components/dashboard/RouteNoveltyMap.tsx
+++ b/src/components/dashboard/RouteNoveltyMap.tsx
@@ -164,6 +164,10 @@ export default function RouteNoveltyMap() {
           </Source>
         </Map>
       </div>
+      <p className="text-sm text-muted-foreground mt-2">
+        Routes are colored by novelty—gray for familiar paths, red for unique ones.
+        Clustered labels show novelty at starting points.
+      </p>
       <div className="h-40">
         <ChartContainer
           config={{ novelty: { label: "Novelty", color: "hsl(var(--chart-1))" } }}


### PR DESCRIPTION
## Summary
- explain novelty color scheme and clustered labels below map

## Testing
- `npx vitest run` *(fails: Dashboard > shows fragility description)*

------
https://chatgpt.com/codex/tasks/task_e_688d7df3f2b48324902b6e2f12039c58