### PR TITLE
refactor routes with categories

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -15,25 +15,30 @@ export default function AppSidebar() {
     <Sidebar>
       <SidebarHeader />
       <SidebarContent>
-        <SidebarGroup>
-          {dashboardRoutes.map((link) => (
-            <li key={link.to}>
-              <NavLink
-                to={link.to}
-                className={({ isActive }) =>
-                  cn(
-                    "block rounded-md px-3 py-2 text-sm",
-                    isActive
-                      ? "bg-accent text-accent-foreground"
-                      : "hover:bg-muted",
-                  )
-                }
-              >
-                {link.label}
-              </NavLink>
+        {dashboardRoutes.map((group) => (
+          <SidebarGroup key={group.label}>
+            <li className="px-3 py-2 text-xs font-semibold text-muted-foreground">
+              {group.label}
             </li>
-          ))}
-        </SidebarGroup>
+            {group.items.map((link) => (
+              <li key={link.to}>
+                <NavLink
+                  to={link.to}
+                  className={({ isActive }) =>
+                    cn(
+                      "block rounded-md px-3 py-2 text-sm",
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted",
+                    )
+                  }
+                >
+                  {link.label}
+                </NavLink>
+              </li>
+            ))}
+          </SidebarGroup>
+        ))}
       </SidebarContent>
       <SidebarFooter />
     </Sidebar>

--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
-import { dashboardRoutes } from "@/routes";
+import { dashboardRoutes, DashboardRoute } from "@/routes";
 
 export default function CommandPalette() {
   const [open, setOpen] = React.useState(false);
@@ -19,8 +19,13 @@ export default function CommandPalette() {
     return () => document.removeEventListener("keydown", down);
   }, []);
 
-  const filtered = dashboardRoutes.filter((route) =>
-    route.label.toLowerCase().includes(query.toLowerCase())
+  const routes = React.useMemo(
+    () => dashboardRoutes.flatMap((group) => group.items),
+    [],
+  );
+
+  const filtered = routes.filter((route: DashboardRoute) =>
+    route.label.toLowerCase().includes(query.toLowerCase()),
   );
 
   const handleSelect = (path: string) => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,13 +1,34 @@
-export const dashboardRoutes = [
-  { to: "/dashboard/map", label: "Map playground" },
-  { to: "/dashboard/route-similarity", label: "Route similarity" },
-  { to: "/dashboard/route-novelty", label: "Route novelty" },
-  { to: "/dashboard/examples", label: "Analytics fun" },
-  { to: "/dashboard/mileage-globe", label: "Mileage Globe" },
-  { to: "/dashboard/fragility", label: "Fragility" },
-  { to: "/dashboard/session-similarity", label: "Session Similarity" },
-  { to: "/dashboard/good-day", label: "Good Day" },
-  { to: "/dashboard/habit-consistency", label: "Habit consistency" },
-];
+export interface DashboardRoute {
+  to: string;
+  label: string;
+}
 
-export type DashboardRoute = (typeof dashboardRoutes)[number];
+export interface DashboardRouteGroup {
+  label: string;
+  items: DashboardRoute[];
+}
+
+export const dashboardRoutes: DashboardRouteGroup[] = [
+  {
+    label: "Maps",
+    items: [
+      { to: "/dashboard/map", label: "Map playground" },
+      { to: "/dashboard/route-similarity", label: "Route similarity" },
+      { to: "/dashboard/route-novelty", label: "Route novelty" },
+      { to: "/dashboard/mileage-globe", label: "Mileage Globe" },
+    ],
+  },
+  {
+    label: "Session Analysis",
+    items: [
+      { to: "/dashboard/fragility", label: "Fragility" },
+      { to: "/dashboard/session-similarity", label: "Session Similarity" },
+      { to: "/dashboard/good-day", label: "Good Day" },
+      { to: "/dashboard/habit-consistency", label: "Habit consistency" },
+    ],
+  },
+  {
+    label: "Examples",
+    items: [{ to: "/dashboard/examples", label: "Analytics fun" }],
+  },
+];


### PR DESCRIPTION
## Summary
- group dashboardRoutes into labeled categories
- update sidebar to render grouped navigation
- adjust command palette to search across grouped routes

## Testing
- `npm test` *(fails: No "useSeasonalBaseline" export is defined on the "@/hooks/useGarminData" mock)*

------
https://chatgpt.com/codex/tasks/task_e_688da482b67c8324ad357c9b873adb52