### PR TITLE
Handle map fetch failure in MileageGlobe

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -20,6 +20,7 @@ function GlobeRenderer({
   const svgRef = useRef<SVGSVGElement | null>(null)
   const [dimensions, setDimensions] = useState({ width: 300, height: 300 })
   const [worldData, setWorldData] = useState<any | null>(null)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     const svg = svgRef.current
@@ -46,9 +47,16 @@ function GlobeRenderer({
   }, [])
 
   useEffect(() => {
-    fetch('/world-110m.json')
-      .then((res) => res.json())
-      .then((world) => setWorldData(world))
+    const load = async () => {
+      try {
+        const res = await fetch('/world-110m.json')
+        const world = await res.json()
+        setWorldData(world)
+      } catch {
+        setError(true)
+      }
+    }
+    load()
   }, [])
 
   useEffect(() => {
@@ -147,11 +155,17 @@ function GlobeRenderer({
 
   return (
     <div className='relative aspect-square w-full'>
-      <svg
-        ref={svgRef}
-        className='h-full w-full rounded'
-        preserveAspectRatio='xMidYMid meet'
-      />
+      {error ? (
+        <div className='flex h-full w-full items-center justify-center rounded bg-muted text-muted-foreground'>
+          Map unavailable
+        </div>
+      ) : (
+        <svg
+          ref={svgRef}
+          className='h-full w-full rounded'
+          preserveAspectRatio='xMidYMid meet'
+        />
+      )}
     </div>
   )
 }

--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -56,6 +56,28 @@ describe("MileageGlobe", () => {
     });
   });
 
+  it("shows fallback when map data fails to load", async () => {
+    mockUseMileageTimeline.mockReturnValue([
+      {
+        date: "2024-01-01",
+        miles: 5,
+        cumulativeMiles: 5,
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      },
+    ])
+
+    global.fetch = vi.fn().mockRejectedValue(new Error("network")) as any
+
+    render(<MileageGlobe />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Map unavailable/i)).toBeInTheDocument()
+    })
+  })
+
   it("displays total mileage", async () => {
     mockUseMileageTimeline.mockReturnValue([
       {


### PR DESCRIPTION
## Summary
- handle fetch errors when loading world map data in MileageGlobe
- show a fallback message if the globe cannot load
- test the failure case of globe loading

## Testing
- `npx vitest run --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_688ec42cfacc8324bce3454f8701fccb