### PR TITLE
feat: add diverging color scale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "d3-drag": "^3.0.0",
         "d3-geo": "^3.1.1",
         "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
         "d3-zoom": "^3.0.0",
@@ -3465,6 +3466,19 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "d3-drag": "^3.0.0",
     "d3-geo": "^3.1.1",
     "d3-scale": "^4.0.2",
+    "d3-scale-chromatic": "^3.1.0",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
     "d3-zoom": "^3.0.0",


### PR DESCRIPTION
## Summary
- use perceptually uniform blue-white-red color scale with configurable bounds
- allow customizing min/max range for matrix colors
- add `d3-scale-chromatic` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ebc3ea4d48324a00e349008ed1fd8