### PR TITLE
refactor: add sidebar group label and content components

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -4,6 +4,8 @@ import {
   SidebarHeader,
   SidebarContent,
   SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
   SidebarFooter,
 } from "@/components/ui/sidebar";
 import { NavLink } from "react-router-dom";
@@ -18,28 +20,29 @@ export default function AppSidebar() {
         <SidebarContent>
           {dashboardRoutes.map((group: DashboardRouteGroup) => (
             <SidebarGroup key={group.label}>
-              <h4 className="mb-2 text-xs font-semibold">{group.label}</h4>
-              <ul>
-                {group.items.map((link) => (
-                  <li key={link.to}>
-                    <NavLink
-                      to={link.to}
-                      className={({ isActive }) =>
-                        cn(
-                          "block rounded-md px-3 py-2 text-sm",
-                          isActive
-                            ? "bg-accent text-accent-foreground"
-                            : "hover:bg-muted",
-                        )
-                      }
-                    >
-                      {link.label}
-                    </NavLink>
-                  </li>
-                ))}
-              </ul>
+              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <ul className="space-y-1">
+                  {group.items.map((link) => (
+                    <li key={link.to}>
+                      <NavLink
+                        to={link.to}
+                        className={({ isActive }) =>
+                          cn(
+                            "block rounded-md px-3 py-2 text-sm",
+                            isActive
+                              ? "bg-accent text-accent-foreground"
+                              : "hover:bg-muted",
+                          )
+                        }
+                      >
+                        {link.label}
+                      </NavLink>
+                    </li>
+                  ))}
+                </ul>
+              </SidebarGroupContent>
             </SidebarGroup>
-
           ))}
         </SidebarContent>
         <SidebarFooter />

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -68,12 +68,33 @@ const SidebarContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTM
 );
 SidebarContent.displayName = "SidebarContent";
 
-const SidebarGroup = React.forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListElement>>(
-  ({ className, ...props }, ref) => (
-    <ul ref={ref} className={cn("space-y-1", className)} {...props} />
-  )
-);
+const SidebarGroup = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("", className)} {...props} />
+));
 SidebarGroup.displayName = "SidebarGroup";
+
+const SidebarGroupLabel = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h4
+    ref={ref}
+    className={cn("mb-2 text-xs font-semibold", className)}
+    {...props}
+  />
+));
+SidebarGroupLabel.displayName = "SidebarGroupLabel";
+
+const SidebarGroupContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("", className)} {...props} />
+));
+SidebarGroupContent.displayName = "SidebarGroupContent";
 
 const SidebarItem = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIElement>>(
   ({ className, ...props }, ref) => (
@@ -118,6 +139,8 @@ export {
   SidebarHeader,
   SidebarContent,
   SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
   SidebarItem,
   SidebarFooter,
   SidebarProvider,


### PR DESCRIPTION
## Summary
- refactor SidebarGroup to render a div instead of ul
- add SidebarGroupLabel and SidebarGroupContent components
- update AppSidebar to use new group components

## Testing
- `npm test`
- `npx vitest run` *(warnings; all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_688db4a044808324939e130f7abbbc95