### PR TITLE
feat: add tooltip content to TimeInBedChart

### DIFF
--- a/src/components/dashboard/TimeInBedChart.tsx
+++ b/src/components/dashboard/TimeInBedChart.tsx
@@ -9,6 +9,7 @@ import {
   YAxis,
   ReferenceLine,
   Tooltip as ChartTooltip,
+  ChartTooltipContent,
 } from '@/components/ui/chart'
 import ChartCard from './ChartCard'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -49,7 +50,15 @@ export default function TimeInBedChart() {
           <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
           <YAxis />
           <ReferenceLine y={8} stroke={config.goal.color} strokeDasharray="4 4" />
-          <ChartTooltip />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                nameKey="timeInBed"
+                formatter={(v) => `${v} hr`}
+                labelFormatter={(d) => new Date(d).toLocaleDateString()}
+              />
+            }
+          />
           <Area
             type="monotone"
             dataKey="timeInBed"


### PR DESCRIPTION
## Summary
- show time in bed tooltip with hours and formatted date

## Testing
- `npm test` *(fails: Expected ")" but found "export" in MileageGlobe, assertion error in useFragilityHistory)*

------
https://chatgpt.com/codex/tasks/task_e_688ec74f0cf48324affe8e608597f69f