### PR TITLE
feat: add accessible breadcrumbs to layout

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link, useLocation } from "react-router-dom";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import AppSidebar from "@/components/app-sidebar";
 import CommandPalette from "@/components/ui/CommandPalette";
@@ -20,6 +21,44 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
+function Breadcrumbs() {
+  const location = useLocation();
+  const segments = location.pathname.split("/").filter(Boolean);
+
+  if (!segments.length) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="flex overflow-hidden">
+      <ol className="flex items-center text-sm text-muted-foreground">
+        {segments.map((segment, idx) => {
+          const path = "/" + segments.slice(0, idx + 1).join("/");
+          const label = decodeURIComponent(segment)
+            .replace(/-/g, " ")
+            .replace(/\b\w/g, (c) => c.toUpperCase());
+          const isLast = idx === segments.length - 1;
+          return (
+            <li key={path} className="inline-flex items-center">
+              {isLast ? (
+                <span aria-current="page" className="font-medium text-foreground">
+                  {label}
+                </span>
+              ) : (
+                <Link
+                  to={path}
+                  className="hover:underline focus:outline-none focus:underline"
+                >
+                  {label}
+                </Link>
+              )}
+              {!isLast && <span className="px-2">&gt;</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
 export default function Layout({ children }: LayoutProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -29,7 +68,10 @@ export default function Layout({ children }: LayoutProps) {
       <CommandPalette open={open} setOpen={setOpen} />
       <SidebarInset>
         <header className="flex items-center justify-between p-4">
-          <SidebarTrigger />
+          <div className="flex items-center gap-2">
+            <SidebarTrigger />
+            <Breadcrumbs />
+          </div>
           <div className="flex items-center gap-2">
             <TooltipProvider delayDuration={100}>
               <Tooltip>


### PR DESCRIPTION
## Summary
- add Breadcrumbs component deriving segments from `react-router-dom` location
- display breadcrumb hierarchy in layout header before action buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e95376654832489b5867eb0b2464a