### PR TITLE
feat: add fragility sparkline

### DIFF
--- a/src/components/dashboard/FragilityIndexSparkline.tsx
+++ b/src/components/dashboard/FragilityIndexSparkline.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+import type { ChartConfig } from '@/components/ui/chart'
+import useFragilityHistory from '@/hooks/useFragilityHistory'
+import { Skeleton } from '@/components/ui/skeleton'
+
+/**
+ * Small sparkline showing recent fragility index trend.
+ */
+export default function FragilityIndexSparkline() {
+  const history = useFragilityHistory(14)
+
+  if (!history) return <Skeleton className="h-8 w-full" />
+
+  const data = history.map((d) => ({
+    date: d.date,
+    low: d.value < 0.33 ? d.value : null,
+    medium: d.value >= 0.33 && d.value < 0.66 ? d.value : null,
+    high: d.value >= 0.66 ? d.value : null,
+  }))
+
+  const config = {
+    low: { label: 'Low', color: 'hsl(var(--chart-3))' },
+    medium: { label: 'Medium', color: 'hsl(var(--chart-8))' },
+    high: { label: 'High', color: 'hsl(var(--destructive))' },
+  } satisfies ChartConfig
+
+  return (
+    <ChartContainer config={config} className="h-16 w-full">
+      <LineChart data={data} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+        <XAxis dataKey="date" hide />
+        <YAxis domain={[0, 1]} hide />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <Line type="monotone" dataKey="low" stroke={config.low.color} strokeWidth={2} dot={false} />
+        <Line type="monotone" dataKey="medium" stroke={config.medium.color} strokeWidth={2} dot={false} />
+        <Line type="monotone" dataKey="high" stroke={config.high.color} strokeWidth={2} dot={false} />
+      </LineChart>
+    </ChartContainer>
+  )
+}
+

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -26,6 +26,7 @@ export { default as MovementFingerprint } from "./MovementFingerprint";
 
 export { default as FragilityGauge } from "./FragilityGauge";
 export { default as CircularFragilityRing } from "./CircularFragilityRing";
+export { default as FragilityIndexSparkline } from "./FragilityIndexSparkline";
 
 export { default as TrainingEntropyHeatmap } from "./TrainingEntropyHeatmap";
 

--- a/src/hooks/useFragilityHistory.ts
+++ b/src/hooks/useFragilityHistory.ts
@@ -1,0 +1,44 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getHourlySteps, getWeeklyVolume, type HourlySteps, type WeeklyVolumePoint } from '@/lib/api'
+import { computeFragilityIndex } from './useFragilityIndex'
+
+export interface FragilityPoint {
+  date: string
+  value: number
+}
+
+/**
+ * Computes historical fragility index values for recent days.
+ * Returns an array of points ordered by date ascending.
+ */
+export default function useFragilityHistory(days = 14): FragilityPoint[] | null {
+  const [weekly, setWeekly] = useState<WeeklyVolumePoint[] | null>(null)
+  const [hours, setHours] = useState<HourlySteps[] | null>(null)
+
+  useEffect(() => {
+    getWeeklyVolume().then(setWeekly)
+    getHourlySteps().then(setHours)
+  }, [])
+
+  return useMemo(() => {
+    if (!weekly || !hours) return null
+
+    const byDay: Record<string, HourlySteps[]> = {}
+    hours.forEach((h) => {
+      const day = h.timestamp.slice(0, 10)
+      if (!byDay[day]) byDay[day] = []
+      byDay[day].push(h)
+    })
+    const dates = Object.keys(byDay).sort()
+    const history: FragilityPoint[] = []
+    for (let i = 1; i < dates.length; i++) {
+      const date = dates[i]
+      const weeklyUpTo = weekly.filter((w) => w.week <= date)
+      const hoursUpTo = dates.slice(0, i + 1).flatMap((d) => byDay[d])
+      const value = computeFragilityIndex(weeklyUpTo, hoursUpTo)
+      history.push({ date, value })
+    }
+    return history.slice(-days)
+  }, [weekly, hours, days])
+}
+

--- a/src/pages/Fragility.tsx
+++ b/src/pages/Fragility.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CircularFragilityRing } from "@/components/dashboard";
+import { CircularFragilityRing, FragilityIndexSparkline } from "@/components/dashboard";
 
 export default function FragilityPage() {
   return (
@@ -15,7 +15,12 @@ export default function FragilityPage() {
         <li><span className="text-yellow-600">0.34–0.66</span>: monitor</li>
         <li><span className="text-red-600">0.67–1.00</span>: high risk</li>
       </ul>
-      <CircularFragilityRing />
+      <div className="flex flex-col items-center space-y-2">
+        <CircularFragilityRing />
+        <div className="w-full max-w-sm">
+          <FragilityIndexSparkline />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add hook to compute historical fragility index
- create sparkline component with risk-colored segments
- display sparkline on fragility index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0788b3d08324940eec212c9ed657