### PR TITLE
feat: add social engagement visualization and visit map

### DIFF
--- a/src/components/dashboard/MapView.tsx
+++ b/src/components/dashboard/MapView.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useMemo, useState } from "react";
+import Map, { Source, Layer } from "react-map-gl/maplibre";
+import maplibregl from "maplibre-gl";
+import { getLocationVisits, type LocationVisit } from "@/lib/api";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function MapView() {
+  const [visits, setVisits] = useState<LocationVisit[] | null>(null);
+
+  useEffect(() => {
+    getLocationVisits().then(setVisits);
+  }, []);
+
+  const geojson = useMemo(() => {
+    if (!visits) return null;
+    const features = visits.map((v) => {
+      const [lat, lon] = v.placeId.split(",").map(Number);
+      return {
+        type: "Feature" as const,
+        geometry: { type: "Point" as const, coordinates: [lon, lat] },
+        properties: { category: v.category },
+      };
+    });
+    return { type: "FeatureCollection" as const, features };
+  }, [visits]);
+
+  if (!geojson) return <Skeleton className="h-64" />;
+
+  return (
+    <div className="h-64 w-full">
+      <Map
+        mapLib={maplibregl}
+        mapStyle="https://demotiles.maplibre.org/style.json"
+        initialViewState={{ longitude: -93, latitude: 44, zoom: 12 }}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <Source id="visits" type="geojson" data={geojson} cluster clusterRadius={40}>
+          <Layer
+            id="clusters"
+            type="circle"
+            filter={["has", "point_count"]}
+            paint={{
+              "circle-color": "hsl(var(--chart-3))",
+              "circle-radius": [
+                "step",
+                ["get", "point_count"],
+                15,
+                5,
+                20,
+                10,
+                25,
+              ],
+            }}
+          />
+          <Layer
+            id="cluster-count"
+            type="symbol"
+            filter={["has", "point_count"]}
+            layout={{ "text-field": "{point_count}", "text-size": 12 }}
+          />
+          <Layer
+            id="unclustered-point"
+            type="circle"
+            filter={["!", ["has", "point_count"]]}
+            paint={{ "circle-color": "hsl(var(--chart-1))", "circle-radius": 6 }}
+          />
+        </Source>
+      </Map>
+    </div>
+  );
+}

--- a/src/components/dashboard/SocialEngagementCard.tsx
+++ b/src/components/dashboard/SocialEngagementCard.tsx
@@ -1,11 +1,42 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import useSocialEngagement from "@/hooks/useSocialEngagement";
+import {
+  ChartContainer,
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  Legend,
+  type ChartConfig,
+} from "@/components/ui/chart";
 
 export default function SocialEngagementCard() {
   const data = useSocialEngagement();
-  if (!data) return <Skeleton className="h-32" />;
-  const { index, consecutiveHomeDays } = data;
+  if (!data) return <Skeleton className="h-64" />;
+  const {
+    index,
+    consecutiveHomeDays,
+    locationEntropy,
+    outOfHomeFrequency,
+    baseline,
+  } = data;
+  const chartData = [
+    {
+      metric: "Entropy",
+      current: locationEntropy,
+      baseline: baseline.locationEntropy,
+    },
+    {
+      metric: "Out of Home",
+      current: outOfHomeFrequency,
+      baseline: baseline.outOfHomeFrequency,
+    },
+  ];
+  const chartConfig = {
+    current: { label: "Current", color: "hsl(var(--chart-1))" },
+    baseline: { label: "Baseline", color: "hsl(var(--chart-2))" },
+  } satisfies ChartConfig;
   const message =
     consecutiveHomeDays >= 5
       ? "You've been mostly at home for 5 days—maybe schedule a quick meetup or change of scenery."
@@ -15,9 +46,30 @@ export default function SocialEngagementCard() {
       <CardHeader>
         <CardTitle>Social Engagement</CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
         <div className="text-3xl font-bold tabular-nums">{index.toFixed(2)}</div>
-        {message && <p className="mt-2 text-sm text-muted-foreground">{message}</p>}
+        <ChartContainer config={chartConfig} className="h-48">
+          <RadarChart data={chartData}>
+            <PolarGrid />
+            <PolarAngleAxis dataKey="metric" />
+            <Radar
+              name="Current"
+              dataKey="current"
+              stroke="var(--color-current)"
+              fill="var(--color-current)"
+              fillOpacity={0.6}
+            />
+            <Radar
+              name="Baseline"
+              dataKey="baseline"
+              stroke="var(--color-baseline)"
+              fill="var(--color-baseline)"
+              fillOpacity={0.3}
+            />
+            <Legend />
+          </RadarChart>
+        </ChartContainer>
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -33,5 +33,6 @@ export { default as RouteSimilarity } from "./RouteSimilarity";
 export { default as RouteNoveltyMap } from "./RouteNoveltyMap";
 
 export { default as SocialEngagementCard } from "./SocialEngagementCard";
+export { default as MapView } from "./MapView";
 
 

--- a/src/hooks/useSocialEngagement.ts
+++ b/src/hooks/useSocialEngagement.ts
@@ -71,7 +71,16 @@ export default function useSocialEngagement() {
 
   return useMemo(() => {
     if (!visits) return null;
-    return computeSocialEngagementIndex(visits);
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 7);
+    const recent = visits.filter((v) => new Date(v.date) >= cutoff);
+    const baselineVisits = visits.filter((v) => new Date(v.date) < cutoff);
+
+    const current = computeSocialEngagementIndex(recent);
+    const baseline = computeSocialEngagementIndex(baselineVisits);
+
+    return { ...current, baseline };
   }, [visits]);
 }
 

--- a/src/lib/locationStore.ts
+++ b/src/lib/locationStore.ts
@@ -1,4 +1,6 @@
 
+import { groupConsecutivePoints, placeIdFor, type LocationPoint } from './locationProcessing';
+
 export interface LocationFix {
   timestamp: number;
   lat: number;
@@ -41,9 +43,7 @@ export async function getFixes(): Promise<LocationFix[]> {
     req.onsuccess = () => resolve(req.result as LocationFix[]);
     req.onerror = () => reject(req.error);
   });
-=======
-import { groupConsecutivePoints, placeIdFor, type LocationPoint } from './locationProcessing';
-
+}
 export type LocationCategory = 'home' | 'work' | 'other';
 
 export interface LocationCluster {


### PR DESCRIPTION
## Summary
- add MapLibre-based MapView with visit clustering
- add radar chart to SocialEngagementCard comparing current vs baseline
- extend social engagement hook with baseline metrics

## Testing
- `npm test` *(fails: missing "Session Analysis" button and GeoActivityExplorer state details)*

------
https://chatgpt.com/codex/tasks/task_e_688da8b8d0d88324b3b433828da17f63