### PR TITLE
Add analytics routes and sidebar group

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -15,9 +15,9 @@ import {
   SidebarMenuSubButton,
 } from "@/components/ui/sidebar";
 import { NavLink, useLocation } from "react-router-dom";
-import { Map as MapIcon, ChevronRight, Star } from "lucide-react";
+import { Map as MapIcon, ChevronRight, Star, ChartLine } from "lucide-react";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { chartRouteGroups, mapRoutes } from "@/routes";
+import { chartRouteGroups, mapRoutes, analyticsRoutes } from "@/routes";
 import { cn } from "@/lib/utils";
 import {
   Tooltip,
@@ -82,7 +82,11 @@ export default function AppSidebar() {
   };
 
   const allRoutes = React.useMemo(
-    () => [...mapRoutes, ...chartRouteGroups.flatMap((g) => g.items)],
+    () => [
+      ...mapRoutes,
+      ...analyticsRoutes,
+      ...chartRouteGroups.flatMap((g) => g.items),
+    ],
     []
   );
   const favoriteRoutes = React.useMemo(
@@ -215,6 +219,54 @@ export default function AppSidebar() {
                     </Collapsible.Root>
                   );
                 })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
+        {analyticsRoutes.length > 0 && (
+          <SidebarGroup>
+            <SidebarGroupLabel>Analytics</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {analyticsRoutes.map((route) => (
+                  <SidebarMenuItem key={route.to}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={pathname === route.to}
+                          className="justify-start"
+                        >
+                          <NavLink
+                            to={route.to}
+                            className="flex w-full items-center"
+                          >
+                            <ChartLine className="mr-2 h-4 w-4" />
+                            <span className="flex-1">{route.label}</span>
+                            <Star
+                              className={cn(
+                                "ml-auto h-4 w-4",
+                                favorites.includes(route.to)
+                                  ? "fill-yellow-400 text-yellow-400"
+                                  : "text-muted-foreground"
+                              )}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                toggleFavorite(route.to);
+                              }}
+                            />
+                          </NavLink>
+                        </SidebarMenuButton>
+                      </TooltipTrigger>
+                      {route.description && (
+                        <TooltipContent side="right">
+                          {route.description}
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  </SidebarMenuItem>
+                ))}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -22,6 +22,39 @@ export interface DashboardRouteGroup {
 }
 
 
+export const analyticsRoutes: DashboardRoute[] = [
+  {
+    to: "/dashboard/mileage-globe",
+    label: "Global Mileage Map",
+    description: "Visualize mileage across the world using a globe",
+  },
+  {
+    to: "/dashboard/fragility",
+    label: "Fragility Analysis",
+    description: "Review training fragility indicators",
+  },
+  {
+    to: "/dashboard/session-similarity",
+    label: "Session Similarity Analysis",
+    description: "Find training sessions that resemble each other",
+  },
+  {
+    to: "/dashboard/good-day",
+    label: "Good Day Analysis",
+    description: "Identify patterns that contribute to positive days",
+  },
+  {
+    to: "/dashboard/habit-consistency",
+    label: "Habit Consistency Trend",
+    description: "Track how consistently habits are maintained over time",
+  },
+  {
+    to: "/dashboard/statistics",
+    label: "Metric Correlation Matrix",
+    description: "Explore correlations between daily metrics",
+  },
+];
+
 export const dashboardRoutes: DashboardRouteGroup[] = [
   {
     label: "Playground",
@@ -47,38 +80,7 @@ export const dashboardRoutes: DashboardRouteGroup[] = [
   {
     label: "Analytics",
     icon: ChartLine,
-    items: [
-      {
-        to: "/dashboard/mileage-globe",
-        label: "Global Mileage Map",
-        description: "Visualize mileage across the world using a globe",
-      },
-      {
-        to: "/dashboard/fragility",
-        label: "Fragility Analysis",
-        description: "Review training fragility indicators",
-      },
-      {
-        to: "/dashboard/session-similarity",
-        label: "Session Similarity Analysis",
-        description: "Find training sessions that resemble each other",
-      },
-      {
-        to: "/dashboard/good-day",
-        label: "Good Day Analysis",
-        description: "Identify patterns that contribute to positive days",
-      },
-      {
-        to: "/dashboard/habit-consistency",
-        label: "Habit Consistency Trend",
-        description: "Track how consistently habits are maintained over time",
-      },
-      {
-        to: "/dashboard/statistics",
-        label: "Metric Correlation Matrix",
-        description: "Explore correlations between daily metrics",
-      },
-    ],
+    items: analyticsRoutes,
   },
 ];
 


### PR DESCRIPTION
## Summary
- export `analyticsRoutes` with mileage, fragility, session similarity and other analytics pages
- show Analytics section in sidebar and track favorites for those routes

## Testing
- `npm test` *(fails: useFragilityHistory.test.ts expected values but received null)*

------
https://chatgpt.com/codex/tasks/task_e_688ec20b9b5c832495aa137a3a25dbb8