### PR TITLE
feat: add background location logging plugin

### DIFF
--- a/android/app/src/main/java/com/improvedsystem/app/MainActivity.kt
+++ b/android/app/src/main/java/com/improvedsystem/app/MainActivity.kt
@@ -1,0 +1,58 @@
+package com.improvedsystem.app
+
+import android.os.Looper
+import com.getcapacitor.BridgeActivity
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.getcapacitor.annotation.PluginMethod
+import com.getcapacitor.JSObject
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+
+@CapacitorPlugin(name = "Location")
+class LocationPlugin : Plugin() {
+    private lateinit var fusedClient: FusedLocationProviderClient
+    private var callback: LocationCallback? = null
+
+    override fun load() {
+        fusedClient = LocationServices.getFusedLocationProviderClient(context)
+    }
+
+    @PluginMethod
+    fun start(call: PluginCall) {
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+            15 * 60 * 1000L
+        ).setMinUpdateIntervalMillis(10 * 60 * 1000L).build()
+
+        callback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                for (location in result.locations) {
+                    val data = JSObject().apply {
+                        put("timestamp", location.time)
+                        put("lat", location.latitude)
+                        put("lng", location.longitude)
+                    }
+                    notifyListeners("location", data)
+                }
+            }
+        }
+
+        fusedClient.requestLocationUpdates(request, callback!!, Looper.getMainLooper())
+        call.resolve()
+    }
+
+    @PluginMethod
+    fun stop(call: PluginCall) {
+        callback?.let { fusedClient.removeLocationUpdates(it) }
+        callback = null
+        call.resolve()
+    }
+}
+
+class MainActivity : BridgeActivity()

--- a/src/lib/locationStore.ts
+++ b/src/lib/locationStore.ts
@@ -1,0 +1,43 @@
+export interface LocationFix {
+  timestamp: number;
+  lat: number;
+  lng: number;
+}
+
+const DB_NAME = 'location-db';
+const STORE_NAME = 'fixes';
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function getDB(): Promise<IDBDatabase> {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore(STORE_NAME, { keyPath: 'timestamp' });
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+  return dbPromise;
+}
+
+export async function storeFix(fix: LocationFix): Promise<void> {
+  const db = await getDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(fix);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getFixes(): Promise<LocationFix[]> {
+  const db = await getDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).getAll();
+    req.onsuccess = () => resolve(req.result as LocationFix[]);
+    req.onerror = () => reject(req.error);
+  });
+}

--- a/src/native/location.ts
+++ b/src/native/location.ts
@@ -1,0 +1,28 @@
+import { PluginListenerHandle, registerPlugin } from '@capacitor/core';
+import { storeFix } from '@/lib/locationStore';
+
+export interface LocationFix {
+  timestamp: number;
+  lat: number;
+  lng: number;
+}
+
+interface LocationPlugin {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  addListener(
+    eventName: 'location',
+    listener: (fix: LocationFix) => void,
+  ): Promise<PluginListenerHandle>;
+}
+
+const Location = registerPlugin<LocationPlugin>('Location');
+
+export const startLocationLogging = async () => {
+  await Location.start();
+  await Location.addListener('location', storeFix);
+};
+
+export const stopLocationLogging = () => Location.stop();
+
+export default Location;


### PR DESCRIPTION
## Summary
- add Android `LocationPlugin` using `FusedLocationProviderClient` to emit 10–15 min balanced fixes
- expose start/stop helpers in new Capacitor plugin
- persist each fix `{timestamp, lat, lng}` in IndexedDB store

## Testing
- `npm test` *(fails: No "useSeasonalBaseline" export in mock; GeoActivityExplorer test assertion)*

------
https://chatgpt.com/codex/tasks/task_e_688da57ff8f883249ecd9375a59f7e9b