### PR TITLE
Add CorrelationRippleMatrix visualization

### DIFF
--- a/src/components/visualizations/CorrelationRippleMatrix.tsx
+++ b/src/components/visualizations/CorrelationRippleMatrix.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  Rectangle,
+  LineChart,
+  Line,
+  Tooltip,
+} from "recharts";
+
+interface CorrelationRippleMatrixProps {
+  matrix: number[][]; // correlation values between -1 and 1
+  labels: string[]; // axis labels
+  drilldown?: Record<string, { x: number; y: number }[]>; // optional mini chart data
+}
+
+interface CellData {
+  x: number; // column index
+  y: number; // row index
+  value: number;
+}
+
+const cellSize = 24;
+
+// simple blue to red scale
+function colorScale(v: number) {
+  const hue = v >= 0 ? 0 : 240; // red for positive, blue for negative
+  const saturation = Math.round(Math.abs(v) * 100);
+  return `hsl(${hue}, ${saturation}%, 50%)`;
+}
+
+export default function CorrelationRippleMatrix({
+  matrix,
+  labels,
+  drilldown = {},
+}: CorrelationRippleMatrixProps) {
+  const [active, setActive] = useState<CellData | null>(null);
+
+  const heatData: CellData[] = matrix.flatMap((row, y) =>
+    row.map((value, x) => ({ x, y, value }))
+  );
+
+  const handleCellClick = (cell: CellData) => {
+    setActive(cell);
+  };
+
+  const activeKey = active ? `${active.y}-${active.x}` : null;
+  const chartData = activeKey && drilldown[activeKey] ? drilldown[activeKey] : [];
+
+  const width = labels.length * cellSize;
+  const height = labels.length * cellSize;
+
+  return (
+    <div className="relative" style={{ width, height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+          <XAxis
+            type="number"
+            dataKey="x"
+            tickFormatter={(i) => labels[i] || ""}
+            ticks={labels.map((_, i) => i)}
+            interval={0}
+            tickLine={false}
+            axisLine={false}
+          />
+          <YAxis
+            type="number"
+            dataKey="y"
+            tickFormatter={(i) => labels[i] || ""}
+            ticks={labels.map((_, i) => i)}
+            interval={0}
+            tickLine={false}
+            axisLine={false}
+          />
+          <Scatter data={heatData} shape={(props: any) => {
+            const { cx, cy, payload } = props;
+            const x = cx - cellSize / 2;
+            const y = cy - cellSize / 2;
+            return (
+              <Rectangle
+                x={x}
+                y={y}
+                width={cellSize}
+                height={cellSize}
+                fill={colorScale(payload.value)}
+                stroke="#ffffff"
+                onClick={() => handleCellClick(payload as CellData)}
+                cursor="pointer"
+              />
+            );
+          }} />
+        </ScatterChart>
+      </ResponsiveContainer>
+      {active && chartData.length > 0 && (
+        <div
+          className="absolute bg-white border p-2 rounded shadow"
+          style={{
+            left: active.x * cellSize + cellSize / 2,
+            top: active.y * cellSize + cellSize / 2,
+            transform: "translate(-50%, -50%)",
+            animation: "ripple 0.3s ease-out",
+            pointerEvents: "auto",
+          }}
+          onClick={() => setActive(null)}
+        >
+          <LineChart width={150} height={80} data={chartData}>
+            <Line type="monotone" dataKey="y" stroke="#8884d8" dot={false} />
+            <Tooltip />
+          </LineChart>
+        </div>
+      )}
+      <style>{`
+        @keyframes ripple {
+          from { transform: translate(-50%, -50%) scale(0.2); opacity: 0; }
+          to { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/visualizations/index.ts
+++ b/src/components/visualizations/index.ts
@@ -1,2 +1,3 @@
 export { default as BehavioralCharterMap } from "./BehavioralCharterMap";
 export { default as TransitionMatrix } from "./TransitionMatrix";
+export { default as CorrelationRippleMatrix } from "./CorrelationRippleMatrix";


### PR DESCRIPTION
## Summary
- add `CorrelationRippleMatrix` component rendering a Recharts-based heatmap of correlation values
- show mini line chart popup that expands when heatmap cells are clicked
- export new visualization component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688eac4f65b4832497961f2d5ad69b03