### PR TITLE
feat: add weighting and monotony to fragility index

### DIFF
--- a/src/hooks/__tests__/useFragilityIndex.test.ts
+++ b/src/hooks/__tests__/useFragilityIndex.test.ts
@@ -20,9 +20,30 @@ const hours = [...baselineDay, ...todayDay]
 
 describe('computeFragilityIndex', () => {
   it('returns index with components', () => {
-    const { index, acwr, disruption } = computeFragilityIndex(weekly, hours)
+    const { index, acwr, disruption, monotony } = computeFragilityIndex(
+      weekly,
+      hours,
+    )
     expect(index).toBeCloseTo(0.55, 2)
     expect(acwr).toBeCloseTo(1.1, 1)
     expect(disruption).toBeCloseTo(1, 2)
+    expect(monotony).toBeCloseTo(0.85, 2)
+  })
+
+  it('applies custom weights', () => {
+    const { index } = computeFragilityIndex(weekly, hours, {
+      disruptionWeight: 3,
+      acwrWeight: 1,
+    })
+    expect(index).toBeCloseTo(0.78, 2)
+  })
+
+  it('includes monotony when weighted', () => {
+    const { index } = computeFragilityIndex(weekly, hours, {
+      disruptionWeight: 1,
+      acwrWeight: 1,
+      monotonyWeight: 1,
+    })
+    expect(index).toBeCloseTo(0.65, 2)
   })
 })


### PR DESCRIPTION
## Summary
- add configurable weights and monotony component to fragility index
- compute training monotony from weekly loads and normalize weighted index
- test custom weighting and monotony handling

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688e4513f2188324b568160ad00a4feb