### PR TITLE
test: add MileageGlobe tests

### DIFF
--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import MileageGlobe from "../MileageGlobe";
+import useMileageTimeline from "@/hooks/useMileageTimeline";
+import { vi } from "vitest";
+
+vi.mock("@/hooks/useMileageTimeline");
+
+describe("MileageGlobe", () => {
+  const mockUseMileageTimeline = useMileageTimeline as unknown as vi.Mock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("renders loading placeholder when no data", () => {
+    mockUseMileageTimeline.mockReturnValue(null);
+    render(<MileageGlobe />);
+    expect(
+      screen.getByText(/Loading mileage globe.../i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders mileage paths when data is available", async () => {
+    mockUseMileageTimeline.mockReturnValue([
+      {
+        date: "2024-01-01",
+        miles: 5,
+        cumulativeMiles: 5,
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      },
+    ]);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          type: "Topology",
+          objects: { countries: { type: "GeometryCollection", geometries: [] } },
+        }),
+    }) as any;
+
+    const { container } = render(<MileageGlobe />);
+
+    await waitFor(() => {
+      const path = container.querySelector("path[stroke='var(--primary)']");
+      expect(path).toBeTruthy();
+    });
+  });
+
+  it("displays selected mileage when path is clicked", async () => {
+    mockUseMileageTimeline.mockReturnValue([
+      {
+        date: "2024-01-01",
+        miles: 5,
+        cumulativeMiles: 5,
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      },
+    ]);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          type: "Topology",
+          objects: { countries: { type: "GeometryCollection", geometries: [] } },
+        }),
+    }) as any;
+
+    const { container } = render(<MileageGlobe />);
+
+    let path: SVGPathElement | null = null;
+    await waitFor(() => {
+      path = container.querySelector(
+        "path[stroke='var(--primary)']",
+      ) as SVGPathElement | null;
+      expect(path).toBeTruthy();
+    });
+
+    fireEvent.click(path!);
+
+    await waitFor(() => {
+      expect(screen.getByText("2024-01-01: 5 miles")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add RTL tests for MileageGlobe covering loading state, path rendering, and selection

## Testing
- `npm test -- --run src/components/examples/__tests__/MileageGlobe.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688e4b01d9c483248ebbb7cb0cb5d1f4