### PR TITLE
Use ChartLegend in SocialEngagementCard

### DIFF
--- a/src/components/dashboard/SocialEngagementCard.tsx
+++ b/src/components/dashboard/SocialEngagementCard.tsx
@@ -7,7 +7,8 @@ import {
   Radar,
   PolarGrid,
   PolarAngleAxis,
-  Legend,
+  ChartLegend,
+  ChartLegendContent,
   type ChartConfig,
 } from "@/components/ui/chart";
 
@@ -66,7 +67,7 @@ export default function SocialEngagementCard() {
               fill="var(--color-baseline)"
               fillOpacity={0.3}
             />
-            <Legend />
+            <ChartLegend content={<ChartLegendContent />} />
           </RadarChart>
         </ChartContainer>
         {message && <p className="text-sm text-muted-foreground">{message}</p>}


### PR DESCRIPTION
## Summary
- use `ChartLegend` and `ChartLegendContent` for SocialEngagementCard's radar chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688db6f644cc8324a623b3dc88899fee