### PR TITLE
feat: enrich social engagement with activity context

### DIFF
--- a/src/hooks/__tests__/useSocialEngagement.test.ts
+++ b/src/hooks/__tests__/useSocialEngagement.test.ts
@@ -1,19 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { computeSocialEngagementIndex } from '../useSocialEngagement'
-import type { LocationVisit } from '@/lib/api'
+import type { ActivityVisit } from '@/lib/activityContext'
 
-const visits: LocationVisit[] = [
-  { date: '2025-07-01', placeId: 'home', category: 'home' },
-  { date: '2025-07-02', placeId: 'home', category: 'home' },
-  { date: '2025-07-02', placeId: 'office', category: 'work' },
-  { date: '2025-07-03', placeId: 'cafe', category: 'other' },
-  { date: '2025-07-04', placeId: 'home', category: 'home' },
+const visits: ActivityVisit[] = [
+  { date: '2025-07-01', placeId: 'home', category: 'home', activity: 'sedentary' },
+  { date: '2025-07-02', placeId: 'home', category: 'home', activity: 'run' },
+  { date: '2025-07-02', placeId: 'office', category: 'work', activity: 'run' },
+  { date: '2025-07-03', placeId: 'cafe', category: 'other', activity: 'walk' },
+  { date: '2025-07-04', placeId: 'home', category: 'home', activity: 'sedentary' },
 ]
 
 describe('computeSocialEngagementIndex', () => {
   it('calculates index and home streak', () => {
     const { index, consecutiveHomeDays } = computeSocialEngagementIndex(visits)
-    expect(index).toBeCloseTo(0.56, 2)
-    expect(consecutiveHomeDays).toBe(1)
+    expect(index).toBeCloseTo(0.75, 2)
+    expect(consecutiveHomeDays).toBe(0)
   })
 })

--- a/src/hooks/useSocialEngagement.ts
+++ b/src/hooks/useSocialEngagement.ts
@@ -1,12 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
-import { getLocationVisits, type LocationVisit } from "@/lib/api";
+import {
+  getActivityVisits,
+  type ActivityVisit,
+} from "@/lib/activityContext";
 
-function computeLocationEntropy(visits: LocationVisit[]): number {
+function computeLocationEntropy(visits: ActivityVisit[]): number {
+  const active = visits.filter((v) => v.activity !== "sedentary");
   const counts: Record<string, number> = {};
-  visits.forEach((v) => {
+  active.forEach((v) => {
     counts[v.placeId] = (counts[v.placeId] || 0) + 1;
   });
-  const total = visits.length;
+  const total = active.length;
   if (total === 0) return 0;
   let entropy = 0;
   Object.values(counts).forEach((c) => {
@@ -17,9 +21,10 @@ function computeLocationEntropy(visits: LocationVisit[]): number {
   return maxEntropy === 0 ? 0 : entropy / maxEntropy;
 }
 
-function computeOutOfHomeFrequency(visits: LocationVisit[]): number {
-  const byDate: Record<string, LocationVisit[]> = {};
-  visits.forEach((v) => {
+function computeOutOfHomeFrequency(visits: ActivityVisit[]): number {
+  const active = visits.filter((v) => v.activity !== "sedentary");
+  const byDate: Record<string, ActivityVisit[]> = {};
+  active.forEach((v) => {
     if (!byDate[v.date]) byDate[v.date] = [];
     byDate[v.date].push(v);
   });
@@ -32,9 +37,10 @@ function computeOutOfHomeFrequency(visits: LocationVisit[]): number {
   return outDays / days.length;
 }
 
-function computeConsecutiveHomeDays(visits: LocationVisit[]): number {
-  const byDate: Record<string, LocationVisit[]> = {};
-  visits.forEach((v) => {
+function computeConsecutiveHomeDays(visits: ActivityVisit[]): number {
+  const active = visits.filter((v) => v.activity !== "sedentary");
+  const byDate: Record<string, ActivityVisit[]> = {};
+  active.forEach((v) => {
     if (!byDate[v.date]) byDate[v.date] = [];
     byDate[v.date].push(v);
   });
@@ -49,7 +55,7 @@ function computeConsecutiveHomeDays(visits: LocationVisit[]): number {
   return count;
 }
 
-export function computeSocialEngagementIndex(visits: LocationVisit[]): {
+export function computeSocialEngagementIndex(visits: ActivityVisit[]): {
   index: number;
   locationEntropy: number;
   outOfHomeFrequency: number;
@@ -63,10 +69,10 @@ export function computeSocialEngagementIndex(visits: LocationVisit[]): {
 }
 
 export default function useSocialEngagement() {
-  const [visits, setVisits] = useState<LocationVisit[] | null>(null);
+  const [visits, setVisits] = useState<ActivityVisit[] | null>(null);
 
   useEffect(() => {
-    getLocationVisits().then(setVisits);
+    getActivityVisits().then(setVisits);
   }, []);
 
   return useMemo(() => {

--- a/src/lib/activityContext.ts
+++ b/src/lib/activityContext.ts
@@ -1,0 +1,59 @@
+import { getGarminData, getLocationVisits, type LocationVisit } from './api';
+
+export type ActivityLabel = 'run' | 'walk' | 'sedentary';
+
+export interface PhoneActivityState {
+  date: string;
+  type: ActivityLabel;
+}
+
+// Mock phone activity-recognition states
+const mockPhoneStates: PhoneActivityState[] = [
+  {
+    date: new Date().toISOString().slice(0, 10),
+    type: 'walk',
+  },
+  {
+    date: new Date(Date.now() - 86400000).toISOString().slice(0, 10),
+    type: 'sedentary',
+  },
+];
+
+export async function getPhoneActivityStates(): Promise<PhoneActivityState[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(mockPhoneStates), 200);
+  });
+}
+
+export interface ActivityVisit extends LocationVisit {
+  activity: ActivityLabel;
+}
+
+// Fetch Garmin sessions, phone activity states, and enrich visits
+export async function getActivityVisits(): Promise<ActivityVisit[]> {
+  const [visits, garmin, phone] = await Promise.all([
+    getLocationVisits(),
+    getGarminData(),
+    getPhoneActivityStates(),
+  ]);
+
+  const sessionByDate: Record<string, ActivityLabel> = {};
+  garmin.activities.forEach((a) => {
+    const t = a.type.toLowerCase();
+    if (t === 'run' || t === 'walk') {
+      sessionByDate[a.date] = t as ActivityLabel;
+    }
+  });
+
+  const phoneByDate: Record<string, ActivityLabel> = {};
+  phone.forEach((p) => {
+    phoneByDate[p.date] = p.type;
+  });
+
+  return visits.map((v) => {
+    const activity = sessionByDate[v.date] || phoneByDate[v.date] || 'sedentary';
+    return { ...v, activity };
+  });
+}
+
+export default getActivityVisits;


### PR DESCRIPTION
## Summary
- add activityContext utility to merge Garmin sessions and phone activity states
- compute social engagement using activity-labeled visits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db5ac6ed883248866442354a589f2