### PR TITLE
Add useLocationVisits hook

### DIFF
--- a/src/hooks/__tests__/useLocationVisits.test.ts
+++ b/src/hooks/__tests__/useLocationVisits.test.ts
@@ -1,0 +1,24 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import useLocationVisits from "../useLocationVisits";
+import { getLocationVisits } from "@/lib/api";
+import type { LocationVisit } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  __esModule: true,
+  getLocationVisits: vi.fn(),
+}));
+
+describe("useLocationVisits", () => {
+  it("returns visits and manages loading state", async () => {
+    const mockVisits: LocationVisit[] = [
+      { date: "2025-07-30", placeId: "home", category: "home" },
+    ];
+    (getLocationVisits as any).mockResolvedValue(mockVisits);
+    const { result } = renderHook(() => useLocationVisits());
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.visits).toEqual(mockVisits);
+  });
+});

--- a/src/hooks/useLocationVisits.ts
+++ b/src/hooks/useLocationVisits.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { getLocationVisits, type LocationVisit } from "@/lib/api";
+
+/**
+ * React hook that retrieves visits to known locations.
+ *
+ * It fetches data from {@link getLocationVisits} and exposes a loading flag
+ * while the asynchronous call is in progress.
+ *
+ * @returns An object containing the array of visits and a loading indicator.
+ */
+export function useLocationVisits() {
+  const [visits, setVisits] = useState<LocationVisit[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    getLocationVisits()
+      .then((data) => {
+        if (active) setVisits(data);
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { visits, isLoading };
+}
+
+export default useLocationVisits;


### PR DESCRIPTION
## Summary
- add `useLocationVisits` hook for fetching visit history with loading state
- test hook behavior to ensure data retrieval and state updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e0c34c63883249f173377e9cb5a03