### PR TITLE
feat: generate varied sessions for good day stars

### DIFF
--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -67,9 +67,12 @@ export function useRunningSessions(): SessionPoint[] | null {
   useEffect(() => {
     function expectedPace(s: RunningSession): number {
       const hour = new Date(s.start ?? s.date).getHours()
-      const tempAdj = (s.weather.temperature - 55) * 0.02
-      const humidAdj = (s.weather.humidity - 50) * 0.01
-      const windAdj = s.weather.wind * 0.01
+      const temp = s.weather.temperature || 55
+      const humidity = s.weather.humidity || 50
+      const wind = s.weather.wind || 0
+      const tempAdj = (temp - 55) * 0.02
+      const humidAdj = (humidity - 50) * 0.01
+      const windAdj = wind * 0.01
       const conditionAdjMap: Record<string, number> = {
         Clear: -0.05,
         Cloudy: 0.02,
@@ -108,7 +111,7 @@ export function useRunningSessions(): SessionPoint[] | null {
             x,
             y,
             cluster: labels[idx],
-            good: sessions[idx].pace < expected - 0.2,
+            good: paceDelta > 0,
             pace: sessions[idx].pace,
             paceDelta,
             heartRate: sessions[idx].heartRate,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -926,13 +926,23 @@ export function generateMockRunningSessions(): RunningSession[] {
     { lat: 29.7604, lon: -95.3698 }, // Houston
   ]
 
+  const conditions = [
+    "Clear",
+    "Cloudy",
+    "Fog",
+    "Drizzle",
+    "Rain",
+    "Snow",
+    "Storm",
+  ];
+
   return Array.from({ length: 30 }, (_, i) => {
-    const pace = +(5 + Math.random() * 3).toFixed(2);
+    const pace = +(4 + Math.random() * 4).toFixed(2);
     const base = new Date();
     base.setDate(base.getDate() - i);
     const startHour = 5 + Math.round(Math.random() * 14); // 5 AM - 7 PM
     base.setHours(startHour, 0, 0, 0);
-    const { lat, lon } = coords[i % coords.length]
+    const { lat, lon } = coords[i % coords.length];
     return {
       id: i + 1,
       pace,
@@ -943,10 +953,10 @@ export function generateMockRunningSessions(): RunningSession[] {
       lat,
       lon,
       weather: {
-        temperature: 0,
-        humidity: 0,
-        wind: 0,
-        condition: "Unknown",
+        temperature: Math.round(45 + Math.random() * 40),
+        humidity: Math.round(30 + Math.random() * 60),
+        wind: Math.round(Math.random() * 15),
+        condition: conditions[i % conditions.length],
       },
     };
   });
@@ -968,7 +978,7 @@ export async function getRunningSessions(): Promise<RunningSession[]> {
     });
     sessions.forEach((s) => {
       const w = map[s.date];
-      if (w) {
+      if (w && (w.temperature || w.humidity || w.wind)) {
         s.weather = {
           temperature: w.temperature,
           humidity: w.humidity,


### PR DESCRIPTION
## Summary
- vary mock running session pace and weather and skip empty weather API results
- relax expected pace check to flag more `good` sessions

## Testing
- `npm test`
- `npx tsx checkGood.ts` *(temporary)*

------
https://chatgpt.com/codex/tasks/task_e_688e9b7ca88083249f5b2684c4b3dbf1