### PR TITLE
feat: add sidebar inset component

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import AppSidebar from "@/components/app-sidebar";
 import CommandPalette from "@/components/ui/CommandPalette";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  SidebarInset,
+} from "@/components/ui/sidebar";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -13,14 +17,14 @@ export default function Layout({ children }: LayoutProps) {
     <SidebarProvider>
       <AppSidebar />
       <CommandPalette />
-      <main className="flex-1 p-4">
-        <header className="flex justify-between items-center mb-4">
+      <SidebarInset>
+        <header className="flex items-center justify-between p-4">
+          <SidebarTrigger />
           <h1 className="text-xl font-bold">Dashboard</h1>
           <ThemeToggle />
         </header>
-        <SidebarTrigger />
-        <div className="mt-2">{children}</div>
-      </main>
+        <main className="flex-1 p-4 pt-0">{children}</main>
+      </SidebarInset>
     </SidebarProvider>
   );
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -103,6 +103,14 @@ const SidebarItem = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIE
 );
 SidebarItem.displayName = "SidebarItem";
 
+const SidebarInset = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex flex-1 flex-col", className)} {...props} />
+));
+SidebarInset.displayName = "SidebarInset";
+
 const SidebarFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -142,6 +150,7 @@ export {
   SidebarGroupLabel,
   SidebarGroupContent,
   SidebarItem,
+  SidebarInset,
   SidebarFooter,
   SidebarProvider,
   SidebarTrigger,


### PR DESCRIPTION
## Summary
- add SidebarInset component for flexible main content layout
- wrap layout content with SidebarInset and move sidebar trigger into header

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688dbd6fbf0483248ffb446ba89cd716