### PR TITLE
Add statistics correlation page and sidebar navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import FragilityPage from "@/pages/Fragility";
 import SessionSimilarityPage from "@/pages/SessionSimilarity";
 import GoodDayPage from "@/pages/GoodDay";
 import HabitConsistencyPage from "@/pages/HabitConsistency";
+import StatisticsPage from "@/pages/Statistics";
 import AreaChartInteractivePage from "@/pages/charts/AreaChartInteractive";
 import StepsTrendWithGoalPage from "@/pages/charts/StepsTrendWithGoal";
 import AreaChartLoadRatioPage from "@/pages/charts/AreaChartLoadRatio";
@@ -61,6 +62,7 @@ function App() {
               <Route path="session-similarity" element={<SessionSimilarityPage />} />
               <Route path="good-day" element={<GoodDayPage />} />
               <Route path="habit-consistency" element={<HabitConsistencyPage />} />
+              <Route path="statistics" element={<StatisticsPage />} />
               <Route path="charts/area-chart-interactive" element={<AreaChartInteractivePage />} />
               <Route path="charts/steps-trend-with-goal" element={<StepsTrendWithGoalPage />} />
               <Route path="charts/area-chart-load-ratio" element={<AreaChartLoadRatioPage />} />

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import CorrelationRippleMatrix from "@/components/visualizations/CorrelationRippleMatrix";
+import {
+  getDailySteps,
+  getDailySleep,
+  getDailyHeartRate,
+  getDailyCalories,
+  type GarminDay,
+  type MetricDay,
+} from "@/lib/api";
+import { Skeleton } from "@/components/ui/skeleton";
+import useCorrelationMatrix, { type MetricPoint } from "@/hooks/useCorrelationMatrix";
+
+interface Metrics extends MetricPoint {
+  steps: number;
+  sleep: number;
+  heartRate: number;
+  calories: number;
+}
+
+export default function StatisticsPage() {
+  const [points, setPoints] = useState<Metrics[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const [steps, sleep, heart, calories] = await Promise.all([
+        getDailySteps(),
+        getDailySleep(),
+        getDailyHeartRate(),
+        getDailyCalories(),
+      ]);
+      const byDate: Record<string, Partial<Metrics>> = {};
+      steps.forEach((d: GarminDay) => {
+        byDate[d.date] = { ...byDate[d.date], steps: d.steps };
+      });
+      sleep.forEach((d: MetricDay) => {
+        byDate[d.date] = { ...byDate[d.date], sleep: d.value };
+      });
+      heart.forEach((d: MetricDay) => {
+        byDate[d.date] = { ...byDate[d.date], heartRate: d.value };
+      });
+      calories.forEach((d: MetricDay) => {
+        byDate[d.date] = { ...byDate[d.date], calories: d.value };
+      });
+      const merged = Object.values(byDate).filter(
+        (p): p is Metrics =>
+          p.steps !== undefined &&
+          p.sleep !== undefined &&
+          p.heartRate !== undefined &&
+          p.calories !== undefined,
+      );
+      setPoints(merged);
+    }
+    load();
+  }, []);
+
+  const matrixObj = useCorrelationMatrix(points);
+  const labels = ["Steps", "Sleep", "Heart Rate", "Calories"];
+  const keys: (keyof Metrics)[] = ["steps", "sleep", "heartRate", "calories"];
+  const matrix = keys.map((k1) => keys.map((k2) => matrixObj?.[k1]?.[k2] ?? 0));
+
+  if (!points.length) {
+    return (
+      <div className="p-4 space-y-4">
+        <h1 className="text-2xl font-bold">Metric Correlations</h1>
+        <Skeleton className="h-64" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Metric Correlations</h1>
+      <p className="text-sm text-muted-foreground">
+        Correlation between daily steps, sleep, heart rate, and calories.
+      </p>
+      <CorrelationRippleMatrix matrix={matrix} labels={labels} />
+    </div>
+  );
+}
+

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -72,6 +72,11 @@ export const dashboardRoutes: DashboardRouteGroup[] = [
         label: "Habit Consistency Trend",
         description: "Track how consistently habits are maintained over time",
       },
+      {
+        to: "/dashboard/statistics",
+        label: "Metric Correlation Matrix",
+        description: "Explore correlations between daily metrics",
+      },
     ],
   },
 ];
@@ -218,6 +223,17 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
         to: "/dashboard/charts/reading-stack-split",
         label: "Reading Stack Split",
         description: "Segment reading activity across categories",
+      },
+    ],
+  },
+  {
+    label: "Matrix Charts",
+    icon: ChartLine,
+    items: [
+      {
+        to: "/dashboard/statistics",
+        label: "Metric Correlation Matrix",
+        description: "Explore correlations between daily metrics",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- add metric correlation page rendering CorrelationRippleMatrix
- register statistics page in routes and sidebar navigation
- expose statistics route in app router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eae1aeaa88324b92968f5b4719517