### PR TITLE
feat: add icons to route groups

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -109,37 +109,41 @@ export default function AppSidebar() {
             <SidebarGroupLabel>Charts</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {filteredChartGroups.map((group, index) => (
-                  <Collapsible.Root
-                    key={group.label}
-                    open={openGroups[group.label] ?? index === 0}
-                    onOpenChange={handleOpenChange(group.label)}
-                  >
-                    <SidebarMenuItem>
-                      <Collapsible.Trigger asChild>
-                        <SidebarMenuButton className="justify-start">
-                          {highlight(group.label)}
-                          <ChevronRight className="ml-auto transition-transform data-[state=open]:rotate-90" />
-                        </SidebarMenuButton>
-                      </Collapsible.Trigger>
-                      <Collapsible.Content>
-                        <SidebarMenuSub>
-                          {group.items.map((route) => (
-                            <SidebarMenuSubItem key={route.to}>
-                              <SidebarMenuSubButton
-                                asChild
-                                isActive={pathname === route.to}
-                                className="justify-start"
-                              >
-                                <NavLink to={route.to}>{highlight(route.label)}</NavLink>
-                              </SidebarMenuSubButton>
-                            </SidebarMenuSubItem>
-                          ))}
-                        </SidebarMenuSub>
-                      </Collapsible.Content>
-                    </SidebarMenuItem>
-                  </Collapsible.Root>
-                ))}
+                {filteredChartGroups.map((group, index) => {
+                  const Icon = group.icon;
+                  return (
+                    <Collapsible.Root
+                      key={group.label}
+                      open={openGroups[group.label] ?? index === 0}
+                      onOpenChange={handleOpenChange(group.label)}
+                    >
+                      <SidebarMenuItem>
+                        <Collapsible.Trigger asChild>
+                          <SidebarMenuButton className="justify-start">
+                            <Icon className="mr-2 h-4 w-4" />
+                            {highlight(group.label)}
+                            <ChevronRight className="ml-auto transition-transform data-[state=open]:rotate-90" />
+                          </SidebarMenuButton>
+                        </Collapsible.Trigger>
+                        <Collapsible.Content>
+                          <SidebarMenuSub>
+                            {group.items.map((route) => (
+                              <SidebarMenuSubItem key={route.to}>
+                                <SidebarMenuSubButton
+                                  asChild
+                                  isActive={pathname === route.to}
+                                  className="justify-start"
+                                >
+                                  <NavLink to={route.to}>{highlight(route.label)}</NavLink>
+                                </SidebarMenuSubButton>
+                              </SidebarMenuSubItem>
+                            ))}
+                          </SidebarMenuSub>
+                        </Collapsible.Content>
+                      </SidebarMenuItem>
+                    </Collapsible.Root>
+                  );
+                })}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,28 @@
-export const dashboardRoutes = [
+import type { LucideIcon } from "lucide-react";
+import {
+  ChartArea,
+  ChartBar,
+  ChartLine,
+  ChartPie,
+  FlaskConical,
+  Radar,
+} from "lucide-react";
+
+export interface DashboardRoute {
+  to: string;
+  label: string;
+}
+
+export interface DashboardRouteGroup {
+  label: string;
+  icon: LucideIcon;
+  items: DashboardRoute[];
+}
+
+export const dashboardRoutes: DashboardRouteGroup[] = [
   {
     label: "Playground",
+    icon: FlaskConical,
     items: [
       { to: "/dashboard/map", label: "Map playground" },
       { to: "/dashboard/route-similarity", label: "Route similarity" },
@@ -9,6 +31,7 @@ export const dashboardRoutes = [
   },
   {
     label: "Analytics",
+    icon: ChartLine,
     items: [
       { to: "/dashboard/mileage-globe", label: "Mileage Globe" },
       { to: "/dashboard/fragility", label: "Fragility" },
@@ -19,12 +42,10 @@ export const dashboardRoutes = [
   },
 ];
 
-export type DashboardRouteGroup = (typeof dashboardRoutes)[number];
-export type DashboardRoute = DashboardRouteGroup["items"][number];
-
 export const chartRouteGroups: DashboardRouteGroup[] = [
   {
     label: "Area Charts",
+    icon: ChartArea,
     items: [
       { to: "/dashboard/charts/area-chart-interactive", label: "Area Chart Interactive" },
       { to: "/dashboard/charts/steps-trend-with-goal", label: "Steps Trend With Goal" },
@@ -36,6 +57,7 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
   },
   {
     label: "Bar Charts",
+    icon: ChartBar,
     items: [
       { to: "/dashboard/charts/bar-chart-interactive", label: "Bar Chart Interactive" },
       { to: "/dashboard/charts/bar-chart-default", label: "Bar Chart Default" },
@@ -50,6 +72,7 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
   },
   {
     label: "Radar Charts",
+    icon: Radar,
     items: [
       { to: "/dashboard/charts/radar-chart-default", label: "Radar Chart Default" },
       { to: "/dashboard/charts/radar-chart-workout-by-time", label: "Radar Chart Workout By Time" },
@@ -60,6 +83,7 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
   },
   {
     label: "Radial Charts",
+    icon: ChartPie,
     items: [
       { to: "/dashboard/charts/radial-chart-label", label: "Radial Chart Label" },
       { to: "/dashboard/charts/radial-chart-text", label: "Radial Chart Text" },


### PR DESCRIPTION
## Summary
- add icon property to dashboard route groups
- show route group icons in the sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8e7368e08324a8518bb4ae170a5b