### PR TITLE
Sort sleep data chronologically for TimeInBedChart

### DIFF
--- a/src/components/dashboard/TimeInBedChart.tsx
+++ b/src/components/dashboard/TimeInBedChart.tsx
@@ -21,7 +21,9 @@ export default function TimeInBedChart() {
   const [data, setData] = useState<SleepSession[] | null>(null)
 
   useEffect(() => {
-    getSleepSessions().then(setData)
+    getSleepSessions().then((sessions) =>
+      setData([...sessions].sort((a, b) => a.date.localeCompare(b.date)))
+    )
   }, [])
 
   const dataWithAvg = useMemo(() => {


### PR DESCRIPTION
## Summary
- sort sleep sessions by date before rendering TimeInBedChart

## Testing
- `npm test` *(fails: Expected ")" but found "export" in src/components/examples/MileageGlobe.tsx:193)*

------
https://chatgpt.com/codex/tasks/task_e_688ec93bbd948324abc3aa076809a7fb