### PR TITLE
Use shared RouteRun type and trend utility

### DIFF
--- a/src/components/dashboard/RouteNoveltyMap.tsx
+++ b/src/components/dashboard/RouteNoveltyMap.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from "react";
+import type { RouteRun } from "@/lib/api";
 import Map, {
   Layer,
   Source,
@@ -63,7 +64,7 @@ export default function RouteNoveltyMap() {
 
   const showSuggestion = prolongedLow;
 
-  const selectedRun = useMemo(
+  const selectedRun = useMemo<RouteRun | null>(
     () =>
       selectedRunId != null
         ? runs.find((r) => r.id === selectedRunId) ?? null

--- a/src/lib/__tests__/routeNovelty.test.ts
+++ b/src/lib/__tests__/routeNovelty.test.ts
@@ -4,6 +4,7 @@ import {
   recordRouteRun,
   getRouteRunHistory,
   LatLon,
+  type RouteRun,
 } from '../api'
 import { computeNoveltyTrend } from '../utils'
 
@@ -49,7 +50,7 @@ describe('recordRouteRun', () => {
 describe('computeNoveltyTrend', () => {
   it('flags prolonged low novelty', () => {
     const today = new Date()
-    const runs = Array.from({ length: 20 }, (_, i) => {
+    const runs: RouteRun[] = Array.from({ length: 20 }, (_, i) => {
       const d = new Date(today)
       d.setDate(d.getDate() - (19 - i))
       return {


### PR DESCRIPTION
## Summary
- use `RouteRun` type from API in `RouteNoveltyMap`
- cover computeNoveltyTrend in novelty tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688e3d138f4c8324a42ffdd4985de257