### PR TITLE
feat: derive location visits from clustered points

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,11 @@
 import type { DailyWeather } from "./weatherApi";
 import { getWeatherForRuns } from "./weatherApi";
 import { Geolocation } from "@capacitor/geolocation";
+import {
+  getLocationVisits as deriveLocationVisits,
+  type LocationVisit,
+} from "./locationStore";
+export type { LocationVisit } from "./locationStore";
 
 export type Activity = {
   id: number;
@@ -370,34 +375,8 @@ export async function getStateVisits(): Promise<StateVisit[]> {
 
 // ----- Location visits -----
 
-export interface LocationVisit {
-  /** ISO date of the visit */
-  date: string;
-  /** Identifier for the place or cluster */
-  placeId: string;
-  /** Basic category to distinguish home/work/other */
-  category: "home" | "work" | "other";
-}
-
-const today = new Date();
-function daysAgo(day: number) {
-  return new Date(today.getTime() - day * 86400000).toISOString().slice(0, 10);
-}
-
-const mockLocationVisits: LocationVisit[] = [
-  { date: daysAgo(0), placeId: "home", category: "home" },
-  { date: daysAgo(1), placeId: "home", category: "home" },
-  { date: daysAgo(2), placeId: "home", category: "home" },
-  { date: daysAgo(3), placeId: "home", category: "home" },
-  { date: daysAgo(4), placeId: "cafe", category: "other" },
-  { date: daysAgo(5), placeId: "home", category: "home" },
-  { date: daysAgo(5), placeId: "office", category: "work" },
-];
-
 export async function getLocationVisits(): Promise<LocationVisit[]> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(mockLocationVisits), 200);
-  });
+  return deriveLocationVisits();
 }
 
 // ----- Device location -----

--- a/src/lib/locationProcessing.ts
+++ b/src/lib/locationProcessing.ts
@@ -1,0 +1,91 @@
+export interface LocationPoint {
+  latitude: number;
+  longitude: number;
+  /** ISO timestamp */
+  timestamp: string;
+}
+
+export interface VisitGroup {
+  start: string;
+  end: string;
+  latitude: number;
+  longitude: number;
+  placeId: string;
+}
+
+const EARTH_RADIUS = 6371000; // meters
+
+export function haversineDistance(a: LocationPoint, b: LocationPoint): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLon = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * EARTH_RADIUS * Math.asin(Math.sqrt(h));
+}
+
+export function placeIdFor(lat: number, lon: number): string {
+  return `${lat.toFixed(3)},${lon.toFixed(3)}`;
+}
+
+export function groupConsecutivePoints(
+  points: LocationPoint[],
+  threshold = 100,
+): VisitGroup[] {
+  if (!points.length) return [];
+  const sorted = [...points].sort((a, b) =>
+    a.timestamp.localeCompare(b.timestamp),
+  );
+  const visits: VisitGroup[] = [];
+  let current = {
+    start: sorted[0].timestamp,
+    end: sorted[0].timestamp,
+    latitude: sorted[0].latitude,
+    longitude: sorted[0].longitude,
+    count: 1,
+  } as any;
+  let prev = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const p = sorted[i];
+    const dist = haversineDistance(prev, p);
+    if (dist > threshold) {
+      const lat = current.latitude / current.count;
+      const lon = current.longitude / current.count;
+      visits.push({
+        start: current.start,
+        end: current.end,
+        latitude: lat,
+        longitude: lon,
+        placeId: placeIdFor(lat, lon),
+      });
+      current = {
+        start: p.timestamp,
+        end: p.timestamp,
+        latitude: p.latitude,
+        longitude: p.longitude,
+        count: 1,
+      };
+    } else {
+      current.end = p.timestamp;
+      current.latitude += p.latitude;
+      current.longitude += p.longitude;
+      current.count++;
+    }
+    prev = p;
+  }
+  const lat = current.latitude / current.count;
+  const lon = current.longitude / current.count;
+  visits.push({
+    start: current.start,
+    end: current.end,
+    latitude: lat,
+    longitude: lon,
+    placeId: placeIdFor(lat, lon),
+  });
+  return visits;
+}
+
+export default groupConsecutivePoints;

