### PR TITLE
Handle globe fetch errors with fallback

### DIFF
--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -124,4 +124,26 @@ describe("MileageGlobe", () => {
       expect(screen.getByText("Total: 5 miles")).toBeInTheDocument();
     });
   });
+
+  it("renders fallback message when world data fails to load", async () => {
+    mockUseMileageTimeline.mockReturnValue([
+      {
+        date: "2024-01-01",
+        miles: 5,
+        cumulativeMiles: 5,
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      },
+    ]);
+
+    global.fetch = vi.fn().mockRejectedValue(new Error("network"));
+
+    render(<MileageGlobe />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Map unavailable/i)).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- handle failure in MileageGlobe world map fetch and show a fallback message
- test the globe component's error behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec74a849083248f28d866875b8fb6