### PR TITLE
feat: add route novelty hook

### DIFF
--- a/src/hooks/useRouteNovelty.ts
+++ b/src/hooks/useRouteNovelty.ts
@@ -1,0 +1,25 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  getRouteRunHistory,
+  recordRouteRun,
+  type RouteRun,
+  type LatLon,
+} from "@/lib/api";
+import { computeNoveltyTrend } from "@/lib/utils";
+
+export default function useRouteNovelty() {
+  const [runs, setRuns] = useState<RouteRun[]>(() => getRouteRunHistory());
+
+  const { trend, prolongedLow } = useMemo(
+    () => computeNoveltyTrend(runs),
+    [runs],
+  );
+
+  const recordRun = useCallback((points: LatLon[]) => {
+    const run = recordRouteRun(points);
+    setRuns((prev) => [...prev, run]);
+    return run;
+  }, []);
+
+  return [runs, trend, prolongedLow, recordRun] as const;
+}


### PR DESCRIPTION
## Summary
- add `useRouteNovelty` hook to compute novelty trend and expose run recorder
- replace ad-hoc route novelty logic with hook in `RouteNoveltyMap`

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688e092b06288324a246294fa69f5d17