### PR TITLE
docs: document sidebar features

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Forward refs & `cn()` wrappers: every `ui/...` component should use the `cn()` h
 
 Types first: Prop-type definitions should be explicit (e.g. `interface StepsChartProps { data: GarminDay[] }`).
 
+## Sidebar features
+The UI sidebar includes configurable behaviour:
+
+- `SIDEBAR_WIDTH` and `SIDEBAR_WIDTH_MOBILE` control its width on desktop and mobile.
+- `SIDEBAR_KEYBOARD_SHORTCUT` toggles the sidebar via a Cmd/Ctrl + key shortcut.
+- The open state persists in the `SIDEBAR_COOKIE_NAME` cookie; the `SidebarProvider` `defaultOpen` prop sets the initial state.
+
+See [`components/ui/sidebar.tsx`](components/ui/sidebar.tsx) for implementation details.
+
 ## State & data hooks
 Keep all API-specific logic (auth, fetch, shape/normalize) inside `src/hooks/useGarminData.ts`. That way components stay pure/presentational.
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -25,6 +25,13 @@ import {
   TooltipTrigger,
 } from "@/registry/default/ui/tooltip"
 
+/**
+ * Sidebar configuration constants and behaviors.
+ * - `SIDEBAR_WIDTH` and `SIDEBAR_WIDTH_MOBILE` define desktop and mobile sizes.
+ * - `SIDEBAR_KEYBOARD_SHORTCUT` toggles the sidebar with Cmd/Ctrl + key.
+ * - The open state persists in `SIDEBAR_COOKIE_NAME`; `SidebarProvider`'s
+ *   `defaultOpen` prop sets the initial state.
+ */
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"


### PR DESCRIPTION
## Summary
- document sidebar configuration options in README
- add comment describing sizing, keyboard shortcut, and cookie persistence in sidebar component

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688e06ff62d08324804dc0fc244e0300