### PR TITLE
fix: enable client rendering for Mileage Globe

### DIFF
--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from "react";
 import MileageGlobe from "@/components/examples/MileageGlobe";
 import Slider from "@/components/ui/slider";


### PR DESCRIPTION
## Summary
- ensure MileageGlobe page runs on client by adding the `use client` directive

## Testing
- `npm test` (passes, then cancelled watch mode)


------
https://chatgpt.com/codex/tasks/task_e_688eaf1448b88324a237dad125c3c7bf