### PR TITLE
feat: add filters for good day map

### DIFF
--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -22,12 +22,32 @@ import type { ChartConfig } from "@/components/ui/chart"
 
 interface GoodDayMapProps {
   data: SessionPoint[] | null
+  condition?: string | null
+  hourRange?: [number, number]
 }
 
-export default function GoodDayMap({ data }: GoodDayMapProps) {
+export default function GoodDayMap({ data, condition, hourRange = [0, 23] }: GoodDayMapProps) {
   if (!data) return <Skeleton className="h-64" />
 
-  const goodSessions = data.filter((d) => d.good)
+  const goodSessions = data.filter(
+    (d) =>
+      d.good &&
+      (!condition || d.condition === condition) &&
+      d.startHour >= hourRange[0] &&
+      d.startHour <= hourRange[1],
+  )
+
+  if (!goodSessions.length)
+    return (
+      <ChartCard
+        title="Good Day Sessions"
+        description="Sessions exceeding expectations"
+      >
+        <div className="flex items-center justify-center h-64 md:h-80 lg:h-96 text-sm text-muted-foreground">
+          No sessions match the selected filters.
+        </div>
+      </ChartCard>
+    )
   const style = getComputedStyle(document.documentElement)
   const start = `hsl(${style.getPropertyValue("--chart-4")})`
   const end = `hsl(${style.getPropertyValue("--chart-6")})`

--- a/src/pages/GoodDay.tsx
+++ b/src/pages/GoodDay.tsx
@@ -1,9 +1,18 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { GoodDayMap } from "@/components/statistics";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
+import { SimpleSelect } from "@/components/ui/select";
+import Slider from "@/components/ui/slider";
 
 export default function GoodDayPage() {
   const sessions = useRunningSessions();
+  const [condition, setCondition] = useState("all");
+  const [hourRange, setHourRange] = useState<[number, number]>([0, 23]);
+
+  const conditions = useMemo(
+    () => (sessions ? Array.from(new Set(sessions.map((s) => s.condition))) : []),
+    [sessions],
+  );
 
   return (
     <div className="p-4 space-y-4">
@@ -11,7 +20,50 @@ export default function GoodDayPage() {
       <p className="text-sm text-muted-foreground">
         Sessions that exceeded expectations are highlighted below.
       </p>
-      <GoodDayMap data={sessions} />
+      {sessions && (
+        <div className="flex gap-4 flex-wrap items-center">
+          <SimpleSelect
+            label="Condition"
+            value={condition}
+            onValueChange={setCondition}
+            options={[
+              { value: "all", label: "All" },
+              ...conditions.map((c) => ({ value: c, label: c })),
+            ]}
+          />
+          <div className="flex items-center gap-2">
+            <label className="text-sm">Start Hour: {hourRange[0]}</label>
+            <Slider
+              min={0}
+              max={23}
+              step={1}
+              value={[hourRange[0]]}
+              onValueChange={(val) =>
+                setHourRange([val[0], Math.max(val[0], hourRange[1])])
+              }
+              className="w-40"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm">End Hour: {hourRange[1]}</label>
+            <Slider
+              min={0}
+              max={23}
+              step={1}
+              value={[hourRange[1]]}
+              onValueChange={(val) =>
+                setHourRange([Math.min(val[0], hourRange[0]), val[0]])
+              }
+              className="w-40"
+            />
+          </div>
+        </div>
+      )}
+      <GoodDayMap
+        data={sessions}
+        condition={condition === "all" ? null : condition}
+        hourRange={hourRange}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add weather condition dropdown and hour range sliders to Good Day page
- filter good sessions by selected condition and start hour range before plotting

## Testing
- `npm test` *(fails: MileageGlobe test)*

------
https://chatgpt.com/codex/tasks/task_e_688e45323de883248578efe1c6bc76ea