### PR TITLE
chore: render overlay directly in fullscreen dialog

### DIFF
--- a/src/components/examples/__tests__/ChartPreview.test.tsx
+++ b/src/components/examples/__tests__/ChartPreview.test.tsx
@@ -1,10 +1,23 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import ChartPreview from "../ChartPreview";
 
 describe("ChartPreview", () => {
+  it("renders chart content when opened", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChartPreview>
+        <div>chart</div>
+      </ChartPreview>
+    );
+
+    await user.click(screen.getByRole("button", { name: /view larger/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("chart")).toBeInTheDocument();
+  });
+
   it("allows keyboard navigation to the close button", async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/components/ui/__tests__/dialog.test.tsx
@@ -25,7 +25,7 @@ describe("DialogContentFullscreen", () => {
 
     expect(screen.getByText("content")).toBeInTheDocument();
 
-    const overlay = document.querySelector('div[type="button"]') as HTMLElement;
+    const overlay = document.querySelector('[data-state="open"]') as HTMLElement;
 
     await user.click(overlay);
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -48,9 +48,7 @@ const DialogContentFullscreen = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
-    <DialogClose asChild>
-      <DialogOverlay />
-    </DialogClose>
+    <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
## Summary
- remove DialogClose wrapper so DialogOverlay renders directly
- update DialogContentFullscreen overlay click test
- add ChartPreview test to verify dialog content renders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8682a7308324819345943ebddb58