### PR TITLE
feat: show session details in good day map

### DIFF
--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -19,6 +19,8 @@ import { SessionPoint } from "@/hooks/useRunningSessions"
 import { Skeleton } from "@/components/ui/skeleton"
 import { scaleLinear } from "d3-scale"
 import type { ChartConfig } from "@/components/ui/chart"
+import { useState } from "react"
+import SessionDetailDrawer from "./SessionDetailDrawer"
 
 interface GoodDayMapProps {
   data: SessionPoint[] | null
@@ -60,6 +62,7 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23] }: Goo
   const maxDelta = Math.max(...goodSessions.map((d) => d.paceDelta))
   const colorScale = scaleLinear<string>().domain([minDelta, maxDelta]).range([start, end])
   const colored = goodSessions.map((s) => ({ ...s, fill: colorScale(s.paceDelta) }))
+  const [active, setActive] = useState<SessionPoint | null>(null)
 
   return (
     <ChartCard
@@ -79,13 +82,20 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23] }: Goo
             ]}
             content={<ChartLegendContent />}
           />
-          <Scatter data={colored} shape="star" animationDuration={300}>
+          <Scatter
+            data={colored}
+            shape="star"
+            animationDuration={300}
+            onClick={(data) => setActive(data as SessionPoint)}
+            cursor="pointer"
+          >
             {colored.map((entry, idx) => (
               <Cell key={`cell-${idx}`} fill={entry.fill} />
             ))}
           </Scatter>
         </ScatterChart>
       </ChartContainer>
+      <SessionDetailDrawer session={active} onClose={() => setActive(null)} />
     </ChartCard>
   )
 }

--- a/src/components/statistics/SessionDetailDrawer.tsx
+++ b/src/components/statistics/SessionDetailDrawer.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import Map, { Marker } from "react-map-gl/maplibre"
+import maplibregl from "maplibre-gl"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { SessionPoint } from "@/hooks/useRunningSessions"
+
+interface SessionDetailDrawerProps {
+  session: SessionPoint | null
+  onClose: () => void
+}
+
+export default function SessionDetailDrawer({ session, onClose }: SessionDetailDrawerProps) {
+  return (
+    <Sheet open={!!session} onOpenChange={(open) => { if (!open) onClose() }}>
+      <SheetContent side="right" className="w-80 sm:w-96">
+        <SheetHeader>
+          <SheetTitle>Session Details</SheetTitle>
+        </SheetHeader>
+        {session && (
+          <div className="space-y-4">
+            <div className="h-48 w-full">
+              <Map
+                mapLib={maplibregl}
+                mapStyle="https://demotiles.maplibre.org/style.json"
+                initialViewState={{ longitude: session.lon, latitude: session.lat, zoom: 12 }}
+                attributionControl={false}
+                style={{ width: "100%", height: "100%" }}
+              >
+                <Marker longitude={session.lon} latitude={session.lat}>
+                  <circle r={4} fill="hsl(var(--primary))" />
+                </Marker>
+              </Map>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <span>Pace: {session.pace.toFixed(2)} min/mi</span>
+              <span>Δ Pace: {session.paceDelta.toFixed(2)} min/mi</span>
+              <span>Heart Rate: {session.heartRate} bpm</span>
+              <span>Temp: {session.temperature}°F</span>
+              <span>Humidity: {session.humidity}%</span>
+              <span>Wind: {session.wind} mph</span>
+              <span>Start Hour: {session.startHour}</span>
+              <span>Duration: {session.duration} min</span>
+            </div>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}


### PR DESCRIPTION
## Summary
- add SessionDetailDrawer component to show map and metrics
- enable clicking GoodDayMap points to open drawer

## Testing
- `npm test` *(fails: expected null to deeply equal [...])*


------
https://chatgpt.com/codex/tasks/task_e_688e57fa7058832482a9567ff585f235