### PR TITLE
refactor: remove playground and analytics dashboard routes

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,9 +2,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   ChartArea,
   ChartBar,
-  ChartLine,
   ChartPie,
-  FlaskConical,
   Radar,
 } from "lucide-react";
 
@@ -21,60 +19,7 @@ export interface DashboardRouteGroup {
   items: DashboardRoute[];
 }
 
-export const dashboardRoutes: DashboardRouteGroup[] = [
-  {
-    label: "Playground",
-    icon: FlaskConical,
-    items: [
-      {
-        to: "/dashboard/map",
-        label: "Map Exploration",
-        description: "Explore routes and locations on an interactive map",
-      },
-      {
-        to: "/dashboard/route-similarity",
-        label: "Route Similarity Analysis",
-        description: "Compare routes based on similarity metrics",
-      },
-      {
-        to: "/dashboard/route-novelty",
-        label: "Route Novelty Analysis",
-        description: "Assess how unique a route is compared to known paths",
-      },
-    ],
-  },
-  {
-    label: "Analytics",
-    icon: ChartLine,
-    items: [
-      {
-        to: "/dashboard/mileage-globe",
-        label: "Global Mileage Map",
-        description: "Visualize mileage across the world using a globe",
-      },
-      {
-        to: "/dashboard/fragility",
-        label: "Fragility Analysis",
-        description: "Review training fragility indicators",
-      },
-      {
-        to: "/dashboard/session-similarity",
-        label: "Session Similarity Analysis",
-        description: "Find training sessions that resemble each other",
-      },
-      {
-        to: "/dashboard/good-day",
-        label: "Good Day Analysis",
-        description: "Identify patterns that contribute to positive days",
-      },
-      {
-        to: "/dashboard/habit-consistency",
-        label: "Habit Consistency Trend",
-        description: "Track how consistently habits are maintained over time",
-      },
-    ],
-  },
-];
+export const dashboardRoutes: DashboardRouteGroup[] = [];
 
 export const chartRouteGroups: DashboardRouteGroup[] = [
   {


### PR DESCRIPTION
## Summary
- remove Playground and Analytics groups from dashboardRoutes
- clean up unused icon imports

## Testing
- `npm test -- --run` *(fails: useFragilityHistory > returns ordered fragility points and skips missing days)*

------
https://chatgpt.com/codex/tasks/task_e_688eaf198a0c8324b7172a597547c6ec