### PR TITLE
feat: centralize fragility thresholds

### DIFF
--- a/src/components/dashboard/FragilityGauge.tsx
+++ b/src/components/dashboard/FragilityGauge.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import useFragilityIndex from '@/hooks/useFragilityIndex'
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Skeleton } from '@/components/ui/skeleton'
+import { getFragilityLevel } from '@/lib/fragility'
 
 export interface FragilityGaugeProps {
   /** Diameter of the gauge in pixels */
@@ -41,12 +42,7 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
   const circumference = Math.PI * radius
   const offset = circumference - displayIndex * circumference
 
-  let color = 'hsl(var(--chart-3))'
-  if (index > 0.66) {
-    color = 'hsl(var(--destructive))'
-  } else if (index > 0.33) {
-    color = 'hsl(var(--chart-8))'
-  }
+  const { color } = getFragilityLevel(index)
 
   return (
     <TooltipProvider delayDuration={100}>

--- a/src/components/dashboard/FragilityIndexSparkline.tsx
+++ b/src/components/dashboard/FragilityIndexSparkline.tsx
@@ -11,6 +11,7 @@ import {
 import type { ChartConfig } from '@/components/ui/chart'
 import useFragilityHistory from '@/hooks/useFragilityHistory'
 import { Skeleton } from '@/components/ui/skeleton'
+import { FRAGILITY_LEVELS, getFragilityLevel } from '@/lib/fragility'
 
 /**
  * Small sparkline showing recent fragility index trend.
@@ -20,17 +21,20 @@ export default function FragilityIndexSparkline() {
 
   if (!history) return <Skeleton className="h-8 w-full" />
 
-  const data = history.map((d) => ({
-    date: d.date,
-    low: d.value < 0.33 ? d.value : null,
-    medium: d.value >= 0.33 && d.value < 0.66 ? d.value : null,
-    high: d.value >= 0.66 ? d.value : null,
-  }))
+  const data = history.map((d) => {
+    const level = getFragilityLevel(d.value).key
+    return {
+      date: d.date,
+      low: level === 'low' ? d.value : null,
+      medium: level === 'medium' ? d.value : null,
+      high: level === 'high' ? d.value : null,
+    }
+  })
 
   const config = {
-    low: { label: 'Low', color: 'hsl(var(--chart-3))' },
-    medium: { label: 'Medium', color: 'hsl(var(--chart-8))' },
-    high: { label: 'High', color: 'hsl(var(--destructive))' },
+    low: { label: FRAGILITY_LEVELS.low.label, color: FRAGILITY_LEVELS.low.color },
+    medium: { label: FRAGILITY_LEVELS.medium.label, color: FRAGILITY_LEVELS.medium.color },
+    high: { label: FRAGILITY_LEVELS.high.label, color: FRAGILITY_LEVELS.high.color },
   } satisfies ChartConfig
 
   return (

--- a/src/lib/__tests__/fragility.test.ts
+++ b/src/lib/__tests__/fragility.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { getFragilityLevel, FRAGILITY_THRESHOLDS } from '../fragility'
+
+describe('getFragilityLevel', () => {
+  it('returns low for values below medium threshold', () => {
+    expect(getFragilityLevel(0.2).key).toBe('low')
+  })
+
+  it('returns medium for values above medium threshold', () => {
+    expect(getFragilityLevel(FRAGILITY_THRESHOLDS.medium + 0.01).key).toBe('medium')
+  })
+
+  it('returns high for values above high threshold', () => {
+    expect(getFragilityLevel(FRAGILITY_THRESHOLDS.high + 0.01).key).toBe('high')
+  })
+
+  it('handles boundary values', () => {
+    expect(getFragilityLevel(FRAGILITY_THRESHOLDS.medium).key).toBe('low')
+    expect(getFragilityLevel(FRAGILITY_THRESHOLDS.high).key).toBe('medium')
+  })
+})

--- a/src/lib/fragility.ts
+++ b/src/lib/fragility.ts
@@ -1,0 +1,56 @@
+export const FRAGILITY_THRESHOLDS = {
+  medium: 0.33,
+  high: 0.66,
+} as const
+
+export interface FragilityLevel {
+  key: 'low' | 'medium' | 'high'
+  /** Label used in charts */
+  label: string
+  /** Description for textual summaries */
+  description: string
+  /** Color token used for charts and gauges */
+  color: string
+  /** Tailwind text color class for page legend */
+  textClass: string
+  /** Range displayed to users */
+  displayMin: number
+  displayMax: number
+}
+
+export const FRAGILITY_LEVELS: Record<FragilityLevel['key'], FragilityLevel> = {
+  low: {
+    key: 'low',
+    label: 'Low',
+    description: 'stable',
+    color: 'hsl(var(--chart-3))',
+    textClass: 'text-green-600',
+    displayMin: 0,
+    displayMax: FRAGILITY_THRESHOLDS.medium,
+  },
+  medium: {
+    key: 'medium',
+    label: 'Medium',
+    description: 'monitor',
+    color: 'hsl(var(--chart-8))',
+    textClass: 'text-yellow-600',
+    displayMin: FRAGILITY_THRESHOLDS.medium + 0.01,
+    displayMax: FRAGILITY_THRESHOLDS.high,
+  },
+  high: {
+    key: 'high',
+    label: 'High',
+    description: 'high risk',
+    color: 'hsl(var(--destructive))',
+    textClass: 'text-red-600',
+    displayMin: FRAGILITY_THRESHOLDS.high + 0.01,
+    displayMax: 1,
+  },
+} as const
+
+export function getFragilityLevel(index: number): FragilityLevel {
+  if (index > FRAGILITY_THRESHOLDS.high) return FRAGILITY_LEVELS.high
+  if (index > FRAGILITY_THRESHOLDS.medium) return FRAGILITY_LEVELS.medium
+  return FRAGILITY_LEVELS.low
+}
+

--- a/src/pages/Fragility.tsx
+++ b/src/pages/Fragility.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CircularFragilityRing, FragilityIndexSparkline, FragilityBreakdown } from "@/components/dashboard";
+import { FRAGILITY_LEVELS } from "@/lib/fragility";
 
 export default function FragilityPage() {
   return (
@@ -11,9 +12,13 @@ export default function FragilityPage() {
         scores call for caution.
       </p>
       <ul className="text-sm text-muted-foreground list-disc pl-4">
-        <li><span className="text-green-600">0–0.33</span>: stable</li>
-        <li><span className="text-yellow-600">0.34–0.66</span>: monitor</li>
-        <li><span className="text-red-600">0.67–1.00</span>: high risk</li>
+        {Object.values(FRAGILITY_LEVELS).map((level) => (
+          <li key={level.key}>
+            <span className={level.textClass}>
+              {level.displayMin.toFixed(2).replace(/\.00$/, '')}–{level.displayMax.toFixed(2)}
+            </span>: {level.description}
+          </li>
+        ))}
       </ul>
       <div className="flex flex-col items-center space-y-2">
         <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- add fragility utility with shared thresholds and helper
- refactor gauge, sparkline, and page to use shared levels
- test fragility level helper

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688e404deed48324ba5b3d7d3796410e