### PR TITLE
Add legend icons for ReadingStackSplit chart

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -12,6 +12,15 @@ import type { ChartConfig } from "@/components/ui/chart";
 import ChartCard from "./ChartCard";
 import useReadingMediumTotals from "@/hooks/useReadingMediumTotals";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Smartphone,
+  Monitor,
+  Tablet,
+  BookOpen,
+  BookOpenText,
+  HelpCircle,
+  type LucideIcon,
+} from "lucide-react";
 
 const labels: Record<string, string> = {
   phone: "Phone",
@@ -20,6 +29,15 @@ const labels: Record<string, string> = {
   kindle: "Kindle",
   real_book: "Real Book",
   other: "Other",
+};
+
+const icons: Record<string, LucideIcon> = {
+  phone: Smartphone,
+  computer: Monitor,
+  tablet: Tablet,
+  kindle: BookOpen,
+  real_book: BookOpenText,
+  other: HelpCircle,
 };
 
 export default function ReadingStackSplit() {
@@ -33,6 +51,7 @@ export default function ReadingStackSplit() {
   data.forEach((d, i) => {
     (config as any)[d.medium] = {
       label: labels[d.medium],
+      icon: icons[d.medium],
       color: `hsl(var(--chart-${i + 1}))`,
     };
   });

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -25,10 +25,12 @@ vi.mock("@/hooks/useReadingMediumTotals", () => ({
 }));
 
 describe("ReadingStackSplit", () => {
-  it("renders chart title", () => {
-    render(<ReadingStackSplit />);
+  it("renders chart title and icons", () => {
+    const { container } = render(<ReadingStackSplit />);
     expect(screen.getByText(/Reading Stack Split/)).toBeInTheDocument();
     expect(screen.getByText("Phone")).toBeInTheDocument();
     expect(screen.getByText("Kindle")).toBeInTheDocument();
+    expect(container.querySelector("svg.lucide-smartphone")).toBeInTheDocument();
+    expect(container.querySelector("svg.lucide-book-open")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show device-specific icons in ReadingStackSplit legend
- add tests ensuring legend icons render

## Testing
- `npx vitest run src/components/dashboard/__tests__/ReadingStackSplit.test.tsx`
- `npx vitest run` *(fails: useFragilityHistory.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688ec27bb3c08324bf4b5486b44136af