### PR TITLE
feat: show total reading time

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -7,7 +7,7 @@ import {
   ChartLegend,
   ChartLegendContent,
 } from "@/components/ui/chart";
-import { Cell } from "recharts";
+import { Cell, Label } from "recharts";
 import type { ChartConfig } from "@/components/ui/chart";
 import ChartCard from "./ChartCard";
 import useReadingMediumTotals from "@/hooks/useReadingMediumTotals";
@@ -45,6 +45,8 @@ export default function ReadingStackSplit() {
 
   if (!data) return <Skeleton className="h-64" />;
 
+  const total = data.reduce((sum, d) => sum + d.minutes, 0);
+
   const config: ChartConfig = {
     minutes: { label: "Minutes" },
   };
@@ -79,6 +81,22 @@ export default function ReadingStackSplit() {
             {data.map((entry, idx) => (
               <Cell key={entry.medium} fill={`hsl(var(--chart-${idx + 1}))`} />
             ))}
+            <Label
+              content={({ viewBox }) => {
+                const { cx, cy } = viewBox as { cx: number; cy: number };
+                return (
+                  <text
+                    x={cx}
+                    y={cy}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    className="text-xl font-bold fill-foreground"
+                  >
+                    {`${total} 📚`}
+                  </text>
+                );
+              }}
+            />
           </Pie>
         </PieChart>
       </ChartContainer>

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -32,5 +32,6 @@ describe("ReadingStackSplit", () => {
     expect(screen.getByText("Kindle")).toBeInTheDocument();
     expect(container.querySelector("svg.lucide-smartphone")).toBeInTheDocument();
     expect(container.querySelector("svg.lucide-book-open")).toBeInTheDocument();
+    expect(screen.getByText("90 📚")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- calculate total minutes in ReadingStackSplit and display at chart center
- test for total label

## Testing
- `npx vitest run src/components/dashboard/__tests__/ReadingStackSplit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688ec7637e4c83249056fb4cc5b78f02