### PR TITLE
Add circular fragility ring component

### DIFF
--- a/src/components/dashboard/CircularFragilityRing.tsx
+++ b/src/components/dashboard/CircularFragilityRing.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react'
+import useFragilityIndex from '@/hooks/useFragilityIndex'
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export interface CircularFragilityRingProps {
+  /** Diameter of the ring in pixels */
+  size?: number
+  /** Width of the ring stroke */
+  strokeWidth?: number
+}
+
+/**
+ * Full circular gauge representing the behavioral fragility index.
+ */
+export default function CircularFragilityRing({ size = 160, strokeWidth = 12 }: CircularFragilityRingProps) {
+  const index = useFragilityIndex()
+  const [displayIndex, setDisplayIndex] = useState(0)
+
+  useEffect(() => {
+    if (index === null) return
+    setDisplayIndex(0)
+    let start: number | null = null
+    const duration = 500
+    let frame: number
+    const animate = (timestamp: number) => {
+      if (start === null) start = timestamp
+      const progress = Math.min((timestamp - start) / duration, 1)
+      setDisplayIndex(progress * index)
+      if (progress < 1) frame = requestAnimationFrame(animate)
+    }
+    frame = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(frame)
+  }, [index])
+
+  if (index === null) return <Skeleton className="h-40" />
+
+  const radius = size / 2 - strokeWidth / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference * (1 - displayIndex)
+
+  const hue = (1 - displayIndex) * 120
+  const color = `hsl(${hue} 90% 45%)`
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex flex-col items-center" role="img" aria-label={`Fragility ${displayIndex.toFixed(2)}`}>
+            <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+              <circle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                stroke="hsl(var(--muted))"
+                strokeWidth={strokeWidth}
+                fill="none"
+              />
+              <circle
+                cx={size / 2}
+                cy={size / 2}
+                r={radius}
+                stroke={color}
+                strokeWidth={strokeWidth}
+                fill="none"
+                strokeDasharray={circumference}
+                strokeDashoffset={offset}
+                strokeLinecap="round"
+                style={{ transition: 'stroke-dashoffset 0.5s ease, stroke 0.5s ease' }}
+                transform={`rotate(-90 ${size / 2} ${size / 2})`}
+              />
+            </svg>
+            <span className="mt-2 text-lg font-bold tabular-nums">{displayIndex.toFixed(2)}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          Higher values indicate disrupted routine or sudden load increases
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/dashboard/__tests__/CircularFragilityRing.test.tsx
+++ b/src/components/dashboard/__tests__/CircularFragilityRing.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import React from 'react'
+import '@testing-library/jest-dom'
+import CircularFragilityRing from '../CircularFragilityRing'
+
+vi.mock('@/hooks/useFragilityIndex', () => ({
+  __esModule: true,
+  default: () => 0.42,
+}))
+
+describe('CircularFragilityRing', () => {
+  it('applies animation attributes', () => {
+    const { container } = render(<CircularFragilityRing />)
+    const arc = container.querySelector('svg circle:nth-of-type(2)')
+    expect(arc).toHaveAttribute('stroke-dashoffset')
+    expect(arc).toHaveStyle('transition: stroke-dashoffset 0.5s ease, stroke 0.5s ease')
+  })
+})

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -25,6 +25,7 @@ export { default as CompactNextGameCard } from "./CompactNextGameCard";
 export { default as MovementFingerprint } from "./MovementFingerprint";
 
 export { default as FragilityGauge } from "./FragilityGauge";
+export { default as CircularFragilityRing } from "./CircularFragilityRing";
 
 export { default as TrainingEntropyHeatmap } from "./TrainingEntropyHeatmap";
 

--- a/src/pages/Fragility.tsx
+++ b/src/pages/Fragility.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FragilityGauge } from "@/components/dashboard";
+import { CircularFragilityRing } from "@/components/dashboard";
 
 export default function FragilityPage() {
   return (
@@ -15,7 +15,7 @@ export default function FragilityPage() {
         <li><span className="text-yellow-600">0.34–0.66</span>: monitor</li>
         <li><span className="text-red-600">0.67–1.00</span>: high risk</li>
       </ul>
-      <FragilityGauge />
+      <CircularFragilityRing />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a CircularFragilityRing dashboard component using SVG circle and color animation
- export the new component and use it on the Fragility page instead of FragilityGauge
- cover the ring component with unit tests

## Testing
- `npm test`
- `npx vitest run src/components/dashboard/__tests__/CircularFragilityRing.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688e057aad70832481a3b5857dc5aef6