### PR TITLE
feat: expand route similarity metrics

### DIFF
--- a/src/components/dashboard/RouteSimilarity.tsx
+++ b/src/components/dashboard/RouteSimilarity.tsx
@@ -126,13 +126,16 @@ export default function RouteSimilarity() {
         </Map>
       </div>
       <p className="mt-2 text-sm text-muted-foreground">
-        Route A is shown in blue and Route B in red. The Jaccard percentage
-        reflects the degree of overlap.
+        Route A is shown in blue and Route B in red. The percentages below
+        show the overlap (Jaccard), Dynamic Time Warping (DTW), and the maximum
+        of the two metrics.
       </p>
       {similarity != null && (
-        <p className="text-sm text-muted-foreground">
-          Jaccard similarity: {(similarity * 100).toFixed(1)}%
-        </p>
+        <div className="text-sm text-muted-foreground space-y-1">
+          <p>Jaccard similarity: {(similarity.overlapSimilarity * 100).toFixed(1)}%</p>
+          <p>DTW similarity: {(similarity.dtwSimilarity * 100).toFixed(1)}%</p>
+          <p>Max similarity: {(similarity.maxSimilarity * 100).toFixed(1)}%</p>
+        </div>
       )}
     </Card>
   )

--- a/src/hooks/useRouteSimilarity.ts
+++ b/src/hooks/useRouteSimilarity.ts
@@ -3,7 +3,7 @@ import { Route } from '@/lib/api'
 import { computeRouteMetrics } from '@/lib/routeMetrics'
 
 /**
- * React hook to compute the Jaccard similarity between two routes.
+ * React hook to compute similarity metrics between two routes.
  * The result is memoized and recomputed whenever either route or the
  * rounding precision changes.
  */
@@ -11,15 +11,16 @@ export function useRouteSimilarity(
   routeA?: Route,
   routeB?: Route,
   precision = 3,
-): number | null {
+):
+  | {
+      overlapSimilarity: number
+      dtwSimilarity: number
+      maxSimilarity: number
+    }
+  | null {
   return useMemo(() => {
     if (!routeA || !routeB) return null
-    const { overlapSimilarity } = computeRouteMetrics(
-      routeA.points,
-      routeB.points,
-      precision,
-    )
-    return overlapSimilarity
+    return computeRouteMetrics(routeA.points, routeB.points, precision)
   }, [routeA, routeB, precision])
 }
 


### PR DESCRIPTION
## Summary
- expose overlap, DTW, and max route similarity metrics in `useRouteSimilarity`
- surface new metrics in `RouteSimilarity` dashboard component

## Testing
- `npm test` *(fails: useFragilityHistory returns null)*

------
https://chatgpt.com/codex/tasks/task_e_688ecd7f2ef08324ae83992e27aa7637