### PR TITLE
feat: add loading skeleton to behavioral weather widget

### DIFF
--- a/src/components/dashboard/BehavioralWeatherWidget.tsx
+++ b/src/components/dashboard/BehavioralWeatherWidget.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Zap, HeartPulse, Brain } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface ForecastItem {
   label: string;
@@ -18,6 +19,7 @@ const fallbackData: ForecastItem[] = [
 
 export default function BehavioralWeatherWidget() {
   const [data, setData] = useState<ForecastItem[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function load() {
@@ -29,6 +31,8 @@ export default function BehavioralWeatherWidget() {
       } catch {
         // fall back to stubbed data if API call fails
         setData(fallbackData);
+      } finally {
+        setLoading(false);
       }
     }
     load();
@@ -37,23 +41,27 @@ export default function BehavioralWeatherWidget() {
   return (
     <Card className="p-4">
       <h3 className="mb-4 text-sm font-medium">Today's Forecast</h3>
-      <div className="grid grid-cols-3 gap-4 text-center">
-        {data.map((item) => {
-          const diff = item.value - item.typical;
-          const diffPct = Math.round(diff * 100);
-          return (
-            <div key={item.label} className="flex flex-col items-center gap-1">
-              <item.icon className="h-6 w-6" />
-              <span className="text-sm">{item.label}</span>
-              <span className="text-lg font-semibold">{Math.round(item.value * 100)}%</span>
-              <span className="text-xs text-gray-500">
-                {diffPct >= 0 ? "+" : ""}
-                {diffPct}% vs wk avg
-              </span>
-            </div>
-          );
-        })}
-      </div>
+      {loading ? (
+        <Skeleton className="h-24 w-full" />
+      ) : (
+        <div className="grid grid-cols-3 gap-4 text-center">
+          {data.map((item) => {
+            const diff = item.value - item.typical;
+            const diffPct = Math.round(diff * 100);
+            return (
+              <div key={item.label} className="flex flex-col items-center gap-1">
+                <item.icon className="h-6 w-6" />
+                <span className="text-sm">{item.label}</span>
+                <span className="text-lg font-semibold">{Math.round(item.value * 100)}%</span>
+                <span className="text-xs text-gray-500">
+                  {diffPct >= 0 ? "+" : ""}
+                  {diffPct}% vs wk avg
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- show a skeleton placeholder while behavior forecast loads
- track widget loading state for data fetches

## Testing
- `npm test -- --run` *(fails: useFragilityHistory > returns ordered fragility points and skips missing days)*

------
https://chatgpt.com/codex/tasks/task_e_688ec2d65a0083249a1f7271c66a4bcd