### PR TITLE
feat: collapse chart groups in sidebar

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -15,7 +15,8 @@ import {
   SidebarMenuSubButton,
 } from "@/components/ui/sidebar";
 import { NavLink, useLocation } from "react-router-dom";
-import { Map as MapIcon } from "lucide-react";
+import { Map as MapIcon, ChevronRight } from "lucide-react";
+import * as Collapsible from "@radix-ui/react-collapsible";
 import { chartRouteGroups, mapRoutes } from "@/routes";
 
 export default function AppSidebar() {
@@ -29,25 +30,35 @@ export default function AppSidebar() {
           <SidebarGroupLabel>Charts</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {chartRouteGroups.map((group) => (
-                <SidebarMenuItem key={group.label}>
-                  <SidebarMenuButton className="justify-start">
-                    {group.label}
-                  </SidebarMenuButton>
-                  <SidebarMenuSub>
-                    {group.items.map((route) => (
-                      <SidebarMenuSubItem key={route.to}>
-                        <SidebarMenuSubButton
-                          asChild
-                          isActive={pathname === route.to}
-                          className="justify-start"
-                        >
-                          <NavLink to={route.to}>{route.label}</NavLink>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-                    ))}
-                  </SidebarMenuSub>
-                </SidebarMenuItem>
+              {chartRouteGroups.map((group, index) => (
+                <Collapsible.Root
+                  key={group.label}
+                  defaultOpen={index === 0}
+                >
+                  <SidebarMenuItem>
+                    <Collapsible.Trigger asChild>
+                      <SidebarMenuButton className="justify-start">
+                        {group.label}
+                        <ChevronRight className="ml-auto transition-transform data-[state=open]:rotate-90" />
+                      </SidebarMenuButton>
+                    </Collapsible.Trigger>
+                    <Collapsible.Content>
+                      <SidebarMenuSub>
+                        {group.items.map((route) => (
+                          <SidebarMenuSubItem key={route.to}>
+                            <SidebarMenuSubButton
+                              asChild
+                              isActive={pathname === route.to}
+                              className="justify-start"
+                            >
+                              <NavLink to={route.to}>{route.label}</NavLink>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    </Collapsible.Content>
+                  </SidebarMenuItem>
+                </Collapsible.Root>
               ))}
             </SidebarMenu>
           </SidebarGroupContent>


### PR DESCRIPTION
## Summary
- add Collapsible sections to chart groups in sidebar
- show chevron indicator for expanded state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e4b18eb2483249982a364d245c995