### PR TITLE
Add GoodDayMap and session data to dashboard

### DIFF
--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import {
+  ChartContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+} from "@/components/ui/chart"
+import ChartCard from "@/components/dashboard/ChartCard"
+import { SessionPoint } from "@/hooks/useRunningSessions"
+import { Skeleton } from "@/components/ui/skeleton"
+
+const config = {
+  good: { label: "Good Day", color: "hsl(var(--chart-6))" },
+} satisfies Record<string, unknown>
+
+interface GoodDayMapProps {
+  data: SessionPoint[] | null
+}
+
+export default function GoodDayMap({ data }: GoodDayMapProps) {
+  if (!data) return <Skeleton className="h-64" />
+
+  const goodSessions = data.filter((d) => d.good)
+
+  return (
+    <ChartCard
+      title="Good Day Sessions"
+      description="Sessions exceeding expectations"
+    >
+      <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
+        <ScatterChart>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" dataKey="x" name="X" />
+          <YAxis type="number" dataKey="y" name="Y" />
+          <ChartTooltip />
+          <Scatter
+            data={goodSessions}
+            fill="hsl(var(--chart-6))"
+            shape="star"
+            animationDuration={300}
+          />
+        </ScatterChart>
+      </ChartContainer>
+    </ChartCard>
+  )
+}
+

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -17,6 +17,7 @@ export { default as WeeklyComparisonChart } from "./WeeklyComparisonChart";
 
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";
 export { default as SessionSimilarityMap } from "./SessionSimilarityMap";
+export { default as GoodDayMap } from "./GoodDayMap";
 
 export { default as WeatherConditionBar } from "./WeatherConditionBar";
 export { default as PaceVsTemperature } from "./PaceVsTemperature";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,10 +13,12 @@ import {
 } from "@/components/dashboard";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { SessionSimilarityMap } from "@/components/statistics";
+import { SessionSimilarityMap, GoodDayMap } from "@/components/statistics";
+import { useRunningSessions } from "@/hooks/useRunningSessions";
 
 export default function Dashboard() {
   const data = useGarminData();
+  const sessions = useRunningSessions();
   const [activeTab, setActiveTab] = useState<
     | "map"
     | "route"
@@ -25,6 +27,7 @@ export default function Dashboard() {
     | "globe"
     | "fragility"
     | "sessions"
+    | "goodday"
   >("map");
 
   if (!data) {
@@ -51,6 +54,7 @@ export default function Dashboard() {
 
         <TabsTrigger value="fragility">Fragility</TabsTrigger>
         <TabsTrigger value="sessions">Session Similarity</TabsTrigger>
+        <TabsTrigger value="goodday">Good Day</TabsTrigger>
       </TabsList>
       <TabsContent value="map">
         <div className="p-6 text-muted-foreground">
@@ -94,7 +98,10 @@ export default function Dashboard() {
         </div>
       </TabsContent>
       <TabsContent value="sessions">
-        <SessionSimilarityMap />
+        <SessionSimilarityMap data={sessions} />
+      </TabsContent>
+      <TabsContent value="goodday">
+        <GoodDayMap data={sessions} />
       </TabsContent>
     </Tabs>
   );

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/hooks/useGarminData", () => ({
   __esModule: true,
   useGarminData: () => ({ lastSync: new Date().toISOString() }),
 }));
+vi.mock("@/hooks/useRunningSessions", () => ({
+  __esModule: true,
+  useRunningSessions: () => null,
+}));
 
 describe("Dashboard", () => {
   it("shows fragility description", async () => {


### PR DESCRIPTION
## Summary
- add GoodDayMap scatter chart for "good" sessions only
- wire up Dashboard with running session data and new Good Day tab
- mock running sessions hook in Dashboard tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d8740c31c8324a3e89743fbae3324