### PR TITLE
Expose sessions from training consistency hook

### DIFF
--- a/src/components/dashboard/TrainingEntropyHeatmap.tsx
+++ b/src/components/dashboard/TrainingEntropyHeatmap.tsx
@@ -11,16 +11,18 @@ export default function TrainingEntropyHeatmap() {
 
   if (!data) return <Skeleton className="h-64" />;
 
+  const { heatmap, weeklyEntropy } = data;
+
   const grid = Array.from({ length: 24 }, () =>
     Array.from({ length: 7 }, () => ({ count: 0 }))
   );
   let max = 0;
-  data.heatmap.forEach((c) => {
+  heatmap.forEach((c) => {
     grid[c.hour][c.day] = c;
     if (c.count > max) max = c.count;
   });
 
-  const entropySeries = data.weeklyEntropy.map((e, i) => ({ week: i + 1, entropy: e }));
+  const entropySeries = weeklyEntropy.map((e, i) => ({ week: i + 1, entropy: e }));
   const entropyMax = Math.log2(168);
 
   return (

--- a/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
@@ -19,6 +19,7 @@ vi.mock('recharts', async () => {
 vi.mock('@/hooks/useTrainingConsistency', () => ({
   __esModule: true,
   default: () => ({
+    sessions: [],
     heatmap: [{ day: 0, hour: 0, count: 1 }],
     weeklyEntropy: [0.2],
   }),

--- a/src/components/statistics/HabitConsistencyHeatmap.tsx
+++ b/src/components/statistics/HabitConsistencyHeatmap.tsx
@@ -12,11 +12,13 @@ export default function HabitConsistencyHeatmap() {
 
   if (!data) return <Skeleton className="h-64" />
 
+  const { heatmap } = data
+
   const grid = Array.from({ length: 24 }, () =>
     Array.from({ length: 7 }, () => ({ count: 0 })),
   )
   let max = 0
-  data.heatmap.forEach((c) => {
+  heatmap.forEach((c) => {
     grid[c.hour][c.day] = c
     if (c.count > max) max = c.count
   })

--- a/src/hooks/useTrainingConsistency.ts
+++ b/src/hooks/useTrainingConsistency.ts
@@ -8,6 +8,7 @@ export interface TrainingHeatmapCell {
 }
 
 export interface TrainingConsistency {
+  sessions: RunningSession[]
   heatmap: TrainingHeatmapCell[]
   weeklyEntropy: number[]
 }
@@ -66,6 +67,7 @@ export default function useTrainingConsistency(): TrainingConsistency | null {
   return useMemo(() => {
     if (!sessions) return null
     return {
+      sessions,
       heatmap: computeHeatmap(sessions),
       weeklyEntropy: computeWeeklyEntropy(sessions),
     }


### PR DESCRIPTION
## Summary
- Return raw running sessions from `useTrainingConsistency` alongside heatmap and entropy
- Adjust dashboard and statistics components for new hook shape
- Update related test mock to include sessions array

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e3bcc982c8324acd7d855226cafcd