--- a/src/lib/locationStore.ts
+++ b/src/lib/locationStore.ts
@@ -1,0 +1,155 @@
+import { groupConsecutivePoints, placeIdFor, type LocationPoint } from './locationProcessing';
+
+export type LocationCategory = 'home' | 'work' | 'other';
+
+export interface LocationCluster {
+  id: string;
+  latitude: number;
+  longitude: number;
+  category: LocationCategory;
+}
+
+export interface LocationVisit {
+  /** ISO date of the visit */
+  date: string;
+  /** Identifier for the place or cluster */
+  placeId: string;
+  /** Basic category to distinguish home/work/other */
+  category: LocationCategory;
+}
+
+const POINTS_KEY = 'loc:points';
+const CLUSTERS_KEY = 'loc:clusters';
+
+function daysAgo(day: number, hour = 8): string {
+  const d = new Date();
+  d.setDate(d.getDate() - day);
+  d.setHours(hour, 0, 0, 0);
+  return d.toISOString();
+}
+
+const home = { latitude: 44.0, longitude: -93.0 };
+const office = { latitude: 44.002, longitude: -93.002 };
+const cafe = { latitude: 44.003, longitude: -93.003 };
+
+const mockPoints: LocationPoint[] = [
+  { ...home, timestamp: daysAgo(0, 8) },
+  { ...home, timestamp: daysAgo(0, 9) },
+  { ...home, timestamp: daysAgo(1, 8) },
+  { ...home, timestamp: daysAgo(2, 8) },
+  { ...home, timestamp: daysAgo(3, 8) },
+  { ...cafe, timestamp: daysAgo(4, 10) },
+  { ...home, timestamp: daysAgo(5, 8) },
+  { ...office, timestamp: daysAgo(5, 14) },
+];
+
+const mockClusters: Record<string, LocationCluster> = {
+  [placeIdFor(home.latitude, home.longitude)]: {
+    id: placeIdFor(home.latitude, home.longitude),
+    ...home,
+    category: 'home',
+  },
+  [placeIdFor(office.latitude, office.longitude)]: {
+    id: placeIdFor(office.latitude, office.longitude),
+    ...office,
+    category: 'work',
+  },
+  [placeIdFor(cafe.latitude, cafe.longitude)]: {
+    id: placeIdFor(cafe.latitude, cafe.longitude),
+    ...cafe,
+    category: 'other',
+  },
+};
+
+function readPoints(): LocationPoint[] {
+  if (typeof localStorage === 'undefined') return [...mockPoints];
+  try {
+    const raw = localStorage.getItem(POINTS_KEY);
+    if (!raw) return [...mockPoints];
+    return JSON.parse(raw) as LocationPoint[];
+  } catch {
+    return [...mockPoints];
+  }
+}
+
+function writePoints(points: LocationPoint[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(POINTS_KEY, JSON.stringify(points));
+}
+
+export function logLocationPoint(point: LocationPoint): void {
+  const points = readPoints();
+  points.push(point);
+  writePoints(points);
+}
+
+function readClusters(): Record<string, LocationCluster> {
+  if (typeof localStorage === 'undefined') return { ...mockClusters };
+  try {
+    const raw = localStorage.getItem(CLUSTERS_KEY);
+    if (!raw) return { ...mockClusters };
+    return JSON.parse(raw) as Record<string, LocationCluster>;
+  } catch {
+    return { ...mockClusters };
+  }
+}
+
+function writeClusters(clusters: Record<string, LocationCluster>): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(CLUSTERS_KEY, JSON.stringify(clusters));
+}
+
+export function tagCluster(id: string, category: LocationCategory): void {
+  const clusters = readClusters();
+  const existing = clusters[id];
+  if (existing) {
+    existing.category = category;
+  } else {
+    const [lat, lon] = id.split(',').map(Number);
+    clusters[id] = { id, latitude: lat, longitude: lon, category };
+  }
+  writeClusters(clusters);
+}
+
+async function reverseGeocodeCategory(
+  lat: number,
+  lon: number,
+): Promise<LocationCategory> {
+  try {
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`,
+    );
+    const data = await res.json();
+    const addr = data.address || {};
+    if (addr.residential || addr.house_number) return 'home';
+    if (addr.office || addr.commercial || addr.industrial) return 'work';
+    return 'other';
+  } catch {
+    return 'other';
+  }
+}
+
+export async function ensureCluster(
+  id: string,
+  lat: number,
+  lon: number,
+): Promise<LocationCategory> {
+  const clusters = readClusters();
+  const existing = clusters[id];
+  if (existing) return existing.category;
+  const category = await reverseGeocodeCategory(lat, lon);
+  clusters[id] = { id, latitude: lat, longitude: lon, category };
+  writeClusters(clusters);
+  return category;
+}
+
+export function getLocationVisits(): LocationVisit[] {
+  const points = readPoints();
+  const visits = groupConsecutivePoints(points);
+  const clusters = readClusters();
+  return visits.map((v) => ({
+    date: v.start.slice(0, 10),
+    placeId: v.placeId,
+    category: clusters[v.placeId]?.category ?? 'other',
+  }));
+}


### PR DESCRIPTION
## Summary
- derive clustered visits from consecutive GPS points
- persist and tag location clusters, including reverse-geocode support
- use the derived visit log in API

## Testing
- `npm test` *(fails: "useSeasonalBaseline" mock not defined, GeoActivityExplorer assertion)*

------
https://chatgpt.com/codex/tasks/task_e_688da58ad9988324b83177847e3c8c04