### PR TITLE
Prevent chart preview trigger from submitting forms

### DIFF
--- a/src/components/examples/ChartPreview.tsx
+++ b/src/components/examples/ChartPreview.tsx
@@ -35,7 +35,10 @@ export default function ChartPreview({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <div className={cn("relative overflow-hidden mb-6 break-inside-avoid", className)}>
         <DialogTrigger asChild>
-          <button className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground transition-transform hover:scale-110 hover:text-foreground'>
+          <button
+            type="button"
+            className='absolute right-2 top-2 z-40 rounded-md bg-background/80 p-1 text-muted-foreground transition-transform hover:scale-110 hover:text-foreground'
+          >
             <Eye className='h-4 w-4' />
             <span className='sr-only'>View larger</span>
           </button>

--- a/src/components/examples/__tests__/ChartPreview.test.tsx
+++ b/src/components/examples/__tests__/ChartPreview.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
 
 import ChartPreview from "../ChartPreview";
 
@@ -34,6 +35,23 @@ describe("ChartPreview", () => {
 
     await user.tab();
     expect(closeButton).toHaveFocus();
+  });
+
+  it("does not submit surrounding form when opening", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={handleSubmit}>
+        <ChartPreview>
+          <div>chart</div>
+        </ChartPreview>
+      </form>
+    );
+
+    await user.click(screen.getByRole("button", { name: /view larger/i }));
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- avoid unintended form submissions by setting the ChartPreview trigger button type to `button`
- add a regression test ensuring the trigger doesn't submit surrounding forms

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688dc0cda74c8324bc1bc241d99682d3