### PR TITLE
Add week range selection to MileageGlobe

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -23,7 +23,7 @@ function GlobeRenderer({
 }) {
   const svgRef = useRef<SVGSVGElement | null>(null)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 })
+  const [dimensions, setDimensions] = useState({ width: 300, height: 300 })
 
   useEffect(() => {
     const svg = svgRef.current
@@ -176,9 +176,21 @@ function GlobeRenderer({
   )
 }
 
-export default function MileageGlobe({ years = 1 }: { years?: number }) {
-  const data = useMileageTimeline(years)
+export default function MileageGlobe({
+  weekRange,
+}: {
+  weekRange?: [number, number]
+}) {
+  const data = useMileageTimeline(
+    undefined,
+    weekRange
+      ? { startWeek: weekRange[0], endWeek: weekRange[1] }
+      : undefined,
+  )
   const [selected, setSelected] = useState<GlobePoint | null>(null)
+  useEffect(() => {
+    setSelected(null)
+  }, [weekRange])
 
   if (!data) {
     return (

--- a/src/hooks/__tests__/useMileageTimeline.test.ts
+++ b/src/hooks/__tests__/useMileageTimeline.test.ts
@@ -17,11 +17,28 @@ describe("useMileageTimeline", () => {
     ];
     (getMileageTimeline as any).mockResolvedValue(activities);
     const { result } = renderHook(() => useMileageTimeline());
-    await waitFor(() => result.current !== null);
+    await waitFor(() => expect(result.current).not.toBeNull());
     expect(result.current).toEqual([
       { date: "2025-07-20", miles: 10, cumulativeMiles: 10, coordinates: [[0, 0]] },
       { date: "2025-07-27", miles: 20, cumulativeMiles: 30, coordinates: [[1, 1]] },
       { date: "2025-08-03", miles: 15, cumulativeMiles: 45, coordinates: [[2, 2]] },
+    ]);
+  });
+
+  it("filters activities by week range", async () => {
+    const activities = [
+      { date: "2025-07-20", miles: 10, coordinates: [[0, 0]] },
+      { date: "2025-07-27", miles: 20, coordinates: [[1, 1]] },
+      { date: "2025-08-03", miles: 15, coordinates: [[2, 2]] },
+    ];
+    (getMileageTimeline as any).mockResolvedValue(activities);
+    const { result } = renderHook(() =>
+      useMileageTimeline(undefined, { startWeek: 1, endWeek: 2 }),
+    );
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual([
+      { date: "2025-07-27", miles: 20, cumulativeMiles: 20, coordinates: [[1, 1]] },
+      { date: "2025-08-03", miles: 15, cumulativeMiles: 35, coordinates: [[2, 2]] },
     ]);
   });
 });

--- a/src/hooks/useMileageTimeline.ts
+++ b/src/hooks/useMileageTimeline.ts
@@ -10,22 +10,47 @@ export interface CumulativeMileagePoint {
 
 export default function useMileageTimeline(
   years?: number,
+  range?: { startWeek?: number; endWeek?: number },
 ): CumulativeMileagePoint[] | null {
+  const [raw, setRaw] = useState<MileageTimelinePoint[] | null>(null);
   const [data, setData] = useState<CumulativeMileagePoint[] | null>(null);
+
   useEffect(() => {
-    getMileageTimeline(years).then((points: MileageTimelinePoint[]) => {
-      let total = 0;
-      const cumulative = points.map((p) => {
-        total += p.miles;
-        return {
-          date: p.date,
-          miles: p.miles,
-          cumulativeMiles: total,
-          coordinates: p.coordinates,
-        };
-      });
-      setData(cumulative);
-    });
+    getMileageTimeline(years).then(setRaw);
   }, [years]);
+
+  useEffect(() => {
+    if (!raw) return;
+    const startOfWeek = (date: Date) => {
+      const d = new Date(date);
+      const day = d.getDay();
+      d.setDate(d.getDate() - day);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    };
+
+    const sorted = [...raw].sort((a, b) => a.date.localeCompare(b.date));
+    const origin = startOfWeek(new Date(sorted[0].date));
+    const start = range?.startWeek ?? 0;
+    const end = range?.endWeek ?? Number.MAX_SAFE_INTEGER;
+    let total = 0;
+    const filtered: CumulativeMileagePoint[] = [];
+    for (const p of sorted) {
+      const weekIndex = Math.floor(
+        (startOfWeek(new Date(p.date)).getTime() - origin.getTime()) /
+          (7 * 24 * 60 * 60 * 1000),
+      );
+      if (weekIndex < start || weekIndex > end) continue;
+      total += p.miles;
+      filtered.push({
+        date: p.date,
+        miles: p.miles,
+        cumulativeMiles: total,
+        coordinates: p.coordinates,
+      });
+    }
+    setData(filtered);
+  }, [raw, range?.startWeek, range?.endWeek]);
+
   return data;
 }

--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -1,9 +1,17 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import MileageGlobe from "@/components/examples/MileageGlobe";
 import Slider from "@/components/ui/slider";
+import useWeeklyVolumeHistory from "@/hooks/useWeeklyVolumeHistory";
 
 export default function MileageGlobePage() {
-  const [years, setYears] = useState(1);
+  const weekly = useWeeklyVolumeHistory();
+  const [range, setRange] = useState<[number, number] | null>(null);
+
+  useEffect(() => {
+    if (weekly) {
+      setRange([Math.max(0, weekly.length - 52), weekly.length - 1]);
+    }
+  }, [weekly]);
 
   return (
     <div className="space-y-4">
@@ -12,18 +20,25 @@ export default function MileageGlobePage() {
         Explore your activities on an interactive 3D globe. Drag to rotate, and use your
         mouse wheel or touchpad to zoom. Click on a path to inspect mileage.
       </p>
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Years of data: {years}</label>
-        <Slider
-          min={1}
-          max={5}
-          step={1}
-          value={[years]}
-          onValueChange={(val) => setYears(val[0])}
-          className="w-48"
-        />
-      </div>
-      <MileageGlobe years={years} />
+      {weekly && range && (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">
+            Week range: {new Date(weekly[range[0]].week).toLocaleDateString()} -
+            {" "}
+            {new Date(weekly[range[1]].week).toLocaleDateString()}
+          </label>
+          <Slider
+            numberOfThumbs={2}
+            min={0}
+            max={weekly.length - 1}
+            step={1}
+            value={range}
+            onValueChange={(val) => setRange(val as [number, number])}
+            className="w-48"
+          />
+        </div>
+      )}
+      <MileageGlobe weekRange={range ?? undefined} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use weekly volume history to drive a two-thumb week range slider in MileageGlobe page
- allow useMileageTimeline to filter activities by week index range
- forward weekRange through MileageGlobe component and reset selection on range changes

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688e5214a5488324968c734de440e758