### PR TITLE
feat(sidebar): add application menu

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,10 +1,38 @@
 import React from "react";
-import { Sidebar, SidebarContent } from "@/components/ui/sidebar";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from "@/components/ui/sidebar";
 
 export function AppSidebar() {
+  const items = [
+    { title: "Home" },
+    { title: "Inbox" },
+    { title: "Calendar" },
+  ];
+
   return (
     <Sidebar>
-      <SidebarContent />
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Application</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {items.map((item) => (
+                <SidebarMenuItem key={item.title}>
+                  <SidebarMenuButton>{item.title}</SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
     </Sidebar>
   );
 }


### PR DESCRIPTION
## Summary
- add application menu group in sidebar
- map Home, Inbox, and Calendar into sidebar menu items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e02ec097c8324b469aba9c6d146d5