### PR TITLE
fix: export GoodDayMap

### DIFF
--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -1,6 +1,7 @@
 export { default as ActivityByTime } from "./ActivityByTime";
 export { default as AvgDailyMileageRadar } from "./AvgDailyMileageRadar";
 export { default as EquipmentUsageTimeline } from "./EquipmentUsageTimeline";
+export { default as GoodDayMap } from "./GoodDayMap";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";


### PR DESCRIPTION
## Summary
- export `GoodDayMap` from `statistics` so Dashboard can import it

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688d92ddc0cc8324af03467d51d8f5ad