### PR TITLE
Add social engagement index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "garmin-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@capacitor/core": "^7.4.2",
+        "@capacitor/geolocation": "^7.1.4",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-navigation-menu": "^1.2.13",
         "@radix-ui/react-popover": "^1.1.14",
@@ -391,6 +393,33 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.4.2.tgz",
+      "integrity": "sha512-akCf9A1FUR8AWTtmgGjHEq6LmGsjA2U7igaJ9PxiCBfyxKqlDbuGHrlNdpvHEjV5tUPH3KYtkze6gtFcNKPU9A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/geolocation": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-7.1.4.tgz",
+      "integrity": "sha512-8KQfa1RNVmgFoDYYaf13qDuf5rh7ob4mC/zRpzpavPEFhWkuIbFM5dyNpSndc9EFnaIib8BCIjJj9ZQ6+nPrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@capacitor/core": "^7.4.2",
+    "@capacitor/geolocation": "^7.1.4",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-popover": "^1.1.14",

--- a/src/components/dashboard/SocialEngagementCard.tsx
+++ b/src/components/dashboard/SocialEngagementCard.tsx
@@ -1,0 +1,24 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import useSocialEngagement from "@/hooks/useSocialEngagement";
+
+export default function SocialEngagementCard() {
+  const data = useSocialEngagement();
+  if (!data) return <Skeleton className="h-32" />;
+  const { index, consecutiveHomeDays } = data;
+  const message =
+    consecutiveHomeDays >= 5
+      ? "You've been mostly at home for 5 days—maybe schedule a quick meetup or change of scenery."
+      : null;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Social Engagement</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold tabular-nums">{index.toFixed(2)}</div>
+        {message && <p className="mt-2 text-sm text-muted-foreground">{message}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -32,4 +32,6 @@ export { default as RouteSimilarity } from "./RouteSimilarity";
 
 export { default as RouteNoveltyMap } from "./RouteNoveltyMap";
 
+export { default as SocialEngagementCard } from "./SocialEngagementCard";
+
 

--- a/src/hooks/__tests__/useSocialEngagement.test.ts
+++ b/src/hooks/__tests__/useSocialEngagement.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { computeSocialEngagementIndex } from '../useSocialEngagement'
+import type { LocationVisit } from '@/lib/api'
+
+const visits: LocationVisit[] = [
+  { date: '2025-07-01', placeId: 'home', category: 'home' },
+  { date: '2025-07-02', placeId: 'home', category: 'home' },
+  { date: '2025-07-02', placeId: 'office', category: 'work' },
+  { date: '2025-07-03', placeId: 'cafe', category: 'other' },
+  { date: '2025-07-04', placeId: 'home', category: 'home' },
+]
+
+describe('computeSocialEngagementIndex', () => {
+  it('calculates index and home streak', () => {
+    const { index, consecutiveHomeDays } = computeSocialEngagementIndex(visits)
+    expect(index).toBeCloseTo(0.56, 2)
+    expect(consecutiveHomeDays).toBe(1)
+  })
+})

--- a/src/hooks/useSocialEngagement.ts
+++ b/src/hooks/useSocialEngagement.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from "react";
+import { getLocationVisits, type LocationVisit } from "@/lib/api";
+
+function computeLocationEntropy(visits: LocationVisit[]): number {
+  const counts: Record<string, number> = {};
+  visits.forEach((v) => {
+    counts[v.placeId] = (counts[v.placeId] || 0) + 1;
+  });
+  const total = visits.length;
+  if (total === 0) return 0;
+  let entropy = 0;
+  Object.values(counts).forEach((c) => {
+    const p = c / total;
+    entropy -= p * Math.log(p);
+  });
+  const maxEntropy = Math.log(Object.keys(counts).length);
+  return maxEntropy === 0 ? 0 : entropy / maxEntropy;
+}
+
+function computeOutOfHomeFrequency(visits: LocationVisit[]): number {
+  const byDate: Record<string, LocationVisit[]> = {};
+  visits.forEach((v) => {
+    if (!byDate[v.date]) byDate[v.date] = [];
+    byDate[v.date].push(v);
+  });
+  const days = Object.values(byDate);
+  if (days.length === 0) return 0;
+  let outDays = 0;
+  days.forEach((day) => {
+    if (day.some((v) => v.category === "other")) outDays++;
+  });
+  return outDays / days.length;
+}
+
+function computeConsecutiveHomeDays(visits: LocationVisit[]): number {
+  const byDate: Record<string, LocationVisit[]> = {};
+  visits.forEach((v) => {
+    if (!byDate[v.date]) byDate[v.date] = [];
+    byDate[v.date].push(v);
+  });
+  const dates = Object.keys(byDate).sort().reverse();
+  let count = 0;
+  for (const d of dates) {
+    const day = byDate[d];
+    const hasOther = day.some((v) => v.category === "other");
+    if (hasOther) break;
+    count++;
+  }
+  return count;
+}
+
+export function computeSocialEngagementIndex(visits: LocationVisit[]): {
+  index: number;
+  locationEntropy: number;
+  outOfHomeFrequency: number;
+  consecutiveHomeDays: number;
+} {
+  const locationEntropy = computeLocationEntropy(visits);
+  const outOfHomeFrequency = computeOutOfHomeFrequency(visits);
+  const consecutiveHomeDays = computeConsecutiveHomeDays(visits);
+  const index = (locationEntropy + outOfHomeFrequency) / 2;
+  return { index, locationEntropy, outOfHomeFrequency, consecutiveHomeDays };
+}
+
+export default function useSocialEngagement() {
+  const [visits, setVisits] = useState<LocationVisit[] | null>(null);
+
+  useEffect(() => {
+    getLocationVisits().then(setVisits);
+  }, []);
+
+  return useMemo(() => {
+    if (!visits) return null;
+    return computeSocialEngagementIndex(visits);
+  }, [visits]);
+}
+
+export { computeLocationEntropy, computeOutOfHomeFrequency, computeConsecutiveHomeDays };

--- a/src/lib/__tests__/location.test.ts
+++ b/src/lib/__tests__/location.test.ts
@@ -1,0 +1,19 @@
+import { getCurrentLocation } from "@/lib/api";
+
+vi.mock("@capacitor/geolocation", () => ({
+  Geolocation: {
+    requestPermissions: vi.fn().mockResolvedValue({ location: "granted" }),
+    getCurrentPosition: vi
+      .fn()
+      .mockResolvedValue({ coords: { latitude: 44, longitude: -93 } }),
+  },
+}));
+
+describe("getCurrentLocation", () => {
+  it("returns coordinates from the geolocation plugin", async () => {
+    await expect(getCurrentLocation()).resolves.toEqual({
+      latitude: 44,
+      longitude: -93,
+    });
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type { DailyWeather } from "./weatherApi";
 import { getWeatherForRuns } from "./weatherApi";
+import { Geolocation } from "@capacitor/geolocation";
 
 export type Activity = {
   id: number;
@@ -365,6 +366,57 @@ export async function getStateVisits(): Promise<StateVisit[]> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(mockStateVisits), 300);
   });
+}
+
+// ----- Location visits -----
+
+export interface LocationVisit {
+  /** ISO date of the visit */
+  date: string;
+  /** Identifier for the place or cluster */
+  placeId: string;
+  /** Basic category to distinguish home/work/other */
+  category: "home" | "work" | "other";
+}
+
+const today = new Date();
+function daysAgo(day: number) {
+  return new Date(today.getTime() - day * 86400000).toISOString().slice(0, 10);
+}
+
+const mockLocationVisits: LocationVisit[] = [
+  { date: daysAgo(0), placeId: "home", category: "home" },
+  { date: daysAgo(1), placeId: "home", category: "home" },
+  { date: daysAgo(2), placeId: "home", category: "home" },
+  { date: daysAgo(3), placeId: "home", category: "home" },
+  { date: daysAgo(4), placeId: "cafe", category: "other" },
+  { date: daysAgo(5), placeId: "home", category: "home" },
+  { date: daysAgo(5), placeId: "office", category: "work" },
+];
+
+export async function getLocationVisits(): Promise<LocationVisit[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockLocationVisits), 200);
+  });
+}
+
+// ----- Device location -----
+
+export interface CurrentLocation {
+  latitude: number;
+  longitude: number;
+}
+
+export async function getCurrentLocation(): Promise<CurrentLocation | null> {
+  try {
+    await Geolocation.requestPermissions();
+    const { coords } = await Geolocation.getCurrentPosition({
+      enableHighAccuracy: true,
+    });
+    return { latitude: coords.latitude, longitude: coords.longitude };
+  } catch {
+    return null;
+  }
 }
 
 // ----- Running stats -----


### PR DESCRIPTION
## Summary
- add mock location visit API and hook to compute social engagement index
- display social engagement score and home-streak warning in a dashboard card
- cover social engagement index math with unit test
- add Capacitor geolocation wrapper to pull device coordinates via Google's fused location provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8d1bcbc08324b4f50c4de37aca70