### PR TITLE
feat: constrain mileage globe width

### DIFF
--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -39,7 +39,9 @@ export default function MileageGlobePage() {
           />
         </div>
       )}
-      <MileageGlobe weekRange={range ?? undefined} />
+      <div className="mx-auto max-w-md">
+        <MileageGlobe weekRange={range ?? undefined} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap MileageGlobe in a centered max-width container to prevent overflow

## Testing
- `npm test -- --run` *(fails: useFragilityHistory test)*

------
https://chatgpt.com/codex/tasks/task_e_688e903623388324bee2691f20ebb6c3