### PR TITLE
feat: add privacy controls

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,21 @@
+# Privacy and Data Collection
+
+This project collects a small set of information to power analytics and mapping features.
+
+## Data Categories
+
+### Focus Labels
+Tags describing reading or activity focus are stored to highlight trends and surface relevant insights. These labels help the application customise charts and recommendations.
+
+### Location History
+Latitude/longitude fixes are stored locally so the application can build visit summaries and route visualisations. Location data never leaves the device unless exported manually.
+
+### App Usage
+Basic usage information such as chart selections or feature toggles is kept to remember preferences and improve usability.
+
+## Retention Policy
+All locally stored data is subject to a configurable retention period (30 days by default). Entries older than the selected window are purged automatically.
+
+## Export & Deletion
+The privacy dashboard provides buttons to export all stored data as a JSON file or delete it entirely. Clearing data also removes any associated history and retention timers.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import AvgDailyMileageRadarPage from "@/pages/charts/AvgDailyMileageRadar";
 import RadialChartLabelPage from "@/pages/charts/RadialChartLabel";
 import RadialChartTextPage from "@/pages/charts/RadialChartText";
 import RadialChartGridPage from "@/pages/charts/RadialChartGrid";
+import PrivacyDashboardPage from "@/pages/PrivacyDashboard";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 
@@ -62,6 +63,7 @@ function App() {
               <Route path="good-day" element={<GoodDayPage />} />
               <Route path="habit-consistency" element={<HabitConsistencyPage />} />
               <Route path="statistics" element={<StatisticsPage />} />
+              <Route path="privacy" element={<PrivacyDashboardPage />} />
               <Route path="charts/area-chart-interactive" element={<AreaChartInteractivePage />} />
               <Route path="charts/steps-trend-with-goal" element={<StepsTrendWithGoalPage />} />
               <Route path="charts/area-chart-load-ratio" element={<AreaChartLoadRatioPage />} />

--- a/src/pages/PrivacyDashboard.tsx
+++ b/src/pages/PrivacyDashboard.tsx
@@ -1,0 +1,10 @@
+import Privacy from "@/components/settings/Privacy";
+
+export default function PrivacyDashboardPage() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold">Privacy Dashboard</h1>
+      <Privacy />
+    </div>
+  );
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,6 +6,7 @@ import {
   Radar,
   ChartLine,
   FlaskConical,
+  Shield,
 } from "lucide-react";
 
 export interface DashboardRoute {
@@ -81,6 +82,17 @@ export const dashboardRoutes: DashboardRouteGroup[] = [
     label: "Analytics",
     icon: ChartLine,
     items: analyticsRoutes,
+  },
+  {
+    label: "Privacy",
+    icon: Shield,
+    items: [
+      {
+        to: "/dashboard/privacy",
+        label: "Privacy Dashboard",
+        description: "Manage data retention and export/delete options",
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary
- document data categories and retention in PRIVACY.md
- add retention-aware location storage with export and clear helpers
- introduce privacy dashboard with retention and export/delete actions

## Testing
- `npm test` *(fails: Expected ")" but found "export" in MileageGlobe.tsx)*
- `npm run build` *(fails: Expected ")" but found "export" in MileageGlobe.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688ec81144c8832498656668788b79f0