### PR TITLE
Add mileage timeline API with coordinate data

### DIFF
--- a/src/hooks/__tests__/useMileageTimeline.test.ts
+++ b/src/hooks/__tests__/useMileageTimeline.test.ts
@@ -9,19 +9,19 @@ vi.mock("@/lib/api", () => ({
 }));
 
 describe("useMileageTimeline", () => {
-  it("accumulates weekly mileage", async () => {
-    const weeks = [
-      { week: "2025-W30", miles: 10, path: "a" },
-      { week: "2025-W31", miles: 20, path: "b" },
-      { week: "2025-W32", miles: 15, path: "c" },
+  it("accumulates activity mileage", async () => {
+    const activities = [
+      { date: "2025-07-20", miles: 10, coordinates: [[0, 0]] },
+      { date: "2025-07-27", miles: 20, coordinates: [[1, 1]] },
+      { date: "2025-08-03", miles: 15, coordinates: [[2, 2]] },
     ];
-    (getMileageTimeline as any).mockResolvedValue(weeks);
+    (getMileageTimeline as any).mockResolvedValue(activities);
     const { result } = renderHook(() => useMileageTimeline());
     await waitFor(() => result.current !== null);
     expect(result.current).toEqual([
-      { week: "2025-W30", cumulativeMiles: 10, path: "a" },
-      { week: "2025-W31", cumulativeMiles: 30, path: "b" },
-      { week: "2025-W32", cumulativeMiles: 45, path: "c" },
+      { date: "2025-07-20", cumulativeMiles: 10, coordinates: [[0, 0]] },
+      { date: "2025-07-27", cumulativeMiles: 30, coordinates: [[1, 1]] },
+      { date: "2025-08-03", cumulativeMiles: 45, coordinates: [[2, 2]] },
     ]);
   });
 });

--- a/src/hooks/useMileageTimeline.ts
+++ b/src/hooks/useMileageTimeline.ts
@@ -2,22 +2,24 @@ import { useState, useEffect } from "react";
 import { getMileageTimeline, MileageTimelinePoint } from "@/lib/api";
 
 export interface CumulativeMileagePoint {
-  week: string;
+  date: string;
   cumulativeMiles: number;
-  path: string;
+  coordinates: [number, number][];
 }
 
-export default function useMileageTimeline(): CumulativeMileagePoint[] | null {
+export default function useMileageTimeline(
+  years?: number,
+): CumulativeMileagePoint[] | null {
   const [data, setData] = useState<CumulativeMileagePoint[] | null>(null);
   useEffect(() => {
-    getMileageTimeline().then((points: MileageTimelinePoint[]) => {
+    getMileageTimeline(years).then((points: MileageTimelinePoint[]) => {
       let total = 0;
       const cumulative = points.map((p) => {
         total += p.miles;
-        return { week: p.week, cumulativeMiles: total, path: p.path };
+        return { date: p.date, cumulativeMiles: total, coordinates: p.coordinates };
       });
       setData(cumulative);
     });
-  }, []);
+  }, [years]);
   return data;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -651,14 +651,53 @@ export async function getRunBikeVolume(): Promise<RunBikeVolumePoint[]> {
 }
 
 export interface MileageTimelinePoint {
-  week: string;
+  /** ISO date for the activity */
+  date: string;
+  /** Distance covered in miles */
   miles: number;
-  path: string;
+  /** Array of [lng, lat] coordinates representing the path */
+  coordinates: [number, number][];
 }
 
-export async function getMileageTimeline(): Promise<MileageTimelinePoint[]> {
+export function generateMockMileageTimeline(
+  years = 20,
+): MileageTimelinePoint[] {
+  const points: MileageTimelinePoint[] = [];
+  const now = new Date();
+  const start = new Date();
+  start.setFullYear(start.getFullYear() - years);
+
+  // Generate a handful of activities per year within the allowed range
+  for (let y = 0; y < years; y++) {
+    for (let i = 0; i < 5; i++) {
+      const d = new Date(now);
+      d.setFullYear(now.getFullYear() - y);
+      d.setMonth(Math.floor(Math.random() * 12));
+      d.setDate(1 + Math.floor(Math.random() * 28));
+      const miles = +(3 + Math.random() * 10).toFixed(2);
+      const coordinates: [number, number][] = [
+        [-122.5 + Math.random() * 0.1, 37.7 + Math.random() * 0.1],
+        [-122.4 + Math.random() * 0.1, 37.8 + Math.random() * 0.1],
+      ];
+      points.push({
+        date: d.toISOString().slice(0, 10),
+        miles,
+        coordinates,
+      });
+    }
+  }
+
+  // Only keep activities within the requested time range
+  return points
+    .filter((p) => new Date(p.date) >= start)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export async function getMileageTimeline(
+  years = 20,
+): Promise<MileageTimelinePoint[]> {
   return new Promise((resolve) => {
-    setTimeout(() => resolve([]), 200);
+    setTimeout(() => resolve(generateMockMileageTimeline(years)), 200);
   });
 }
 


### PR DESCRIPTION
## Summary
- add MileageTimelinePoint interface with coordinates and mock generator
- expose getMileageTimeline(years) to return activity mileage timeline
- update mileage timeline hook and tests for new date-based data

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d79110fd483249caf4bcb8575787d