### PR TITLE
feat: add mileage tooltip on globe

### DIFF
--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -97,6 +97,48 @@ describe("MileageGlobe", () => {
     });
   });
 
+  it("shows tooltip with date and mileage on path hover", async () => {
+    mockUseMileageTimeline.mockReturnValue([
+      {
+        date: "2024-01-01",
+        miles: 5,
+        cumulativeMiles: 5,
+        coordinates: [
+          [0, 0],
+          [10, 10],
+        ],
+      },
+    ]);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          type: "Topology",
+          objects: { countries: { type: "GeometryCollection", geometries: [] } },
+        }),
+    }) as any;
+
+    const { container } = render(<MileageGlobe />);
+
+    await waitFor(() => {
+      expect(
+        container.querySelector("path[stroke='var(--primary-foreground)']"),
+      ).toBeTruthy();
+    });
+
+    const path = container.querySelector(
+      "path[stroke='var(--primary-foreground)']",
+    ) as SVGPathElement;
+
+    path.dispatchEvent(
+      new MouseEvent("mouseenter", { bubbles: true, clientX: 10, clientY: 10 }),
+    );
+
+    expect(
+      await screen.findByText("2024-01-01: 5 miles"),
+    ).toBeInTheDocument();
+  });
+
   it("displays total mileage", async () => {
     mockUseMileageTimeline.mockReturnValue([
       {


### PR DESCRIPTION
## Summary
- add tooltip rendering to show date and miles on path hover in MileageGlobe
- append mouseenter and mouseleave events to path elements for tooltip
- test that hovering a path renders the tooltip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ec9af1ce483248423e15d4911a1f0