### PR TITLE
style: improve bar chart tick display and spacing

### DIFF
--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -34,9 +34,23 @@ export default function WeeklyVolumeChart() {
   return (
     <ChartCard title="Weekly Volume" description="Historical weekly mileage totals">
       <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
-        <BarChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <BarChart
+          data={data}
+          margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+        >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <XAxis
+            dataKey="week"
+            interval="preserveStartEnd"
+            tickFormatter={(d) => {
+              const date = new Date(d)
+              return (
+                date.toLocaleString('en-US', { month: 'short' }) +
+                " '" +
+                date.toLocaleString('en-US', { year: '2-digit' })
+              )
+            }}
+          />
           <ChartTooltip />
           <Bar dataKey="miles" fill="var(--chart-1)" radius={2} animationDuration={300} />
           <Brush

--- a/src/components/examples/BarChartDefault.tsx
+++ b/src/components/examples/BarChartDefault.tsx
@@ -47,14 +47,26 @@ export default function ChartBarDefault() {
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig} className='h-60 md:h-80 lg:h-96'>
-          <BarChart accessibilityLayer data={chartData}>
+          <BarChart
+            accessibilityLayer
+            data={chartData}
+            margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+          >
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey='month'
               tickLine={false}
               tickMargin={10}
               axisLine={false}
-              tickFormatter={(value) => value.slice(0, 3)}
+              interval={1}
+              tickFormatter={(value) => {
+                const date = new Date(`${value} 1, 2024`)
+                return (
+                  date.toLocaleString('en-US', { month: 'short' }) +
+                  " '" +
+                  date.toLocaleString('en-US', { year: '2-digit' })
+                )
+              }}
             />
             <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
             <Bar dataKey='miles' fill='var(--color-miles)' radius={8} />

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -40,9 +40,23 @@ export default function WeeklyVolumeHistoryChart() {
       description="Historical weekly mileage totals (run + bike)"
     >
       <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
-        <BarChart data={filtered} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <BarChart
+          data={filtered}
+          margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+        >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="week" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
+          <XAxis
+            dataKey="week"
+            interval="preserveStartEnd"
+            tickFormatter={(d) => {
+              const date = new Date(d)
+              return (
+                date.toLocaleString('en-US', { month: 'short' }) +
+                " '" +
+                date.toLocaleString('en-US', { year: '2-digit' })
+              )
+            }}
+          />
           <ChartTooltip
             content={
               <ChartTooltipContent

--- a/src/components/statistics/EquipmentUsageTimeline.tsx
+++ b/src/components/statistics/EquipmentUsageTimeline.tsx
@@ -35,9 +35,25 @@ export default function EquipmentUsageTimeline() {
       description="Bike and shoe usage over time"
     >
       <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
-        <BarChart data={usageData} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+        <BarChart
+          data={usageData}
+          margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+        >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" tickLine={false} axisLine={false} />
+          <XAxis
+            dataKey="month"
+            tickLine={false}
+            axisLine={false}
+            interval={1}
+            tickFormatter={(d) => {
+              const date = new Date(`${d} 1, 2024`)
+              return (
+                date.toLocaleString('en-US', { month: 'short' }) +
+                " '" +
+                date.toLocaleString('en-US', { year: '2-digit' })
+              )
+            }}
+          />
           <ReferenceLine y={REPLACEMENT_MILES} stroke={config.replacement.color} strokeDasharray="4 4" />
           <ChartTooltip />
           <Bar dataKey="shoe" stackId="usage" fill={config.shoe.color} />


### PR DESCRIPTION
## Summary
- abbreviate X axis ticks and space bars in the example bar chart
- trim weekly volume history ticks and show month/year
- do the same for dashboard weekly volume and equipment usage charts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e9d7de50083249ca2999ab7d787b9