### PR TITLE
Add missing icon imports

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,8 @@ import {
   ChartBar,
   ChartPie,
   Radar,
+  ChartLine,
+  FlaskConical,
 } from "lucide-react";
 
 export interface DashboardRoute {


### PR DESCRIPTION
## Summary
- include `ChartLine` and `FlaskConical` in icon imports

## Testing
- `npm run build`
- `npx vitest run` *(fails: useFragilityHistory > returns ordered fragility points and skips missing days)*

------
https://chatgpt.com/codex/tasks/task_e_688eb7052a608324a7218054b084bfa6