### PR TITLE
feat: add command palette trigger

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,14 @@ import React from "react";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import AppSidebar from "@/components/app-sidebar";
 import CommandPalette from "@/components/ui/CommandPalette";
+import { Button } from "@/components/ui/button";
+import {
+  TooltipProvider,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { Command } from "lucide-react";
 import {
   SidebarProvider,
   SidebarTrigger,
@@ -13,15 +21,34 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
+  const [open, setOpen] = React.useState(false);
+
   return (
     <SidebarProvider>
       <AppSidebar />
-      <CommandPalette />
+      <CommandPalette open={open} setOpen={setOpen} />
       <SidebarInset>
         <header className="flex items-center justify-between p-4">
           <SidebarTrigger />
           <h1 className="text-xl font-bold">Dashboard</h1>
-          <ThemeToggle />
+          <div className="flex items-center gap-2">
+            <TooltipProvider delayDuration={100}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setOpen(true)}
+                  >
+                    <Command className="h-4 w-4" />
+                    <span className="sr-only">Open command palette</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Ctrl/⌘+K</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <ThemeToggle />
+          </div>
         </header>
         <main className="flex-1 p-4 pt-0">{children}</main>
       </SidebarInset>

--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -3,8 +3,18 @@ import { useNavigate } from "react-router-dom";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { dashboardRoutes } from "@/routes";
 
-export default function CommandPalette() {
-  const [open, setOpen] = React.useState(false);
+interface CommandPaletteProps {
+  open?: boolean;
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function CommandPalette({
+  open: openProp,
+  setOpen: setOpenProp,
+}: CommandPaletteProps = {}) {
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const open = openProp ?? internalOpen;
+  const setOpen = setOpenProp ?? setInternalOpen;
   const [query, setQuery] = React.useState("");
   const navigate = useNavigate();
 
@@ -17,7 +27,7 @@ export default function CommandPalette() {
     };
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, []);
+  }, [setOpen]);
 
   const allRoutes = dashboardRoutes.flatMap((group) => group.items);
   const filtered = allRoutes.filter((route) =>


### PR DESCRIPTION
## Summary
- add button in layout to open command palette
- allow CommandPalette to be controlled via props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dc0c805988324a69e56549262814c