### PR TITLE
feat: improve mileage globe path visibility

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -101,8 +101,12 @@ function GlobeRenderer({
           .append('path')
           .datum({ type: 'LineString', coordinates: path } as any)
           .attr('fill', 'none')
-          .attr('stroke', 'var(--primary)')
-          .attr('stroke-width', Math.min(10, 1 + totalMiles / 50))
+          .attr('stroke', 'var(--primary-foreground)')
+          .attr(
+            'stroke-width',
+            Math.max(2, Math.min(10, 1 + totalMiles / 50))
+          )
+          .attr('stroke-linecap', 'round')
           .attr('opacity', 0.8)
 
         render()

--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -48,10 +48,11 @@ describe("MileageGlobe", () => {
 
     await waitFor(() => {
       const path = container.querySelector(
-        "path[stroke='var(--primary)']",
+        "path[stroke='var(--primary-foreground)']",
       ) as SVGPathElement | null;
       expect(path).toBeTruthy();
-      expect(path?.getAttribute("stroke-width")).toBe("1.1");
+      expect(path?.getAttribute("stroke-width")).toBe("2");
+      expect(path?.getAttribute("stroke-linecap")).toBe("round");
     });
   });
 


### PR DESCRIPTION
## Summary
- add minimum stroke width and rounded line caps for MileageGlobe path
- improve path contrast with primary-foreground color
- update tests to cover new path rendering and attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e9b2434fc8324a91dbfb232a40d7f