### PR TITLE
feat: apply diverging color scale to correlation ripple matrix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "d3-drag": "^3.0.0",
         "d3-geo": "^3.1.1",
         "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
         "d3-zoom": "^3.0.0",
@@ -3465,6 +3466,19 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "d3-drag": "^3.0.0",
     "d3-geo": "^3.1.1",
     "d3-scale": "^4.0.2",
+    "d3-scale-chromatic": "^3.1.0",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
     "d3-zoom": "^3.0.0",


### PR DESCRIPTION
## Summary
- use perceptually uniform RdBu diverging palette for correlation ripple matrix
- allow configurable min/max bounds and map zero to white
- document color mapping in code and add d3-scale-chromatic dependency

## Testing
- `npm test -- --run` *(fails: src/hooks/__tests__/useFragilityHistory.test.ts > useFragilityHistory > returns ordered fragility points and skips missing days)*

------
https://chatgpt.com/codex/tasks/task_e_688ec2c6f4948324acfd4b92655d8794