### PR TITLE
refactor sidebar structure and add footer

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import {
-  Sidebar as SidebarRoot,
+  Sidebar,
   SidebarHeader,
   SidebarContent,
   SidebarGroup,
-  SidebarItem,
+  SidebarFooter,
 } from "@/components/ui/sidebar";
 import { NavLink } from "react-router-dom";
 import { cn } from "@/lib/utils";
@@ -12,12 +12,12 @@ import { dashboardRoutes } from "@/routes";
 
 export default function AppSidebar() {
   return (
-    <SidebarRoot>
+    <Sidebar>
       <SidebarHeader />
       <SidebarContent>
         <SidebarGroup>
           {dashboardRoutes.map((link) => (
-            <SidebarItem key={link.to}>
+            <li key={link.to}>
               <NavLink
                 to={link.to}
                 className={({ isActive }) =>
@@ -31,10 +31,11 @@ export default function AppSidebar() {
               >
                 {link.label}
               </NavLink>
-            </SidebarItem>
+            </li>
           ))}
         </SidebarGroup>
       </SidebarContent>
-    </SidebarRoot>
+      <SidebarFooter />
+    </Sidebar>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ThemeToggle from "@/components/ui/theme-toggle";
-import Sidebar from "./Sidebar";
+import AppSidebar from "@/components/app-sidebar";
 import CommandPalette from "@/components/ui/CommandPalette";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 
@@ -11,7 +11,7 @@ interface LayoutProps {
 export default function Layout({ children }: LayoutProps) {
   return (
     <SidebarProvider>
-      <Sidebar />
+      <AppSidebar />
       <CommandPalette />
       <main className="flex-1 p-4">
         <header className="flex justify-between items-center mb-4">

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -78,6 +78,14 @@ const SidebarItem = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIE
 );
 SidebarItem.displayName = "SidebarItem";
 
+const SidebarFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-auto", className)} {...props} />
+));
+SidebarFooter.displayName = "SidebarFooter";
+
 export const SidebarTrigger = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement>
@@ -104,6 +112,7 @@ export {
   SidebarContent,
   SidebarGroup,
   SidebarItem,
+  SidebarFooter,
   SidebarProvider,
   SidebarTrigger,
 };


### PR DESCRIPTION
## Summary
- rename and relocate Sidebar component to `app-sidebar` at root
- import `Sidebar` primitives from `@/components/ui/sidebar` and add empty `SidebarFooter`
- adjust `Layout` to consume new `AppSidebar`

## Testing
- `npx vitest run` *(fails: Dashboard > shows fragility description)*

------
https://chatgpt.com/codex/tasks/task_e_688da151e1948324a9910f6d986afed6