### PR TITLE
feat: show fragility breakdown

### DIFF
--- a/src/components/dashboard/CircularFragilityRing.tsx
+++ b/src/components/dashboard/CircularFragilityRing.tsx
@@ -14,11 +14,12 @@ export interface CircularFragilityRingProps {
  * Full circular gauge representing the behavioral fragility index.
  */
 export default function CircularFragilityRing({ size = 160, strokeWidth = 12 }: CircularFragilityRingProps) {
-  const index = useFragilityIndex()
+  const fragility = useFragilityIndex()
   const [displayIndex, setDisplayIndex] = useState(0)
 
   useEffect(() => {
-    if (index === null) return
+    if (!fragility) return
+    const { index } = fragility
     setDisplayIndex(0)
     let start: number | null = null
     const duration = 500
@@ -31,9 +32,10 @@ export default function CircularFragilityRing({ size = 160, strokeWidth = 12 }: 
     }
     frame = requestAnimationFrame(animate)
     return () => cancelAnimationFrame(frame)
-  }, [index])
+  }, [fragility])
 
-  if (index === null) return <Skeleton className="h-40" />
+  if (!fragility) return <Skeleton className="h-40" />
+  const { index } = fragility
 
   const radius = size / 2 - strokeWidth / 2
   const circumference = 2 * Math.PI * radius

