### PR TITLE
refactor: improve training session start typing

### DIFF
--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -65,7 +65,7 @@ export function useRunningSessions(): SessionPoint[] | null {
 
   useEffect(() => {
     function expectedPace(s: RunningSession): number {
-      const hour = new Date(s.start).getHours()
+      const hour = new Date(s.start ?? s.date).getHours()
       const tempAdj = (s.weather.temperature - 55) * 0.02
       const humidAdj = (s.weather.humidity - 50) * 0.01
       const windAdj = s.weather.wind * 0.01
@@ -89,7 +89,7 @@ export function useRunningSessions(): SessionPoint[] | null {
       const input = sessions.map((s) => [
         s.weather.temperature,
         s.weather.humidity,
-        new Date(s.start).getHours(),
+        new Date(s.start ?? s.date).getHours(),
         s.heartRate,
         s.pace,
       ])
@@ -110,7 +110,7 @@ export function useRunningSessions(): SessionPoint[] | null {
           temperature: sessions[idx].weather.temperature,
           humidity: sessions[idx].weather.humidity,
           wind: sessions[idx].weather.wind,
-          startHour: new Date(sessions[idx].start).getHours(),
+          startHour: new Date(sessions[idx].start ?? sessions[idx].date).getHours(),
           duration: sessions[idx].duration,
           lat: sessions[idx].lat,
           lon: sessions[idx].lon,

--- a/src/hooks/useTrainingConsistency.ts
+++ b/src/hooks/useTrainingConsistency.ts
@@ -16,7 +16,7 @@ export interface TrainingConsistency {
 function computeHeatmap(sessions: RunningSession[]): TrainingHeatmapCell[] {
   const bins = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0))
   sessions.forEach((s) => {
-    const d = new Date((s as any).start || s.date)
+    const d = new Date(s.start ?? s.date)
     const day = d.getDay()
     const hour = d.getHours()
     bins[day][hour] += 1
@@ -43,7 +43,7 @@ function shannonEntropy(counts: number[]): number {
 function computeWeeklyEntropy(sessions: RunningSession[]): number[] {
   const weeks: Record<string, number[]> = {}
   sessions.forEach((s) => {
-    const d = new Date((s as any).start || s.date)
+    const d = new Date(s.start ?? s.date)
     const weekStart = new Date(d)
     weekStart.setDate(d.getDate() - d.getDay())
     weekStart.setHours(0, 0, 0, 0)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -904,7 +904,7 @@ export interface RunningSession {
   date: string;
 
   /** ISO timestamp for session start */
-  start: string;
+  start?: string;
   lat: number;
   lon: number;
   weather: {


### PR DESCRIPTION
## Summary
- use typed `start` instead of `any` in training consistency calculations
- allow optional `start` in `RunningSession`
- handle missing `start` in running sessions

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'index' does not exist on type 'SocialBaseline', etc.)*
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688e40a9be5c8324b9b91e5c44f1887e