### PR TITLE
feat: add global command palette

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import Sidebar from "./Sidebar";
+import CommandPalette from "@/components/ui/CommandPalette";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -10,6 +11,7 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <div className="min-h-screen flex">
       <Sidebar />
+      <CommandPalette />
       <div className="flex-1 p-4">
         <header className="flex justify-between items-center mb-4">
           <h1 className="text-xl font-bold">Dashboard</h1>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,25 +7,14 @@ import {
 } from "@/components/ui/navigation-menu";
 import { NavLink } from "react-router-dom";
 import { cn } from "@/lib/utils";
-
-const links = [
-  { to: "/dashboard/map", label: "Map playground" },
-  { to: "/dashboard/route-similarity", label: "Route similarity" },
-  { to: "/dashboard/route-novelty", label: "Route novelty" },
-  { to: "/dashboard/examples", label: "Analytics fun" },
-  { to: "/dashboard/mileage-globe", label: "Mileage Globe" },
-  { to: "/dashboard/fragility", label: "Fragility" },
-  { to: "/dashboard/session-similarity", label: "Session Similarity" },
-  { to: "/dashboard/good-day", label: "Good Day" },
-  { to: "/dashboard/habit-consistency", label: "Habit consistency" },
-];
+import { dashboardRoutes } from "@/routes";
 
 export default function Sidebar() {
   return (
     <aside className="w-56 border-r p-4">
       <NavigationMenu className="flex flex-col">
         <NavigationMenuList className="flex-col space-y-1">
-          {links.map((link) => (
+          {dashboardRoutes.map((link) => (
             <NavigationMenuItem key={link.to}>
               <NavigationMenuLink asChild>
                 <NavLink

--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { dashboardRoutes } from "@/routes";
+
+export default function CommandPalette() {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener("keydown", down);
+    return () => document.removeEventListener("keydown", down);
+  }, []);
+
+  const filtered = dashboardRoutes.filter((route) =>
+    route.label.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const handleSelect = (path: string) => {
+    setOpen(false);
+    setQuery("");
+    navigate(path);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="p-0">
+        <div className="p-2">
+          <input
+            autoFocus
+            className="mb-2 w-full border-b bg-transparent px-2 py-1 outline-none"
+            placeholder="Type a command or search..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <ul className="max-h-60 overflow-y-auto">
+            {filtered.map((route) => (
+              <li key={route.to}>
+                <button
+                  className="block w-full px-2 py-1 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                  onClick={() => handleSelect(route.to)}
+                >
+                  {route.label}
+                </button>
+              </li>
+            ))}
+            {filtered.length === 0 && (
+              <li className="px-2 py-1 text-sm text-muted-foreground">
+                No results found.
+              </li>
+            )}
+          </ul>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,13 @@
+export const dashboardRoutes = [
+  { to: "/dashboard/map", label: "Map playground" },
+  { to: "/dashboard/route-similarity", label: "Route similarity" },
+  { to: "/dashboard/route-novelty", label: "Route novelty" },
+  { to: "/dashboard/examples", label: "Analytics fun" },
+  { to: "/dashboard/mileage-globe", label: "Mileage Globe" },
+  { to: "/dashboard/fragility", label: "Fragility" },
+  { to: "/dashboard/session-similarity", label: "Session Similarity" },
+  { to: "/dashboard/good-day", label: "Good Day" },
+  { to: "/dashboard/habit-consistency", label: "Habit consistency" },
+];
+
+export type DashboardRoute = (typeof dashboardRoutes)[number];


### PR DESCRIPTION
## Summary
- implement command palette with ctrl/cmd+k shortcut
- centralize dashboard route definitions
- mount palette in layout for global use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d928fa99c8324b4142ef3df12f5b1