### PR TITLE
feat: export PeerBenchmarkBands from statistics index

### DIFF
--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -10,6 +10,7 @@ export { default as TrainingLoadRatio } from "./TrainingLoadRatio";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 export { default as SessionStartEntropy } from "./SessionStartEntropy";
+export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";
 
 export { default as RunBikeVolumeComparison } from "./RunBikeVolumeComparison";
 export { default as WeeklyComparisonChart } from "./WeeklyComparisonChart";

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -20,7 +20,7 @@ import AreaChartLoadRatio from "@/components/examples/AreaChartLoadRatio";
 import TreadmillVsOutdoorExample from "@/components/examples/TreadmillVsOutdoor";
 import { mockDailySteps } from "@/lib/api";
 import StepsTrendWithGoal from "@/components/dashboard/StepsTrendWithGoal";
-import PeerBenchmarkBands from "@/components/statistics/PeerBenchmarkBands";
+import { PeerBenchmarkBands } from "@/components/statistics";
 import ChartPreview from "@/components/examples/ChartPreview";
 
 import PerfVsEnvironmentMatrixExample from "@/components/examples/PerfVsEnvironmentMatrix";


### PR DESCRIPTION
## Summary
- export PeerBenchmarkBands from statistics index barrel
- import PeerBenchmarkBands from statistics entry in Examples page

## Testing
- `npm test -- --run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_688d8a0a27a883249330ae4686b4a646