### PR TITLE
Add route novelty legend and map controls

### DIFF
--- a/src/components/dashboard/RouteNoveltyLegend.tsx
+++ b/src/components/dashboard/RouteNoveltyLegend.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export default function RouteNoveltyLegend() {
+  return (
+    <div className="bg-background/90 p-2 rounded shadow text-xs space-y-2">
+      <div>
+        <div className="font-medium mb-1">Novelty</div>
+        <div className="flex items-center gap-2">
+          <span className="text-gray-500">Familiar</span>
+          <div className="h-2 w-20 bg-gradient-to-r from-gray-400 to-red-500 rounded" />
+          <span className="text-red-500">Novel</span>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="w-4 h-4 bg-gray-400 rounded-full flex items-center justify-center text-[0.6rem] text-white">
+          #
+        </div>
+        <span>Cluster count of nearby starts</span>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/RouteNoveltyMap.tsx
+++ b/src/components/dashboard/RouteNoveltyMap.tsx
@@ -6,6 +6,8 @@ import Map, {
   Popup,
   MapLayerMouseEvent,
   MapRef,
+  NavigationControl,
+  ScaleControl,
 } from "react-map-gl/maplibre";
 import maplibregl from "maplibre-gl";
 import {
@@ -19,6 +21,7 @@ import {
 import ChartCard from "./ChartCard";
 import { Alert } from "@/components/ui/alert";
 import useRouteNovelty from "@/hooks/useRouteNovelty";
+import RouteNoveltyLegend from "./RouteNoveltyLegend";
 
 export default function RouteNoveltyMap() {
   const [runs, trend, prolongedLow] = useRouteNovelty();
@@ -90,7 +93,7 @@ export default function RouteNoveltyMap() {
 
   return (
     <ChartCard title="Route Novelty" description="Explore how unique your routes are">
-      <div className="h-64 mb-4">
+      <div className="relative h-64 mb-4">
         <Map
           mapLib={maplibregl}
           ref={mapRef}
@@ -191,7 +194,12 @@ export default function RouteNoveltyMap() {
               </div>
             </Popup>
           )}
+          <NavigationControl position="top-left" />
+          <ScaleControl position="bottom-left" />
         </Map>
+        <div className="absolute top-2 right-2 z-10">
+          <RouteNoveltyLegend />
+        </div>
       </div>
       <p className="text-sm text-muted-foreground mt-2">
         Routes are colored by novelty—gray for familiar paths, red for unique ones.


### PR DESCRIPTION
## Summary
- add RouteNoveltyLegend component showing novelty gradient and cluster meaning
- overlay legend on RouteNoveltyMap and add navigation/scale controls

## Testing
- `npm test` *(fails: MileageGlobe tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e4ee58bc4832481f0489b42409a88