### PR TITLE
feat: add legend to daily mileage radar

### DIFF
--- a/src/components/statistics/AvgDailyMileageRadar.tsx
+++ b/src/components/statistics/AvgDailyMileageRadar.tsx
@@ -8,6 +8,8 @@ import {
   PolarRadiusAxis,
   Radar,
   Tooltip as ChartTooltip,
+  ChartLegend,
+  ChartLegendContent,
 } from "@/components/ui/chart"
 import ChartCard from "@/components/dashboard/ChartCard"
 
@@ -22,7 +24,7 @@ const dailyMileage = [
 ]
 
 const config = {
-  miles: { label: "Miles", color: "var(--chart-3)" },
+  miles: { label: "Miles", color: "hsl(var(--chart-3))" },
 } satisfies Record<string, unknown>
 
 export default function AvgDailyMileageRadar() {
@@ -37,11 +39,12 @@ export default function AvgDailyMileageRadar() {
           <PolarAngleAxis dataKey="day" />
           <PolarRadiusAxis />
           <ChartTooltip />
+          <ChartLegend content={<ChartLegendContent />} />
           <Radar
             name="Mileage"
             dataKey="miles"
-            stroke="var(--chart-3)"
-            fill="var(--chart-3)"
+            stroke={config.miles.color}
+            fill={config.miles.color}
             fillOpacity={0.4}
           />
         </RadarChart>


### PR DESCRIPTION
## Summary
- add chart legend for average daily mileage radar
- use HSL chart tokens for daily mileage colors

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688ec0c814e883249114d38f7efd5b7b