### PR TITLE
refactor: centralize sidebar exports

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -20,7 +20,7 @@ function useSidebar() {
   return context;
 }
 
-export function SidebarProvider({
+function SidebarProvider({
   children,
 }: {
   children: React.ReactNode;
@@ -86,7 +86,7 @@ const SidebarFooter = React.forwardRef<
 ));
 SidebarFooter.displayName = "SidebarFooter";
 
-export const SidebarTrigger = React.forwardRef<
+const SidebarTrigger = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement>
 >(({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- centralize sidebar exports by removing inline `export` keywords from `SidebarProvider` and `SidebarTrigger`

## Testing
- `npm test` *(fails: GeoActivityExplorer toggles state details)*

------
https://chatgpt.com/codex/tasks/task_e_688da3adcbd88324809a17d6aad45fb4