### PR TITLE
Add reminders settings and focus history tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ import AvgDailyMileageRadarPage from "@/pages/charts/AvgDailyMileageRadar";
 import RadialChartLabelPage from "@/pages/charts/RadialChartLabel";
 import RadialChartTextPage from "@/pages/charts/RadialChartText";
 import RadialChartGridPage from "@/pages/charts/RadialChartGrid";
+import FocusHistoryPage from "@/pages/FocusHistory";
+import InterventionSettingsPage from "@/pages/InterventionSettings";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 
@@ -95,6 +97,8 @@ function App() {
               <Route path="charts/radial-chart-label" element={<RadialChartLabelPage />} />
               <Route path="charts/radial-chart-text" element={<RadialChartTextPage />} />
               <Route path="charts/radial-chart-grid" element={<RadialChartGridPage />} />
+              <Route path="focus-history" element={<FocusHistoryPage />} />
+              <Route path="settings" element={<InterventionSettingsPage />} />
             </Route>
           </Routes>
         </Layout>

--- a/src/hooks/__tests__/useInterventionPreferences.test.tsx
+++ b/src/hooks/__tests__/useInterventionPreferences.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, act } from "@testing-library/react";
+import useInterventionPreferences, {
+  InterventionPreferencesProvider,
+} from "../useInterventionPreferences";
+import { describe, it, expect, beforeEach } from "vitest";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <InterventionPreferencesProvider>{children}</InterventionPreferencesProvider>
+  );
+}
+
+describe("useInterventionPreferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie = "intervention_prefs=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+  });
+
+  it("returns default preferences", () => {
+    const { result } = renderHook(() => useInterventionPreferences(), { wrapper });
+    expect(result.current.prefs).toEqual({ remindersEnabled: true, delayMinutes: 30 });
+  });
+
+  it("persists updates", () => {
+    const { result, rerender } = renderHook(() => useInterventionPreferences(), { wrapper });
+    act(() => {
+      result.current.setPrefs({ remindersEnabled: false, delayMinutes: 45 });
+    });
+    rerender();
+    expect(result.current.prefs.remindersEnabled).toBe(false);
+    expect(result.current.prefs.delayMinutes).toBe(45);
+
+    const stored = localStorage.getItem("intervention_prefs");
+    expect(stored).toBeTruthy();
+  });
+});
+

--- a/src/hooks/useEngagementNudges.ts
+++ b/src/hooks/useEngagementNudges.ts
@@ -1,10 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import useSocialEngagement from "./useSocialEngagement";
+import useInterventionPreferences from "./useInterventionPreferences";
+import useFocusHistory from "./useFocusHistory";
 
 export default function useEngagementNudges() {
   const data = useSocialEngagement();
+  const { prefs } = useInterventionPreferences();
+  const { addEvent } = useFocusHistory();
   const [nudges, setNudges] = useState<string[]>([]);
   const notified = useRef<Set<string>>(new Set());
+  const timers = useRef<Record<string, number>>({});
 
   useEffect(() => {
     if (!data) return;
@@ -14,20 +19,29 @@ export default function useEngagementNudges() {
     }
     setNudges(messages);
 
+    Object.values(timers.current).forEach((id) => clearTimeout(id));
+    timers.current = {};
+
     messages.forEach((msg) => {
-      if (notified.current.has(msg)) return;
-      if (typeof window !== "undefined" && "Notification" in window) {
-        if (Notification.permission === "granted") {
-          new Notification(msg);
-        } else if (Notification.permission !== "denied") {
-          Notification.requestPermission().then((perm) => {
-            if (perm === "granted") new Notification(msg);
-          });
+      addEvent({ type: "detection", message: msg });
+      if (!prefs.remindersEnabled || notified.current.has(msg)) return;
+      const delay = prefs.delayMinutes * 60 * 1000;
+      const id = window.setTimeout(() => {
+        if (typeof window !== "undefined" && "Notification" in window) {
+          if (Notification.permission === "granted") {
+            new Notification(msg);
+          } else if (Notification.permission !== "denied") {
+            Notification.requestPermission().then((perm) => {
+              if (perm === "granted") new Notification(msg);
+            });
+          }
         }
-      }
-      notified.current.add(msg);
+        addEvent({ type: "intervention", message: msg });
+        notified.current.add(msg);
+      }, delay);
+      timers.current[msg] = id;
     });
-  }, [data]);
+  }, [data, prefs, addEvent]);
 
   return nudges;
 }

