### PR TITLE
fix dialog overlay z-index

### DIFF
--- a/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/components/ui/__tests__/dialog.test.tsx
@@ -18,7 +18,28 @@ function TestDialog() {
   );
 }
 
+function TestDialogWithButton() {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContentFullscreen>
+        <button onClick={() => setOpen(false)}>close</button>
+      </DialogContentFullscreen>
+    </Dialog>
+  );
+}
+
 describe("DialogContentFullscreen", () => {
+  it("renders content above the overlay", () => {
+    render(<TestDialog />);
+
+    const overlay = document.querySelector('[data-state="open"]') as HTMLElement;
+    const content = screen.getByRole("dialog");
+
+    expect(overlay.className).toMatch(/z-40/);
+    expect(content.className).toMatch(/z-50/);
+  });
+
   it("closes when clicking the overlay", async () => {
     const user = userEvent.setup();
     render(<TestDialog />);
@@ -30,5 +51,16 @@ describe("DialogContentFullscreen", () => {
     await user.click(overlay);
 
     expect(screen.queryByText("content")).not.toBeInTheDocument();
+  });
+
+  it("allows interaction with content above the overlay", async () => {
+    const user = userEvent.setup();
+    render(<TestDialogWithButton />);
+
+    const button = screen.getByRole("button", { name: /close/i });
+
+    await user.click(button);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -15,7 +15,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm",
+      "fixed inset-0 z-40 bg-black/50 backdrop-blur-sm",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- lower DialogOverlay z-index to sit beneath fullscreen content
- add tests ensuring dialog content renders above overlay and remains interactive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d89ee050c8324b926753fd961a5f0