### PR TITLE
Remove dashboard title from layout header

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -30,7 +30,6 @@ export default function Layout({ children }: LayoutProps) {
       <SidebarInset>
         <header className="flex items-center justify-between p-4">
           <SidebarTrigger />
-          <h1 className="text-xl font-bold">Dashboard</h1>
           <div className="flex items-center gap-2">
             <TooltipProvider delayDuration={100}>
               <Tooltip>


### PR DESCRIPTION
## Summary
- remove Dashboard title from the layout header for a cleaner UI

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688dfa78a238832491acf424f8ac1533