### PR TITLE
feat: add controlled and uncontrolled dialog support

### DIFF
--- a/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/components/ui/__tests__/dialog.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import { Dialog, DialogContentFullscreen } from "../dialog";
+import { Dialog, DialogContentFullscreen, DialogTrigger } from "../dialog";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 
 function TestDialog() {
@@ -62,5 +62,29 @@ describe("DialogContentFullscreen", () => {
     await user.click(button);
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+function UncontrolledDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger>open</DialogTrigger>
+      <DialogContentFullscreen>
+        <div>content</div>
+      </DialogContentFullscreen>
+    </Dialog>
+  );
+}
+
+describe("Dialog", () => {
+  it("opens uncontrolled dialog with trigger", async () => {
+    const user = userEvent.setup();
+    render(<UncontrolledDialog />);
+
+    expect(screen.queryByText("content")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("open"));
+
+    expect(screen.getByText("content")).toBeInTheDocument();
   });
 });

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,7 +2,27 @@ import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root;
+interface DialogProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {}
+
+function Dialog({ open, onOpenChange, ...props }: DialogProps) {
+  const [internalOpen, setInternalOpen] = React.useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    if (open === undefined) {
+      setInternalOpen(next);
+    }
+    onOpenChange?.(next);
+  };
+
+  return (
+    <DialogPrimitive.Root
+      open={open === undefined ? internalOpen : open}
+      onOpenChange={handleOpenChange}
+      {...props}
+    />
+  );
+}
 const DialogTrigger = DialogPrimitive.Trigger;
 const DialogClose = DialogPrimitive.Close;
 


### PR DESCRIPTION
## Summary
- use internal state for Dialog when `open` not provided
- add test to ensure `<DialogTrigger>` opens uncontrolled dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dfea6383083248586c193605c7ae5