### PR TITLE
refactor: use vite env for spotify config

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ npm test
 The Run Soundtrack card uses the Spotify Web API. Set the following environment variables so the helpers can obtain an access token:
 
 ```
-SPOTIFY_CLIENT_ID=<your client id>
-SPOTIFY_CLIENT_SECRET=<your client secret>
-SPOTIFY_REFRESH_TOKEN=<refresh token>
+VITE_SPOTIFY_CLIENT_ID=<your client id>
+VITE_SPOTIFY_CLIENT_SECRET=<your client secret>
+VITE_SPOTIFY_REFRESH_TOKEN=<refresh token>
 ```
 
-Alternatively provide `SPOTIFY_ACCESS_TOKEN` directly if you already have one. These values are read at runtime by `src/lib/spotify.ts`.
+Alternatively provide `VITE_SPOTIFY_ACCESS_TOKEN` directly if you already have one. These values are read at runtime by `src/lib/spotify.ts`.
 
 ## Weather overlay
 The geographic explorer can display precipitation tiles from OpenWeatherMap. A

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -9,15 +9,16 @@ let accessToken: string | null = null
 let tokenExpiry = 0
 
 async function refreshAccessToken(): Promise<string> {
-  if (process.env.SPOTIFY_ACCESS_TOKEN) {
-    accessToken = process.env.SPOTIFY_ACCESS_TOKEN
+  const access = import.meta.env.VITE_SPOTIFY_ACCESS_TOKEN
+  if (access) {
+    accessToken = access
     tokenExpiry = Date.now() + 3600_000
     return accessToken
   }
 
-  const refresh = process.env.SPOTIFY_REFRESH_TOKEN
-  const id = process.env.SPOTIFY_CLIENT_ID
-  const secret = process.env.SPOTIFY_CLIENT_SECRET
+  const refresh = import.meta.env.VITE_SPOTIFY_REFRESH_TOKEN
+  const id = import.meta.env.VITE_SPOTIFY_CLIENT_ID
+  const secret = import.meta.env.VITE_SPOTIFY_CLIENT_SECRET
 
   if (!refresh || !id || !secret) {
     accessToken = 'mock-token'
@@ -28,8 +29,7 @@ async function refreshAccessToken(): Promise<string> {
   const res = await fetch('https://accounts.spotify.com/api/token', {
     method: 'POST',
     headers: {
-      Authorization:
-        'Basic ' + Buffer.from(`${id}:${secret}`).toString('base64'),
+      Authorization: 'Basic ' + btoa(`${id}:${secret}`),
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: new URLSearchParams({


### PR DESCRIPTION
## Summary
- replace Node env variables and Buffer with browser-friendly `import.meta.env` and `btoa`
- document Spotify `VITE_` env vars in README

## Testing
- `npm test` (fails: HabitConsistencyHeatmap is not defined)
- `npm run build` (fails: GoodDayMap is not exported)
- `npm run dev` (fails to start: No matching export for GoodDayMap)


------
https://chatgpt.com/codex/tasks/task_e_688d8c5385c08324aeee63e830ea1189