### PR TITLE
feat: add sidebar and route-based dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import Layout from "@/components/layout/Layout";
 import Dashboard from "@/pages/Dashboard";
-import MileageGlobePage from "@/pages/MileageGlobe";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 
 function App() {
@@ -11,8 +10,8 @@ function App() {
       <DashboardFiltersProvider>
         <Layout>
           <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/mileage-globe" element={<MileageGlobePage />} />
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard/*" element={<Dashboard />} />
           </Routes>
         </Layout>
       </DashboardFiltersProvider>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ThemeToggle from "@/components/ui/theme-toggle";
+import Sidebar from "./Sidebar";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -7,12 +8,15 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen p-4">
-      <header className="flex justify-between items-center mb-4">
-        <h1 className="text-xl font-bold">Dashboard</h1>
-        <ThemeToggle />
-      </header>
-      <div className="mt-2">{children}</div>
+    <div className="min-h-screen flex">
+      <Sidebar />
+      <div className="flex-1 p-4">
+        <header className="flex justify-between items-center mb-4">
+          <h1 className="text-xl font-bold">Dashboard</h1>
+          <ThemeToggle />
+        </header>
+        <div className="mt-2">{children}</div>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+} from "@/components/ui/navigation-menu";
+import { NavLink } from "react-router-dom";
+import { cn } from "@/lib/utils";
+
+const links = [
+  { to: "/dashboard/map", label: "Map playground" },
+  { to: "/dashboard/route-similarity", label: "Route similarity" },
+  { to: "/dashboard/route-novelty", label: "Route novelty" },
+  { to: "/dashboard/examples", label: "Analytics fun" },
+  { to: "/dashboard/mileage-globe", label: "Mileage Globe" },
+  { to: "/dashboard/fragility", label: "Fragility" },
+  { to: "/dashboard/session-similarity", label: "Session Similarity" },
+  { to: "/dashboard/good-day", label: "Good Day" },
+  { to: "/dashboard/habit-consistency", label: "Habit consistency" },
+];
+
+export default function Sidebar() {
+  return (
+    <aside className="w-56 border-r p-4">
+      <NavigationMenu className="flex flex-col">
+        <NavigationMenuList className="flex-col space-y-1">
+          {links.map((link) => (
+            <NavigationMenuItem key={link.to}>
+              <NavigationMenuLink asChild>
+                <NavLink
+                  to={link.to}
+                  className={({ isActive }) =>
+                    cn(
+                      "block rounded-md px-3 py-2 text-sm",
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted"
+                    )
+                  }
+                >
+                  {link.label}
+                </NavLink>
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+          ))}
+        </NavigationMenuList>
+      </NavigationMenu>
+    </aside>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,40 +1,26 @@
-import React, { useState } from "react";
+import React from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGarminData } from "@/hooks/useGarminData";
 import { minutesSince } from "@/lib/utils";
 import Examples from "@/pages/Examples";
-
 import MileageGlobePage from "@/pages/MileageGlobe";
-
 import {
   FragilityGauge,
   RouteNoveltyMap,
   RouteSimilarity,
 } from "@/components/dashboard";
-
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-
-import { SessionSimilarityMap, GoodDayMap } from "@/components/statistics";
+import {
+  SessionSimilarityMap,
+  GoodDayMap,
+  HabitConsistencyHeatmap,
+} from "@/components/statistics";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
 
 
 export default function Dashboard() {
   const data = useGarminData();
   const sessions = useRunningSessions();
-  const [activeTab, setActiveTab] = useState<
-    | "map"
-    | "route"
-    | "novelty"
-    | "examples"
-    | "globe"
-    | "fragility"
-    | "sessions"
-
-    | "goodday"
-
-    | "consistency"
-
-  >("map");
 
   if (!data) {
     return (
@@ -49,73 +35,51 @@ export default function Dashboard() {
   minutesSince(data.lastSync); // retain side-effect-free call for now
 
   return (
-    <Tabs value={activeTab} onValueChange={setActiveTab}>
-      <TabsList>
-        <TabsTrigger value="map">Map playground</TabsTrigger>
-        <TabsTrigger value="route">Route similarity</TabsTrigger>
-        <TabsTrigger value="novelty">Route Novelty</TabsTrigger>
-        <TabsTrigger value="examples">Analytics fun</TabsTrigger>
-
-        <TabsTrigger value="globe">Mileage Globe</TabsTrigger>
-
-        <TabsTrigger value="fragility">Fragility</TabsTrigger>
-        <TabsTrigger value="sessions">Session Similarity</TabsTrigger>
-
-        <TabsTrigger value="goodday">Good Day</TabsTrigger>
-
-        <TabsTrigger value="consistency">Habit consistency</TabsTrigger>
-
-      </TabsList>
-      <TabsContent value="map">
-        <div className="p-6 text-muted-foreground">
-          Map playground details coming soon.
-        </div>
-      </TabsContent>
-      <TabsContent value="route">
-        <RouteSimilarity />
-      </TabsContent>
-      <TabsContent value="novelty">
-        <RouteNoveltyMap />
-      </TabsContent>
-      <TabsContent value="examples">
-        <Examples />
-      </TabsContent>
-
-      <TabsContent value="globe">
-        <MileageGlobePage />
-      </TabsContent>
-
-      <TabsContent value="fragility">
-        <div className="space-y-4 p-4">
-          <h3 className="text-lg font-semibold">Fragility index</h3>
-          <p className="text-sm text-muted-foreground">
-            The fragility index blends training consistency with load spikes to
-            estimate injury risk. Lower scores signal resilience, while higher
-            scores call for caution.
-          </p>
-          <ul className="text-sm text-muted-foreground list-disc pl-4">
-            <li>
-              <span className="text-green-600">0–0.33</span>: stable
-            </li>
-            <li>
-              <span className="text-yellow-600">0.34–0.66</span>: monitor
-            </li>
-            <li>
-              <span className="text-red-600">0.67–1.00</span>: high risk
-            </li>
-          </ul>
-          <FragilityGauge />
-        </div>
-      </TabsContent>
-      <TabsContent value="sessions">
-        <SessionSimilarityMap data={sessions} />
-      </TabsContent>
-      <TabsContent value="goodday">
-        <GoodDayMap data={sessions} />
-      </TabsContent>
-      <TabsContent value="consistency">
-        <HabitConsistencyHeatmap />
-      </TabsContent>
-    </Tabs>
+    <Routes>
+      <Route
+        path="map"
+        element={
+          <div className="p-6 text-muted-foreground">
+            Map playground details coming soon.
+          </div>
+        }
+      />
+      <Route path="route-similarity" element={<RouteSimilarity />} />
+      <Route path="route-novelty" element={<RouteNoveltyMap />} />
+      <Route path="examples" element={<Examples />} />
+      <Route path="mileage-globe" element={<MileageGlobePage />} />
+      <Route
+        path="fragility"
+        element={
+          <div className="space-y-4 p-4">
+            <h3 className="text-lg font-semibold">Fragility index</h3>
+            <p className="text-sm text-muted-foreground">
+              The fragility index blends training consistency with load spikes to
+              estimate injury risk. Lower scores signal resilience, while higher
+              scores call for caution.
+            </p>
+            <ul className="text-sm text-muted-foreground list-disc pl-4">
+              <li>
+                <span className="text-green-600">0–0.33</span>: stable
+              </li>
+              <li>
+                <span className="text-yellow-600">0.34–0.66</span>: monitor
+              </li>
+              <li>
+                <span className="text-red-600">0.67–1.00</span>: high risk
+              </li>
+            </ul>
+            <FragilityGauge />
+          </div>
+        }
+      />
+      <Route
+        path="session-similarity"
+        element={<SessionSimilarityMap data={sessions} />}
+      />
+      <Route path="good-day" element={<GoodDayMap data={sessions} />} />
+      <Route path="habit-consistency" element={<HabitConsistencyHeatmap />} />
+      <Route index element={<Navigate to="route-similarity" replace />} />
+    </Routes>
   );
 }

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 import React from "react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
 import Dashboard from "../Dashboard";
 
 vi.mock("@/hooks/useGarminData", () => ({
@@ -15,9 +15,14 @@ vi.mock("@/hooks/useRunningSessions", () => ({
 }));
 
 describe("Dashboard", () => {
-  it("shows fragility description", async () => {
-    render(<Dashboard />);
-    await userEvent.click(screen.getByRole("button", { name: /fragility/i }));
+  it("shows fragility description", () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/fragility']}>
+        <Routes>
+          <Route path="/dashboard/*" element={<Dashboard />} />
+        </Routes>
+      </MemoryRouter>
+    );
     expect(
       screen.getByRole("heading", { name: /fragility index/i })
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add sidebar navigation using NavigationMenu
- render sidebar in layout next to main content
- replace dashboard tabs with router-based routes and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8c9bac5c8324a7fd518a507eb005