### PR TITLE
feat: add state visits map

### DIFF
--- a/src/pages/MapPlayground.tsx
+++ b/src/pages/MapPlayground.tsx
@@ -1,12 +1,14 @@
 import React from "react";
+import GeoActivityExplorer from "@/components/map/GeoActivityExplorer";
 
 export default function MapPlaygroundPage() {
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Map Playground</h1>
+      <h1 className="text-2xl font-bold">State Visits Map</h1>
       <p className="text-sm text-muted-foreground">
-        Map playground details coming soon.
+        View the states you've visited on an interactive map.
       </p>
+      <GeoActivityExplorer />
     </div>
   );
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -29,8 +29,8 @@ export const dashboardRoutes: DashboardRouteGroup[] = [
     items: [
       {
         to: "/dashboard/map",
-        label: "Map Exploration",
-        description: "Explore routes and locations on an interactive map",
+        label: "State Visits Map",
+        description: "View visited states on an interactive map",
       },
       {
         to: "/dashboard/route-similarity",
@@ -239,8 +239,8 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
 export const mapRoutes: DashboardRoute[] = [
   {
     to: "/dashboard/map",
-    label: "Map Exploration",
-    description: "Explore routes and locations on an interactive map",
+    label: "State Visits Map",
+    description: "View visited states on an interactive map",
   },
   {
     to: "/dashboard/route-similarity",


### PR DESCRIPTION
## Summary
- embed GeoActivityExplorer map in MapPlayground page
- rename map route label to State Visits Map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec2e08b6c8324ae06e8d78ffe302c