### PR TITLE
refactor: remove duplicate session point fields

### DIFF
--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -13,13 +13,9 @@ export interface SessionPoint {
   humidity: number
   wind: number
   startHour: number
-  pace: number
-  heartRate: number
   duration: number
   lat: number
   lon: number
-  humidity: number
-  wind: number
   condition: string
 }
 
@@ -115,13 +111,9 @@ export function useRunningSessions(): SessionPoint[] | null {
           humidity: sessions[idx].weather.humidity,
           wind: sessions[idx].weather.wind,
           startHour: new Date(sessions[idx].start).getHours(),
-          pace: sessions[idx].pace,
-          heartRate: sessions[idx].heartRate,
           duration: sessions[idx].duration,
           lat: sessions[idx].lat,
           lon: sessions[idx].lon,
-          humidity: sessions[idx].weather.humidity,
-          wind: sessions[idx].weather.wind,
           condition: sessions[idx].weather.condition,
         }),
       )


### PR DESCRIPTION
## Summary
- remove duplicate `pace`, `heartRate`, `humidity` and `wind` declarations in `SessionPoint`
- clean up session data mapping to expose each field once

## Testing
- `npm test` *(fails: ReferenceError: nextRouteRunId is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e0e70204483248d2114360c3e8720