--- a/src/hooks/useFocusHistory.tsx
+++ b/src/hooks/useFocusHistory.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export interface FocusEvent {
+  timestamp: number;
+  type: "detection" | "intervention";
+  message: string;
+}
+
+interface FocusHistoryState {
+  history: FocusEvent[];
+  addEvent: (evt: Omit<FocusEvent, "timestamp"> & { timestamp?: number }) => void;
+}
+
+const STORAGE_KEY = "focus_history";
+
+function loadHistory(): FocusEvent[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(atob(raw)) as FocusEvent[];
+  } catch {
+    return [];
+  }
+}
+
+function storeHistory(history: FocusEvent[]) {
+  if (typeof window === "undefined") return;
+  try {
+    const encoded = btoa(JSON.stringify(history));
+    localStorage.setItem(STORAGE_KEY, encoded);
+  } catch {
+    // ignore
+  }
+}
+
+const FocusHistoryContext = createContext<FocusHistoryState | undefined>(undefined);
+
+function useProvideFocusHistory(): FocusHistoryState {
+  const [history, setHistory] = useState<FocusEvent[]>([]);
+
+  useEffect(() => {
+    setHistory(loadHistory());
+  }, []);
+
+  const addEvent = (evt: Omit<FocusEvent, "timestamp"> & { timestamp?: number }) => {
+    setHistory((prev) => {
+      const next = [...prev, { ...evt, timestamp: evt.timestamp ?? Date.now() }];
+      storeHistory(next);
+      return next;
+    });
+  };
+
+  return { history, addEvent };
+}
+
+export function FocusHistoryProvider({ children }: { children: ReactNode }) {
+  const value = useProvideFocusHistory();
+  return <FocusHistoryContext.Provider value={value}>{children}</FocusHistoryContext.Provider>;
+}
+
+export default function useFocusHistory(): FocusHistoryState {
+  const ctx = useContext(FocusHistoryContext);
+  const fallback = useProvideFocusHistory();
+  return ctx || fallback;
+}
+

--- a/src/hooks/useInterventionPreferences.tsx
+++ b/src/hooks/useInterventionPreferences.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export interface InterventionPreferences {
+  remindersEnabled: boolean;
+  delayMinutes: number;
+}
+
+interface InterventionPreferencesState {
+  prefs: InterventionPreferences;
+  setPrefs: (update: Partial<InterventionPreferences>) => void;
+}
+
+const DEFAULT_PREFS: InterventionPreferences = {
+  remindersEnabled: true,
+  delayMinutes: 30,
+};
+
+const STORAGE_KEY = "intervention_prefs";
+const COOKIE_NAME = "intervention_prefs";
+
+function loadPrefs(): InterventionPreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFS;
+  try {
+    const raw =
+      localStorage.getItem(STORAGE_KEY) ||
+      document.cookie
+        .split("; ")
+        .find((row) => row.startsWith(`${COOKIE_NAME}=`))?.split("=")[1];
+    if (!raw) return DEFAULT_PREFS;
+    const decoded = JSON.parse(atob(raw));
+    return { ...DEFAULT_PREFS, ...decoded };
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+function storePrefs(p: InterventionPreferences) {
+  if (typeof window === "undefined") return;
+  try {
+    const encoded = btoa(JSON.stringify(p));
+    localStorage.setItem(STORAGE_KEY, encoded);
+    document.cookie = `${COOKIE_NAME}=${encoded}; path=/; max-age=31536000; samesite=lax`;
+  } catch {
+    // ignore
+  }
+}
+
+const InterventionPreferencesContext = createContext<
+  InterventionPreferencesState | undefined
+>(undefined);
+
+function useProvideInterventionPreferences(): InterventionPreferencesState {
+  const [prefs, setPrefsState] = useState<InterventionPreferences>(DEFAULT_PREFS);
+
+  useEffect(() => {
+    setPrefsState(loadPrefs());
+  }, []);
+
+  const setPrefs = (update: Partial<InterventionPreferences>) => {
+    setPrefsState((prev) => {
+      const next = { ...prev, ...update };
+      storePrefs(next);
+      return next;
+    });
+  };
+
+  return { prefs, setPrefs };
+}
+
+export function InterventionPreferencesProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const value = useProvideInterventionPreferences();
+  return (
+    <InterventionPreferencesContext.Provider value={value}>
+      {children}
+    </InterventionPreferencesContext.Provider>
+  );
+}
+
+export default function useInterventionPreferences(): InterventionPreferencesState {
+  const ctx = useContext(InterventionPreferencesContext);
+  const fallback = useProvideInterventionPreferences();
+  return ctx || fallback;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,15 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/globals.css";
 import "maplibre-gl/dist/maplibre-gl.css";
+import { InterventionPreferencesProvider } from "@/hooks/useInterventionPreferences";
+import { FocusHistoryProvider } from "@/hooks/useFocusHistory";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <InterventionPreferencesProvider>
+      <FocusHistoryProvider>
+        <App />
+      </FocusHistoryProvider>
+    </InterventionPreferencesProvider>
+  </React.StrictMode>,
 );

