### PR TITLE
Add triangular view toggle for correlation matrix

### DIFF
--- a/src/components/visualizations/CorrelationRippleMatrix.tsx
+++ b/src/components/visualizations/CorrelationRippleMatrix.tsx
@@ -24,6 +24,7 @@ interface CorrelationRippleMatrixProps {
   maxValue?: number; // upper bound for color scale
   showValues?: boolean; // display correlation values in cells
   cellSize?: number; // explicit cell size override
+  upperOnly?: boolean; // only render x >= y cells
 
 }
 
@@ -68,6 +69,7 @@ export default function CorrelationRippleMatrix({
   maxValue = 1,
   showValues = false,
   cellSize: cellSizeProp,
+  upperOnly = false,
 
 }: CorrelationRippleMatrixProps) {
   const [active, setActive] = useState<CellData | null>(null);
@@ -89,9 +91,9 @@ export default function CorrelationRippleMatrix({
     return () => observer.disconnect();
   }, [cellSizeProp, labels.length]);
 
-  const heatData: CellData[] = matrix.flatMap((row, y) =>
-    row.map((value, x) => ({ x, y, value }))
-  );
+  const heatData: CellData[] = matrix
+    .flatMap((row, y) => row.map((value, x) => ({ x, y, value })))
+    .filter(({ x, y }) => !upperOnly || x >= y);
 
   const colorScale = createColorScale(minValue, maxValue);
 

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import CorrelationRippleMatrix from "@/components/visualizations/CorrelationRippleMatrix";
+import { Button } from "@/components/ui/button";
 import {
   getDailySteps,
   getDailySleep,
@@ -20,6 +21,7 @@ interface Metrics extends MetricPoint {
 
 export default function StatisticsPage() {
   const [points, setPoints] = useState<Metrics[]>([]);
+  const [upperOnly, setUpperOnly] = useState(true);
 
   useEffect(() => {
     async function load() {
@@ -74,7 +76,18 @@ export default function StatisticsPage() {
       <p className="text-sm text-muted-foreground">
         Correlation between daily steps, sleep, heart rate, and calories.
       </p>
-      <CorrelationRippleMatrix matrix={matrix} labels={labels} />
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setUpperOnly((p) => !p)}
+      >
+        {upperOnly ? "Show Full Matrix" : "Show Upper Triangle"}
+      </Button>
+      <CorrelationRippleMatrix
+        matrix={matrix}
+        labels={labels}
+        upperOnly={upperOnly}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `upperOnly` option to `CorrelationRippleMatrix` to filter heatmap to upper-triangular cells
- add button on statistics page to toggle between full and triangular correlation views

## Testing
- `npm test` *(fails: Expected ")" but found "export" in MileageGlobe.tsx)*


------
https://chatgpt.com/codex/tasks/task_e_688ec996b4c88324a18cd90b4e1eab3a