### PR TITLE
Add detailed route similarity metrics

### DIFF
--- a/src/lib/__tests__/routeNovelty.test.ts
+++ b/src/lib/__tests__/routeNovelty.test.ts
@@ -10,7 +10,7 @@ import { computeNoveltyTrend } from '../utils'
 describe('computeRouteNovelty', () => {
   it('returns 1 when no history', () => {
     const route: LatLon[] = [{ lat: 0, lon: 0 }]
-    expect(computeRouteNovelty(route, [])).toBe(1)
+    expect(computeRouteNovelty(route, []).novelty).toBe(1)
   })
 })
 
@@ -47,6 +47,8 @@ describe('computeNoveltyTrend', () => {
         timestamp: d.toISOString(),
         points: [],
         novelty: i < 7 ? 0.9 : 0.1,
+        dtwSim: 0,
+        overlapSim: 0,
       }
     })
     const { trend, prolongedLow } = computeNoveltyTrend(runs, 7, 0.2)


### PR DESCRIPTION
## Summary
- enrich RouteRun records with dtwSim and overlapSim similarity fields
- expose detailed similarity components from computeRouteNovelty
- persist new similarity metrics when recording route runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e0c51fac483248090af62eb1ebaf8