### PR TITLE
feat: add years selector for mileage globe

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -121,8 +121,8 @@ function GlobeRenderer({
   )
 }
 
-export default function MileageGlobe() {
-  const data = useMileageTimeline()
+export default function MileageGlobe({ years = 1 }: { years?: number }) {
+  const data = useMileageTimeline(years)
   const [selected, setSelected] = useState<GlobePoint | null>(null)
 
   if (!data) {

--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -1,7 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import MileageGlobe from "@/components/examples/MileageGlobe";
+import Slider from "@/components/ui/slider";
 
 export default function MileageGlobePage() {
+  const [years, setYears] = useState(1);
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Mileage Globe</h2>
@@ -9,7 +12,18 @@ export default function MileageGlobePage() {
         Explore your activities on an interactive 3D globe. Drag to rotate, and use your
         mouse wheel or touchpad to zoom. Click on a path to inspect mileage.
       </p>
-      <MileageGlobe />
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Years of data: {years}</label>
+        <Slider
+          min={1}
+          max={5}
+          step={1}
+          value={[years]}
+          onValueChange={(val) => setYears(val[0])}
+          className="w-48"
+        />
+      </div>
+      <MileageGlobe years={years} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- let MileageGlobe be filtered by a selectable number of years
- forward selected years to mileage timeline hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e43961800832499cbb7c37b97d2ab