--- a/src/components/dashboard/FragilityBreakdown.tsx
+++ b/src/components/dashboard/FragilityBreakdown.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import useFragilityIndex from '@/hooks/useFragilityIndex'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function FragilityBreakdown() {
+  const fragility = useFragilityIndex()
+  if (!fragility) return <Skeleton className="h-10 w-40" />
+  const { acwr, disruption } = fragility
+  const acwrComponent = Math.max(0, acwr - 1)
+  const acwrWidth = Math.min(acwrComponent, 1) * 50
+  const disruptionWidth = Math.min(disruption, 1) * 50
+
+  return (
+    <div className="flex flex-col items-center space-y-1 w-40">
+      <div className="w-full h-3 bg-muted rounded flex overflow-hidden" aria-label="Fragility breakdown">
+        <div
+          style={{ width: `${acwrWidth}%`, backgroundColor: 'hsl(var(--chart-8))' }}
+          className="h-full"
+        />
+        <div
+          style={{ width: `${disruptionWidth}%`, backgroundColor: 'hsl(var(--chart-3))' }}
+          className="h-full"
+        />
+      </div>
+      <div className="flex justify-between w-full text-xs text-muted-foreground">
+        <span>ACWR {acwr.toFixed(2)}</span>
+        <span>Disrupt {disruption.toFixed(2)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/FragilityGauge.tsx
+++ b/src/components/dashboard/FragilityGauge.tsx
@@ -14,11 +14,12 @@ export interface FragilityGaugeProps {
  * Semicircular gauge displaying the behavioral fragility index.
  */
 export default function FragilityGauge({ size = 160, strokeWidth = 12 }: FragilityGaugeProps) {
-  const index = useFragilityIndex()
+  const fragility = useFragilityIndex()
   const [displayIndex, setDisplayIndex] = useState(0)
 
   useEffect(() => {
-    if (index === null) return
+    if (!fragility) return
+    const { index } = fragility
     setDisplayIndex(0)
     let start: number | null = null
     const duration = 500
@@ -31,9 +32,10 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
     }
     frame = requestAnimationFrame(animate)
     return () => cancelAnimationFrame(frame)
-  }, [index])
+  }, [fragility])
 
-  if (index === null) return <Skeleton className="h-32" />
+  if (!fragility) return <Skeleton className="h-32" />
+  const { index } = fragility
 
   const radius = size / 2 - strokeWidth / 2
   const circumference = Math.PI * radius

--- a/src/components/dashboard/__tests__/CircularFragilityRing.test.tsx
+++ b/src/components/dashboard/__tests__/CircularFragilityRing.test.tsx
@@ -6,7 +6,7 @@ import CircularFragilityRing from '../CircularFragilityRing'
 
 vi.mock('@/hooks/useFragilityIndex', () => ({
   __esModule: true,
-  default: () => 0.42,
+  default: () => ({ index: 0.42, acwr: 1, disruption: 0.2 }),
 }))
 
 describe('CircularFragilityRing', () => {

--- a/src/components/dashboard/__tests__/FragilityGauge.test.tsx
+++ b/src/components/dashboard/__tests__/FragilityGauge.test.tsx
@@ -6,7 +6,7 @@ import FragilityGauge from '../FragilityGauge'
 
 vi.mock('@/hooks/useFragilityIndex', () => ({
   __esModule: true,
-  default: () => 0.42,
+  default: () => ({ index: 0.42, acwr: 1, disruption: 0.2 }),
 }))
 
 describe('FragilityGauge', () => {

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -27,6 +27,7 @@ export { default as MovementFingerprint } from "./MovementFingerprint";
 export { default as FragilityGauge } from "./FragilityGauge";
 export { default as CircularFragilityRing } from "./CircularFragilityRing";
 export { default as FragilityIndexSparkline } from "./FragilityIndexSparkline";
+export { default as FragilityBreakdown } from "./FragilityBreakdown";
 
 export { default as TrainingEntropyHeatmap } from "./TrainingEntropyHeatmap";
 

--- a/src/hooks/__tests__/useFragilityIndex.test.ts
+++ b/src/hooks/__tests__/useFragilityIndex.test.ts
@@ -19,8 +19,10 @@ const todayDay: HourlySteps[] = Array.from({ length: 24 }, (_, h) => ({
 const hours = [...baselineDay, ...todayDay]
 
 describe('computeFragilityIndex', () => {
-  it('combines disruption and acwr', () => {
-    const idx = computeFragilityIndex(weekly, hours)
-    expect(idx).toBeCloseTo(0.55, 1)
+  it('returns index with components', () => {
+    const { index, acwr, disruption } = computeFragilityIndex(weekly, hours)
+    expect(index).toBeCloseTo(0.55, 2)
+    expect(acwr).toBeCloseTo(1.1, 1)
+    expect(disruption).toBeCloseTo(1, 2)
   })
 })

--- a/src/hooks/useFragilityHistory.ts
+++ b/src/hooks/useFragilityHistory.ts
@@ -35,8 +35,8 @@ export default function useFragilityHistory(days = 14): FragilityPoint[] | null 
       const date = dates[i]
       const weeklyUpTo = weekly.filter((w) => w.week <= date)
       const hoursUpTo = dates.slice(0, i + 1).flatMap((d) => byDay[d])
-      const value = computeFragilityIndex(weeklyUpTo, hoursUpTo)
-      history.push({ date, value })
+      const { index } = computeFragilityIndex(weeklyUpTo, hoursUpTo)
+      history.push({ date, value: index })
     }
     return history.slice(-days)
   }, [weekly, hours, days])

--- a/src/pages/Fragility.tsx
+++ b/src/pages/Fragility.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CircularFragilityRing, FragilityIndexSparkline } from "@/components/dashboard";
+import { CircularFragilityRing, FragilityIndexSparkline, FragilityBreakdown } from "@/components/dashboard";
 
 export default function FragilityPage() {
   return (
@@ -16,7 +16,10 @@ export default function FragilityPage() {
         <li><span className="text-red-600">0.67–1.00</span>: high risk</li>
       </ul>
       <div className="flex flex-col items-center space-y-2">
-        <CircularFragilityRing />
+        <div className="flex items-center space-x-4">
+          <CircularFragilityRing />
+          <FragilityBreakdown />
+        </div>
         <div className="w-full max-w-sm">
           <FragilityIndexSparkline />
         </div>


### PR DESCRIPTION
## Summary
- expose ACWR and routine disruption from `useFragilityIndex`
- add `FragilityBreakdown` to visualize fragility components
- place the breakdown next to the primary fragility ring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0904b3788324a036d634dcbdb2d6