### PR TITLE
refactor: centralize route metrics

### DIFF
--- a/src/hooks/useRouteSimilarity.ts
+++ b/src/hooks/useRouteSimilarity.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import { calculateRouteSimilarity, Route } from '@/lib/api'
+import { Route } from '@/lib/api'
+import { computeRouteMetrics } from '@/lib/routeMetrics'
 
 /**
  * React hook to compute the Jaccard similarity between two routes.
@@ -13,7 +14,12 @@ export function useRouteSimilarity(
 ): number | null {
   return useMemo(() => {
     if (!routeA || !routeB) return null
-    return calculateRouteSimilarity(routeA.points, routeB.points, precision)
+    const { overlapSimilarity } = computeRouteMetrics(
+      routeA.points,
+      routeB.points,
+      precision,
+    )
+    return overlapSimilarity
   }, [routeA, routeB, precision])
 }
 

--- a/src/lib/routeMetrics.ts
+++ b/src/lib/routeMetrics.ts
@@ -1,0 +1,43 @@
+import type { LatLon } from './api'
+
+export function calculateRouteSimilarity(
+  a: LatLon[],
+  b: LatLon[],
+  precision = 3,
+): number {
+  const toKey = ({ lat, lon }: LatLon) => `${lat.toFixed(precision)},${lon.toFixed(precision)}`
+  const setA = new Set(a.map(toKey))
+  const setB = new Set(b.map(toKey))
+  const intersection = [...setA].filter((p) => setB.has(p))
+  const union = new Set([...setA, ...setB])
+  return union.size === 0 ? 0 : intersection.length / union.size
+}
+
+function dtwDistance(a: LatLon[], b: LatLon[]): number {
+  const n = a.length
+  const m = b.length
+  const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(Infinity))
+  dp[0][0] = 0
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      const cost = Math.hypot(
+        a[i - 1].lat - b[j - 1].lat,
+        a[i - 1].lon - b[j - 1].lon,
+      )
+      dp[i][j] = cost + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+    }
+  }
+  return dp[n][m] / (n + m)
+}
+
+export function computeRouteMetrics(
+  a: LatLon[],
+  b: LatLon[],
+  precision = 3,
+): { overlapSimilarity: number; dtwSimilarity: number; maxSimilarity: number } {
+  const overlapSimilarity = calculateRouteSimilarity(a, b, precision)
+  const dtwSimilarity = 1 / (1 + dtwDistance(a, b))
+  const maxSimilarity = Math.max(overlapSimilarity, dtwSimilarity)
+  return { overlapSimilarity, dtwSimilarity, maxSimilarity }
+}
+


### PR DESCRIPTION
## Summary
- centralize route overlap and DTW calculations in new routeMetrics utility
- compute route novelty using combined metrics
- expose overlap results through updated useRouteSimilarity hook

## Testing
- `npm test` *(fails: MileageGlobe tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e4eaa3ce88324a94c37b9fb82da44