### PR TITLE
Aggregate mileage paths and show totals on globe

### DIFF
--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import MileageGlobe from "../MileageGlobe";
 import useMileageTimeline from "@/hooks/useMileageTimeline";
@@ -23,7 +23,7 @@ describe("MileageGlobe", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders mileage paths when data is available", async () => {
+  it("renders mileage path when data is available", async () => {
     mockUseMileageTimeline.mockReturnValue([
       {
         date: "2024-01-01",
@@ -47,46 +47,39 @@ describe("MileageGlobe", () => {
     const { container } = render(<MileageGlobe />);
 
     await waitFor(() => {
-      const path = container.querySelector("path[stroke='var(--primary)']");
-      expect(path).toBeTruthy();
-    });
-  });
-
-  it("displays selected mileage when path is clicked", async () => {
-    mockUseMileageTimeline.mockReturnValue([
-      {
-        date: "2024-01-01",
-        miles: 5,
-        cumulativeMiles: 5,
-        coordinates: [
-          [0, 0],
-          [10, 10],
-        ],
-      },
-    ]);
-
-    global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          type: "Topology",
-          objects: { countries: { type: "GeometryCollection", geometries: [] } },
-        }),
-    }) as any;
-
-    const { container } = render(<MileageGlobe />);
-
-    let path: SVGPathElement | null = null;
-    await waitFor(() => {
-      path = container.querySelector(
+      const path = container.querySelector(
         "path[stroke='var(--primary)']",
       ) as SVGPathElement | null;
       expect(path).toBeTruthy();
+      expect(path?.getAttribute("stroke-width")).toBe("1.1");
     });
+  });
 
-    fireEvent.click(path!);
+  it("displays total mileage", async () => {
+    mockUseMileageTimeline.mockReturnValue([
+      {
+        date: "2024-01-01",
+        miles: 5,
+        cumulativeMiles: 5,
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      },
+    ]);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          type: "Topology",
+          objects: { countries: { type: "GeometryCollection", geometries: [] } },
+        }),
+    }) as any;
+
+    render(<MileageGlobe />);
 
     await waitFor(() => {
-      expect(screen.getByText("2024-01-01: 5 miles")).toBeInTheDocument();
+      expect(screen.getByText("Total: 5 miles")).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -18,7 +18,8 @@ export default function MileageGlobePage() {
       <h2 className="text-xl font-semibold">Mileage Globe</h2>
       <p className="text-sm text-muted-foreground">
         Explore your activities on an interactive 3D globe. Drag to rotate, and use your
-        mouse wheel or touchpad to zoom. Click on a path to inspect mileage.
+        mouse wheel or touchpad to zoom. Total mileage for the selected period is shown
+        below the globe.
       </p>
       {weekly && range && (
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Flatten filtered activity coordinates into a single path and render one mileage line with width scaling by total miles
- Show total mileage below the globe and adjust page copy accordingly
- Update tests for aggregated path and mileage summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5424d2f483248dcb7a48a755f26d