### PR TITLE
Handle world data fetch errors in MileageGlobe

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import useMileageTimeline from '@/hooks/useMileageTimeline'
 
 interface MileageGlobeProps {
@@ -12,10 +12,22 @@ export default function MileageGlobe({ weekRange }: MileageGlobeProps) {
     weekRange ? { startWeek: weekRange[0], endWeek: weekRange[1] } : undefined,
   )
 
+  const [worldError, setWorldError] = useState(false)
+
   useEffect(() => {
-    // Simulate loading of world data to satisfy tests
-    fetch('/world-110m.json').catch(() => {})
+    // Attempt to load world data, track failure for fallback rendering
+    fetch('/world-110m.json')
+      .then(() => setWorldError(false))
+      .catch(() => setWorldError(true))
   }, [])
+
+  if (worldError) {
+    return (
+      <div className='flex items-center justify-center h-96 w-full bg-muted text-muted-foreground rounded'>
+        Map unavailable
+      </div>
+    )
+  }
 
   if (!data) {
     return (


### PR DESCRIPTION
## Summary
- handle world data fetch errors in MileageGlobe component
- show fallback message when map data fails to load

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688ecc4ad89483248af62ad355612e63