### PR TITLE
Add privacy controls and social engagement nudges

### DIFF
--- a/src/components/dashboard/SocialEngagementCard.tsx
+++ b/src/components/dashboard/SocialEngagementCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import useSocialEngagement from "@/hooks/useSocialEngagement";
+import useEngagementNudges from "@/hooks/useEngagementNudges";
 import {
   ChartContainer,
   RadarChart,
@@ -14,13 +15,8 @@ import {
 export default function SocialEngagementCard() {
   const data = useSocialEngagement();
   if (!data) return <Skeleton className="h-64" />;
-  const {
-    index,
-    consecutiveHomeDays,
-    locationEntropy,
-    outOfHomeFrequency,
-    baseline,
-  } = data;
+  const { index, locationEntropy, outOfHomeFrequency, baseline } = data;
+  const nudges = useEngagementNudges();
   const chartData = [
     {
       metric: "Entropy",
@@ -37,10 +33,6 @@ export default function SocialEngagementCard() {
     current: { label: "Current", color: "hsl(var(--chart-1))" },
     baseline: { label: "Baseline", color: "hsl(var(--chart-2))" },
   } satisfies ChartConfig;
-  const message =
-    consecutiveHomeDays >= 5
-      ? "You've been mostly at home for 5 days—maybe schedule a quick meetup or change of scenery."
-      : null;
   return (
     <Card>
       <CardHeader>
@@ -69,7 +61,11 @@ export default function SocialEngagementCard() {
             <Legend />
           </RadarChart>
         </ChartContainer>
-        {message && <p className="text-sm text-muted-foreground">{message}</p>}
+        {nudges.map((msg) => (
+          <p key={msg} className="text-sm text-muted-foreground">
+            {msg}
+          </p>
+        ))}
       </CardContent>
     </Card>
   );

--- a/src/components/settings/Privacy.tsx
+++ b/src/components/settings/Privacy.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function Privacy() {
+  const [backgroundLocation, setBackgroundLocation] = useState(false);
+
+  useEffect(() => {
+    if (typeof localStorage === "undefined") return;
+    const stored = localStorage.getItem("bg:location");
+    setBackgroundLocation(stored === "true");
+  }, []);
+
+  function toggleBackgroundLocation() {
+    const next = !backgroundLocation;
+    setBackgroundLocation(next);
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("bg:location", String(next));
+    }
+  }
+
+  function clearHistory() {
+    if (typeof localStorage !== "undefined") {
+      localStorage.removeItem("loc:points");
+      localStorage.removeItem("loc:clusters");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={backgroundLocation}
+          onChange={toggleBackgroundLocation}
+        />
+        <span>Enable background location</span>
+      </label>
+      <Button variant="outline" onClick={clearHistory}>
+        Clear history
+      </Button>
+    </div>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,0 +1,1 @@
+export { default as Privacy } from "./Privacy";

--- a/src/hooks/useEngagementNudges.ts
+++ b/src/hooks/useEngagementNudges.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from "react";
+import useSocialEngagement from "./useSocialEngagement";
+
+export default function useEngagementNudges() {
+  const data = useSocialEngagement();
+  const [nudges, setNudges] = useState<string[]>([]);
+  const notified = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!data) return;
+    const messages: string[] = [];
+    if (data.consecutiveHomeDays >= 5) {
+      messages.push("Been home 5 days—try a short outing?");
+    }
+    setNudges(messages);
+
+    messages.forEach((msg) => {
+      if (notified.current.has(msg)) return;
+      if (typeof window !== "undefined" && "Notification" in window) {
+        if (Notification.permission === "granted") {
+          new Notification(msg);
+        } else if (Notification.permission !== "denied") {
+          Notification.requestPermission().then((perm) => {
+            if (perm === "granted") new Notification(msg);
+          });
+        }
+      }
+      notified.current.add(msg);
+    });
+  }, [data]);
+
+  return nudges;
+}


### PR DESCRIPTION
## Summary
- add Privacy settings screen with background location toggle and clear history button
- introduce `useEngagementNudges` hook to surface social engagement reminders and send notifications
- show active nudges in `SocialEngagementCard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db5a770dc8324b207ccef7d837d4b