### PR TITLE
feat: include individual mileage in timeline

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -65,7 +65,7 @@ export default function MileageGlobe() {
 
   const points: GlobePoint[] = data.map((p) => ({
     date: p.date,
-    miles: p.cumulativeMiles,
+    miles: p.miles,
     coordinates: p.coordinates,
   }))
 

--- a/src/hooks/__tests__/useMileageTimeline.test.ts
+++ b/src/hooks/__tests__/useMileageTimeline.test.ts
@@ -19,9 +19,9 @@ describe("useMileageTimeline", () => {
     const { result } = renderHook(() => useMileageTimeline());
     await waitFor(() => result.current !== null);
     expect(result.current).toEqual([
-      { date: "2025-07-20", cumulativeMiles: 10, coordinates: [[0, 0]] },
-      { date: "2025-07-27", cumulativeMiles: 30, coordinates: [[1, 1]] },
-      { date: "2025-08-03", cumulativeMiles: 45, coordinates: [[2, 2]] },
+      { date: "2025-07-20", miles: 10, cumulativeMiles: 10, coordinates: [[0, 0]] },
+      { date: "2025-07-27", miles: 20, cumulativeMiles: 30, coordinates: [[1, 1]] },
+      { date: "2025-08-03", miles: 15, cumulativeMiles: 45, coordinates: [[2, 2]] },
     ]);
   });
 });

--- a/src/hooks/useMileageTimeline.ts
+++ b/src/hooks/useMileageTimeline.ts
@@ -3,6 +3,7 @@ import { getMileageTimeline, MileageTimelinePoint } from "@/lib/api";
 
 export interface CumulativeMileagePoint {
   date: string;
+  miles: number;
   cumulativeMiles: number;
   coordinates: [number, number][];
 }
@@ -16,7 +17,12 @@ export default function useMileageTimeline(
       let total = 0;
       const cumulative = points.map((p) => {
         total += p.miles;
-        return { date: p.date, cumulativeMiles: total, coordinates: p.coordinates };
+        return {
+          date: p.date,
+          miles: p.miles,
+          cumulativeMiles: total,
+          coordinates: p.coordinates,
+        };
       });
       setData(cumulative);
     });


### PR DESCRIPTION
## Summary
- add `miles` to `CumulativeMileagePoint`
- preserve per-activity mileage while computing cumulative totals
- adjust tests and mileage globe example for new field

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688e0a9974f88324a744cde9693f55e4