### PR TITLE
Refactor layout to use SidebarProvider and trigger

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import Sidebar from "./Sidebar";
 import CommandPalette from "@/components/ui/CommandPalette";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -9,16 +10,17 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen flex">
+    <SidebarProvider>
       <Sidebar />
       <CommandPalette />
-      <div className="flex-1 p-4">
+      <main className="flex-1 p-4">
         <header className="flex justify-between items-center mb-4">
           <h1 className="text-xl font-bold">Dashboard</h1>
           <ThemeToggle />
         </header>
+        <SidebarTrigger />
         <div className="mt-2">{children}</div>
-      </div>
-    </div>
+      </main>
+    </SidebarProvider>
   );
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,15 +1,53 @@
 import * as React from "react";
+import { Menu } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
-const Sidebar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+interface SidebarContextValue {
+  open: boolean;
+  toggle: () => void;
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | undefined>(
+  undefined,
+);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider");
+  }
+  return context;
+}
+
+export function SidebarProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = React.useState(true);
+  const toggle = React.useCallback(() => setOpen((o) => !o), []);
+
+  return (
+    <SidebarContext.Provider value={{ open, toggle }}>
+      <div className="flex min-h-screen w-full">{children}</div>
+    </SidebarContext.Provider>
+  );
+}
+
+const Sidebar = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { open } = useSidebar();
+  return (
     <aside
       ref={ref}
-      className={cn("w-56 border-r p-4", className)}
+      className={cn("w-56 border-r p-4", !open && "hidden", className)}
       {...props}
     />
-  )
-);
+  );
+});
 Sidebar.displayName = "Sidebar";
 
 const SidebarHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
@@ -40,5 +78,33 @@ const SidebarItem = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIE
 );
 SidebarItem.displayName = "SidebarItem";
 
-export { Sidebar, SidebarHeader, SidebarContent, SidebarGroup, SidebarItem };
+export const SidebarTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>(({ className, ...props }, ref) => {
+  const { toggle } = useSidebar();
+  return (
+    <Button
+      ref={ref}
+      variant="outline"
+      size="sm"
+      className={cn("mb-4", className)}
+      onClick={toggle}
+      {...props}
+    >
+      <Menu className="h-4 w-4" />
+    </Button>
+  );
+});
+SidebarTrigger.displayName = "SidebarTrigger";
+
+export {
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarGroup,
+  SidebarItem,
+  SidebarProvider,
+  SidebarTrigger,
+};
 


### PR DESCRIPTION
## Summary
- wrap root layout with `SidebarProvider` and render `SidebarTrigger`
- add `SidebarProvider` and `SidebarTrigger` components for sidebar state management

## Testing
- `npm test` *(fails: 2 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688d9ff0a4ac832486f7a9ad24c76016