### PR TITLE
Parse weekly dates in fragility history

### DIFF
--- a/src/hooks/useFragilityHistory.ts
+++ b/src/hooks/useFragilityHistory.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { parseISO, startOfISOWeek } from 'date-fns'
 import { getHourlySteps, getWeeklyVolume, type HourlySteps, type WeeklyVolumePoint } from '@/lib/api'
 import { computeFragilityIndex } from './useFragilityIndex'
 
@@ -23,6 +24,24 @@ export default function useFragilityHistory(days = 14): FragilityPoint[] | null 
   return useMemo(() => {
     if (!weekly || !hours) return null
 
+    function parseWeek(week: string): Date {
+      if (/^\d{4}-W\d{2}$/.test(week)) {
+        const [yearStr, weekStr] = week.split('-W')
+        const year = Number(yearStr)
+        const weekNum = Number(weekStr)
+        const jan4 = new Date(Date.UTC(year, 0, 4))
+        const day = jan4.getUTCDay() || 7
+        const start = new Date(jan4)
+        start.setUTCDate(jan4.getUTCDate() - day + 1 + (weekNum - 1) * 7)
+        return start
+      }
+      return startOfISOWeek(parseISO(week))
+    }
+
+    const weeklySorted = weekly
+      .map((w) => ({ ...w, weekDate: parseWeek(w.week) }))
+      .sort((a, b) => a.weekDate.getTime() - b.weekDate.getTime())
+
     const byDay: Record<string, HourlySteps[]> = {}
     hours.forEach((h) => {
       const day = h.timestamp.slice(0, 10)
@@ -32,11 +51,14 @@ export default function useFragilityHistory(days = 14): FragilityPoint[] | null 
     const dates = Object.keys(byDay).sort()
     const history: FragilityPoint[] = []
     for (let i = 1; i < dates.length; i++) {
-      const date = dates[i]
-      const weeklyUpTo = weekly.filter((w) => w.week <= date)
+      const dateStr = dates[i]
+      const dateObj = parseISO(dateStr)
+      const weeklyUpTo = weeklySorted
+        .filter((w) => w.weekDate <= dateObj)
+        .map(({ weekDate, ...rest }) => rest)
       const hoursUpTo = dates.slice(0, i + 1).flatMap((d) => byDay[d])
       const { index } = computeFragilityIndex(weeklyUpTo, hoursUpTo)
-      history.push({ date, value: index })
+      history.push({ date: dateStr, value: index })
     }
     return history.slice(-days)
   }, [weekly, hours, days])


### PR DESCRIPTION
## Summary
- parse WeeklyVolumePoint.week to a Date and handle ISO week strings
- compare weekly data using parsed Date objects and sort before computing fragility index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e3cb2db508324ae638d960149447b