### PR TITLE
feat: share selection state across dashboard charts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,11 +44,13 @@ import RadialChartGridPage from "@/pages/charts/RadialChartGrid";
 import PrivacyDashboardPage from "@/pages/PrivacyDashboard";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
+import { SelectionProvider } from "@/hooks/useSelection";
 
 function App() {
   return (
     <BrowserRouter>
       <DashboardFiltersProvider>
+        <SelectionProvider>
         <Layout>
           <Routes>
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
@@ -100,6 +102,7 @@ function App() {
             </Route>
           </Routes>
         </Layout>
+        </SelectionProvider>
       </DashboardFiltersProvider>
     </BrowserRouter>
   );

--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -16,6 +16,7 @@ import { useGarminData } from "@/hooks/useGarminData";
 import useDashboardFilters from "@/hooks/useDashboardFilters";
 import { Skeleton } from "@/components/ui/skeleton";
 import { chartColors } from "@/lib/chartColors";
+import useSelection from "@/hooks/useSelection";
 
 const chartConfig = {
   distance: {
@@ -31,6 +32,7 @@ const chartConfig = {
 export function ActivitiesChart() {
   const data = useGarminData();
   const { activity, range } = useDashboardFilters();
+  const { selected, toggle } = useSelection();
   if (!data) return <Skeleton className="h-60 md:col-span-2" />;
   let activities = data.activities;
 
@@ -61,11 +63,41 @@ export function ActivitiesChart() {
           <YAxis yAxisId="left" orientation="left" />
           <YAxis yAxisId="right" orientation="right" />
         <ChartTooltip
-          content={<ChartTooltipContent labelFormatter={(d) => new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" })} />}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(d) =>
+                new Date(d).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                })
+              }
+            />
+          }
         />
-        <ChartLegend content={<ChartLegendContent />} />
-        <Line yAxisId="left" type="monotone" dataKey="distance" stroke={chartConfig.distance.color} animationDuration={300} />
-        <Line yAxisId="right" type="monotone" dataKey="duration" stroke={chartConfig.duration.color} animationDuration={300} />
+        <ChartLegend
+          onClick={(o: any) => {
+            if (o && o.dataKey) toggle(String(o.dataKey));
+          }}
+          content={<ChartLegendContent />}
+        />
+        {(!selected.length || selected.includes("distance")) && (
+          <Line
+            yAxisId="left"
+            type="monotone"
+            dataKey="distance"
+            stroke={chartConfig.distance.color}
+            animationDuration={300}
+          />
+        )}
+        {(!selected.length || selected.includes("duration")) && (
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="duration"
+            stroke={chartConfig.duration.color}
+            animationDuration={300}
+          />
+        )}
       </LineChart>
       </ChartContainer>
     </ChartCard>

--- a/src/components/dashboard/FragilityGauge.tsx
+++ b/src/components/dashboard/FragilityGauge.tsx
@@ -3,6 +3,7 @@ import useFragilityIndex from '@/hooks/useFragilityIndex'
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Skeleton } from '@/components/ui/skeleton'
 import { getFragilityLevel } from '@/lib/fragility'
+import useSelection from '@/hooks/useSelection'
 
 export interface FragilityGaugeProps {
   /** Diameter of the gauge in pixels */
@@ -17,6 +18,7 @@ export interface FragilityGaugeProps {
 export default function FragilityGauge({ size = 160, strokeWidth = 12 }: FragilityGaugeProps) {
   const fragility = useFragilityIndex()
   const [displayIndex, setDisplayIndex] = useState(0)
+  const { selected, toggle } = useSelection()
 
   useEffect(() => {
     if (!fragility) return
@@ -44,11 +46,18 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
 
   const { color } = getFragilityLevel(index)
 
+  const isDimmed = selected.length && !selected.includes('fragility')
+
   return (
     <TooltipProvider delayDuration={100}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex flex-col items-center" role="img" aria-label={`Fragility ${displayIndex.toFixed(2)}`}> 
+          <div
+            className={isDimmed ? 'flex flex-col items-center opacity-30' : 'flex flex-col items-center'}
+            role="img"
+            aria-label={`Fragility ${displayIndex.toFixed(2)}`}
+            onClick={() => toggle('fragility')}
+          >
             <svg width={size} height={size / 2} viewBox={`0 0 ${size} ${size / 2}`}>
               <path
                 d={`M ${strokeWidth / 2},${size / 2 - strokeWidth / 2} A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2 - strokeWidth / 2}`}
@@ -67,7 +76,7 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
                 style={{ transition: 'stroke-dashoffset 0.5s ease' }}
               />
             </svg>
-            <span className="mt-2 text-lg font-bold tabular-nums">{displayIndex.toFixed(2)}</span>
+          <span className="mt-2 text-lg font-bold tabular-nums">{displayIndex.toFixed(2)}</span>
           </div>
         </TooltipTrigger>
         <TooltipContent>

--- a/src/hooks/useSelection.tsx
+++ b/src/hooks/useSelection.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+interface SelectionState {
+  selected: string[]
+  toggle: (key: string) => void
+  clear: () => void
+}
+
+const SelectionContext = createContext<SelectionState | undefined>(undefined)
+
+function useProvideSelection(): SelectionState {
+  const [selected, setSelected] = useState<string[]>([])
+  const toggle = (key: string) =>
+    setSelected((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    )
+  const clear = () => setSelected([])
+  return { selected, toggle, clear }
+}
+
+export function SelectionProvider({ children }: { children: ReactNode }) {
+  const value = useProvideSelection()
+  return <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>
+}
+
+export default function useSelection(): SelectionState {
+  const ctx = useContext(SelectionContext)
+  const fallback = useProvideSelection()
+  return ctx || fallback
+}
+


### PR DESCRIPTION
## Summary
- add selection provider to share active filter state
- connect activities chart and fragility gauge to update and read shared selections
- wrap app with selection provider

## Testing
- `npm test` *(fails: Expected ")" but found "export" in MileageGlobe.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688ec98443a48324a3b2664d6f54eaa6