### PR TITLE
feat: add gradient utility

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -27,7 +27,7 @@ export default function Layout({ children }: LayoutProps) {
     <SidebarProvider>
       <AppSidebar />
       <CommandPalette open={open} setOpen={setOpen} />
-      <SidebarInset>
+      <SidebarInset className="bg-gradient">
         <header className="flex items-center justify-between p-4">
           <SidebarTrigger />
           <div className="flex items-center gap-2">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -48,6 +48,7 @@
     --wild-wheat: 41 40% 80%;
     --spotify-primary: 141 60% 50%;
     --spotify-foreground: 0 0% 0%;
+    --gradient: linear-gradient(to top left, #72C6EF, #004E8F);
     --font-slab: "Georgia", "Times New Roman", serif;
   }
 
@@ -95,10 +96,17 @@
     --wild-wheat: 41 40% 80%;
     --spotify-primary: 141 65% 58%;
     --spotify-foreground: 0 0% 100%;
+    --gradient: linear-gradient(to top left, #004E8F, #001B36);
     --font-slab: "Georgia", "Times New Roman", serif;
   }
 
   html, body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .bg-gradient {
+    background: var(--gradient);
   }
 }


### PR DESCRIPTION
## Summary
- add `--gradient` CSS variable for light and dark themes
- expose `.bg-gradient` utility class for applying theme gradient backgrounds
- use new gradient background in layout sidebar inset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e43a7b3088324982aacb0cfb60eb9