### PR TITLE
feat: add route run identifiers

### DIFF
--- a/src/components/dashboard/RouteNoveltyMap.tsx
+++ b/src/components/dashboard/RouteNoveltyMap.tsx
@@ -32,14 +32,14 @@ export default function RouteNoveltyMap() {
   const routeFeatures = useMemo(
     () => ({
       type: "FeatureCollection",
-      features: runs.map((r, i) => ({
+      features: runs.map((r) => ({
         type: "Feature",
-        id: i,
+        id: r.id,
         geometry: {
           type: "LineString",
           coordinates: r.points.map((p) => [p.lon, p.lat]),
         },
-        properties: { novelty: r.novelty, index: i },
+        properties: { novelty: r.novelty },
       })),
     }),
     [runs],
@@ -50,6 +50,7 @@ export default function RouteNoveltyMap() {
       type: "FeatureCollection",
       features: runs.map((r) => ({
         type: "Feature",
+        id: r.id,
         geometry: {
           type: "Point",
           coordinates: [r.points[0].lon, r.points[0].lat],
@@ -64,8 +65,8 @@ export default function RouteNoveltyMap() {
 
   const selectedRun = useMemo(
     () =>
-      selectedRunId != null && runs[selectedRunId]
-        ? runs[selectedRunId]
+      selectedRunId != null
+        ? runs.find((r) => r.id === selectedRunId) ?? null
         : null,
     [runs, selectedRunId],
   );
@@ -183,6 +184,7 @@ export default function RouteNoveltyMap() {
               }}
             >
               <div>
+                <div>{selectedRun.name}</div>
                 <div>{selectedRun.timestamp.slice(0, 10)}</div>
                 <div>Novelty: {selectedRun.novelty}</div>
               </div>

--- a/src/lib/__tests__/routeNovelty.test.ts
+++ b/src/lib/__tests__/routeNovelty.test.ts
@@ -30,6 +30,12 @@ describe('recordRouteRun', () => {
     const run2 = recordRouteRun(b)
     const run3 = recordRouteRun(c)
 
+    expect(run1.id).toBe(1)
+    expect(run1.name).toBe('Run 1')
+    expect(run2.id).toBe(2)
+    expect(run2.name).toBe('Run 2')
+    expect(run3.id).toBe(3)
+    expect(run3.name).toBe('Run 3')
     expect(run1.novelty).toBe(1)
     expect(run2.novelty).toBeLessThan(0.05)
     expect(run3.novelty).toBeGreaterThan(0.8)
@@ -44,6 +50,8 @@ describe('computeNoveltyTrend', () => {
       const d = new Date(today)
       d.setDate(d.getDate() - (19 - i))
       return {
+        id: i + 1,
+        name: `Run ${i + 1}`,
         timestamp: d.toISOString(),
         points: [],
         novelty: i < 7 ? 0.9 : 0.1,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1073,11 +1073,14 @@ export function calculateRouteSimilarity(
 }
 
 export interface RouteRun {
+  id: number;
+  name: string;
   timestamp: string;
   points: LatLon[];
   novelty: number;
 }
 
+let nextRouteRunId = 1;
 const routeHistory: RouteRun[] = [];
 
 function dtwDistance(a: LatLon[], b: LatLon[]): number {
@@ -1117,11 +1120,14 @@ export function computeRouteNovelty(
 export function recordRouteRun(points: LatLon[]): RouteRun {
   const novelty = computeRouteNovelty(points, routeHistory.map((r) => r.points));
   const run: RouteRun = {
+    id: nextRouteRunId,
+    name: `Run ${nextRouteRunId}`,
     timestamp: new Date().toISOString(),
     points,
     novelty,
   };
   routeHistory.push(run);
+  nextRouteRunId++;
   return run;
 }
 


### PR DESCRIPTION
## Summary
- track route run IDs and names in API
- ensure route history and map use run identifiers
- test route runs with new metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e0c4790148324afb48bc6feef15a8