--- a/src/pages/FocusHistory.tsx
+++ b/src/pages/FocusHistory.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import useFocusHistory from "@/hooks/useFocusHistory";
+import { Card } from "@/components/ui/card";
+
+export default function FocusHistoryPage() {
+  const { history } = useFocusHistory();
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Focus History</h1>
+      {history.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No history yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {history.map((e, idx) => (
+            <Card key={idx} className="p-4">
+              <div className="text-sm text-muted-foreground">
+                {new Date(e.timestamp).toLocaleString()}
+              </div>
+              <div className="font-medium capitalize">{e.type}</div>
+              <div>{e.message}</div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/pages/InterventionSettings.tsx
+++ b/src/pages/InterventionSettings.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import useInterventionPreferences from "@/hooks/useInterventionPreferences";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Slider from "@/components/ui/slider";
+
+export default function InterventionSettingsPage() {
+  const { prefs, setPrefs } = useInterventionPreferences();
+
+  return (
+    <div className="p-4 space-y-4 max-w-md">
+      <h1 className="text-2xl font-bold">Intervention Settings</h1>
+      <Card className="p-4 space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="font-medium">Reminders</p>
+            <p className="text-sm text-muted-foreground">
+              {prefs.remindersEnabled ? "On" : "Off"}
+            </p>
+          </div>
+          <Button
+            variant={prefs.remindersEnabled ? "default" : "outline"}
+            onClick={() =>
+              setPrefs({ remindersEnabled: !prefs.remindersEnabled })
+            }
+          >
+            {prefs.remindersEnabled ? "Disable" : "Enable"}
+          </Button>
+        </div>
+        <div>
+          <p className="font-medium mb-2">Delay Threshold (minutes)</p>
+          <Slider
+            min={30}
+            max={60}
+            step={5}
+            value={[prefs.delayMinutes]}
+            onValueChange={(val) => setPrefs({ delayMinutes: val[0] })}
+          />
+          <p className="text-sm text-muted-foreground mt-2">
+            Notify after {prefs.delayMinutes} minutes of fragmentation.
+          </p>
+        </div>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -53,6 +53,16 @@ export const analyticsRoutes: DashboardRoute[] = [
     label: "Metric Correlation Matrix",
     description: "Explore correlations between daily metrics",
   },
+  {
+    to: "/dashboard/focus-history",
+    label: "Focus History",
+    description: "Review past focus detections and interventions",
+  },
+  {
+    to: "/dashboard/settings",
+    label: "Intervention Settings",
+    description: "Configure reminder preferences",
+  },
 ];
 
 export const dashboardRoutes: DashboardRouteGroup[] = [


### PR DESCRIPTION
## Summary
- add provider to persist intervention preferences and focus history
- settings page to toggle reminders and adjust delay thresholds
- focus history page to review detections and interventions
- respect preferences in engagement nudges and log events

## Testing
- `npm test` *(fails: Expected ")" but found "export" in MileageGlobe.tsx)*
- `npx vitest run src/hooks/__tests__/useInterventionPreferences.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688ec80dd2e483248874d054627d64c2