### PR TITLE
fix: async route run recording

### DIFF
--- a/src/lib/__tests__/routeNovelty.test.ts
+++ b/src/lib/__tests__/routeNovelty.test.ts
@@ -59,8 +59,8 @@ describe('computeNoveltyTrend', () => {
         points: [],
         novelty: i < 7 ? 0.9 : 0.1,
 
-        dtwSim: 0,
-        overlapSim: 0,
+        dtwSimilarity: 0,
+        overlapSimilarity: 0,
 
       }
     })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1079,10 +1079,8 @@ export interface RouteRun {
   timestamp: string;
   points: LatLon[];
   novelty: number;
-
-  dtwSim: number;
-  overlapSim: number;
-
+  dtwSimilarity: number;
+  overlapSimilarity: number;
 }
 
 
@@ -1108,9 +1106,9 @@ function dtwDistance(a: LatLon[], b: LatLon[]): number {
 export function computeRouteNovelty(
   route: LatLon[],
   history: LatLon[][],
-): { novelty: number; dtwSim: number; overlapSim: number } {
+): { novelty: number; dtwSimilarity: number; overlapSimilarity: number } {
   if (history.length === 0) {
-    return { novelty: 1, dtwSim: 0, overlapSim: 0 };
+    return { novelty: 1, dtwSimilarity: 0, overlapSimilarity: 0 };
   }
   let maxSim = 0;
   let bestDtw = 0;
@@ -1125,12 +1123,19 @@ export function computeRouteNovelty(
       bestOverlap = overlapSim;
     }
   }
-  return { novelty: 1 - maxSim, dtwSim: bestDtw, overlapSim: bestOverlap };
+  return {
+    novelty: 1 - maxSim,
+    dtwSimilarity: bestDtw,
+    overlapSimilarity: bestOverlap,
+  };
 }
 
 
-export function recordRouteRun(points: LatLon[]): RouteRun {
-  const { novelty, dtwSim, overlapSim } = computeRouteNovelty(
+let nextRouteRunId = 1;
+const routeHistory: RouteRun[] = [];
+
+export async function recordRouteRun(points: LatLon[]): Promise<RouteRun> {
+  const { novelty, dtwSimilarity, overlapSimilarity } = computeRouteNovelty(
     points,
     routeHistory.map((r) => r.points),
   );
@@ -1142,10 +1147,13 @@ export function recordRouteRun(points: LatLon[]): RouteRun {
     points,
     novelty,
 
-    dtwSim,
-    overlapSim,
+    dtwSimilarity,
+    overlapSimilarity,
 
   };
+
+  nextRouteRunId++;
+  routeHistory.push(run);
 
   await trackRouteRun(run);
 


### PR DESCRIPTION
## Summary
- fix recordRouteRun by making it async, adding run history, and awaiting telemetry tracking
- expose dtwSimilarity and overlapSimilarity fields on RouteRun
- adjust route novelty test helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e103ba46483249e76f6337f7e435f