### PR TITLE
Add correlation matrix hook with typed API

### DIFF
--- a/src/hooks/__tests__/useCorrelationMatrix.test.ts
+++ b/src/hooks/__tests__/useCorrelationMatrix.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { computeCorrelationMatrix, type MetricPoint } from '../useCorrelationMatrix'
+
+describe('computeCorrelationMatrix', () => {
+  it('computes correlations between metrics', () => {
+    interface SamplePoint extends MetricPoint {
+      a: number
+      b: number
+      c: number
+    }
+    const points: SamplePoint[] = [
+      { a: 1, b: 2, c: 5 },
+      { a: 2, b: 4, c: 4 },
+      { a: 3, b: 6, c: 3 },
+      { a: 4, b: 8, c: 2 },
+      { a: 5, b: 10, c: 1 },
+    ]
+    const matrix = computeCorrelationMatrix(points)
+    expect(matrix.a.a).toBeCloseTo(1)
+    expect(matrix.a.b).toBeCloseTo(1)
+    expect(matrix.a.c).toBeCloseTo(-1)
+    expect(matrix.b.c).toBeCloseTo(-1)
+  })
+})
+

--- a/src/hooks/useCorrelationMatrix.ts
+++ b/src/hooks/useCorrelationMatrix.ts
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+
+export type MetricPoint = Record<string, number>;
+
+export type CorrelationMatrix<T extends MetricPoint> = {
+  [K in keyof T]: { [K2 in keyof T]: number };
+};
+
+function pearson(x: number[], y: number[]): number {
+  const n = x.length;
+  if (n === 0) return 0;
+  const meanX = x.reduce((sum, v) => sum + v, 0) / n;
+  const meanY = y.reduce((sum, v) => sum + v, 0) / n;
+  let num = 0;
+  let denomX = 0;
+  let denomY = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = x[i] - meanX;
+    const dy = y[i] - meanY;
+    num += dx * dy;
+    denomX += dx * dx;
+    denomY += dy * dy;
+  }
+  return denomX && denomY ? num / Math.sqrt(denomX * denomY) : 0;
+}
+
+export function computeCorrelationMatrix<T extends MetricPoint>(
+  points: T[],
+): CorrelationMatrix<T> {
+  if (!points.length) return {} as CorrelationMatrix<T>;
+  const keys = Object.keys(points[0]) as (keyof T)[];
+  const series: Record<keyof T, number[]> = {} as any;
+  for (const key of keys) {
+    series[key] = points.map((p) => p[key]);
+  }
+  const matrix = {} as CorrelationMatrix<T>;
+  for (const k1 of keys) {
+    matrix[k1] = {} as Record<keyof T, number>;
+    for (const k2 of keys) {
+      matrix[k1][k2] = pearson(series[k1], series[k2]);
+    }
+  }
+  return matrix;
+}
+
+export function useCorrelationMatrix<T extends MetricPoint>(
+  points: T[],
+): CorrelationMatrix<T> {
+  return useMemo(() => computeCorrelationMatrix(points), [points]);
+}
+
+export default useCorrelationMatrix;
+


### PR DESCRIPTION
## Summary
- add reusable `useCorrelationMatrix` hook with generic typing
- test correlation matrix computation across metrics

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688ea8e0538c8324873d20f4eca59fe9