### PR TITLE
feat: integrate sidebar into app layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import AppSidebar from "@/components/app-sidebar";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <SidebarProvider>
+          <AppSidebar />
+          <main>
+            <SidebarTrigger />
+            {children}
+          </main>
+        </SidebarProvider>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add root layout that wraps content with `SidebarProvider`
- render `AppSidebar` and `SidebarTrigger` within layout main section

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688dfd82dbc88324a2ff2b1d22d1e134