### PR TITLE
Make pie charts responsive with gradients

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -6,6 +6,7 @@ import {
   ChartTooltip,
   ChartLegend,
   ChartLegendContent,
+  ResponsiveContainer,
 } from "@/components/ui/chart";
 import { Cell, Label } from "recharts";
 import { useState } from "react";
@@ -63,52 +64,73 @@ export default function ReadingStackSplit() {
   return (
     <ChartCard title="Reading Stack Split" description="Time by device">
       <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
-        <PieChart width={200} height={160}>
-          <ChartTooltip />
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign="bottom"
-            height={24}
-          />
-          <Pie
-            data={data}
-            dataKey="minutes"
-            nameKey="medium"
-            innerRadius={50}
-            paddingAngle={4}
-            cornerRadius={8}
-            label={({ percent }) => `${Math.round(percent * 100)}%`}
-            onMouseEnter={(_, index) => setActiveIndex(index)}
-            onMouseLeave={() => setActiveIndex(null)}
-            isAnimationActive
-            animationDuration={500}
-          >
-            {data.map((entry, idx) => (
-              <Cell
-                key={entry.medium}
-                fill={`hsl(var(--chart-${idx + 1}))`}
-                outerRadius={activeIndex === idx ? 80 : 70}
-                opacity={activeIndex === idx ? 1 : 0.6}
-              />
-            ))}
-            <Label
-              content={({ viewBox }) => {
-                const { cx, cy } = viewBox as { cx: number; cy: number };
-                return (
-                  <text
-                    x={cx}
-                    y={cy}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    className="text-xl font-bold fill-foreground"
-                  >
-                    {`${total} 📚`}
-                  </text>
-                );
-              }}
+        <ResponsiveContainer>
+          <PieChart>
+            <defs>
+              {data.map((_, idx) => (
+                <linearGradient
+                  key={idx}
+                  id={`reading-split-gradient-${idx}`}
+                >
+                  <stop
+                    offset="0%"
+                    stopColor={`hsl(var(--chart-${idx + 1}))`}
+                    stopOpacity={0.8}
+                  />
+                  <stop
+                    offset="100%"
+                    stopColor={`hsl(var(--chart-${idx + 1}))`}
+                    stopOpacity={0.5}
+                  />
+                </linearGradient>
+              ))}
+            </defs>
+            <ChartTooltip />
+            <ChartLegend
+              content={<ChartLegendContent />}
+              verticalAlign="bottom"
+              height={24}
             />
-          </Pie>
-        </PieChart>
+            <Pie
+              data={data}
+              dataKey="minutes"
+              nameKey="medium"
+              innerRadius="60%"
+              outerRadius="85%"
+              paddingAngle={4}
+              cornerRadius={8}
+              label={({ percent }) => `${Math.round(percent * 100)}%`}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+              onMouseLeave={() => setActiveIndex(null)}
+              isAnimationActive
+              animationDuration={500}
+            >
+              {data.map((entry, idx) => (
+                <Cell
+                  key={entry.medium}
+                  fill={`url(#reading-split-gradient-${idx})`}
+                  opacity={activeIndex === idx ? 1 : 0.6}
+                />
+              ))}
+              <Label
+                content={({ viewBox }) => {
+                  const { cx, cy } = viewBox as { cx: number; cy: number };
+                  return (
+                    <text
+                      x={cx}
+                      y={cy}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      className="text-xl font-bold fill-foreground"
+                    >
+                      {`${total} 📚`}
+                    </text>
+                  );
+                }}
+              />
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
       </ChartContainer>
     </ChartCard>
   );

--- a/src/components/statistics/TreadmillVsOutdoor.tsx
+++ b/src/components/statistics/TreadmillVsOutdoor.tsx
@@ -6,6 +6,7 @@ import {
   Pie,
   Tooltip as ChartTooltip,
   ChartLegend,
+  ResponsiveContainer,
 } from "@/components/ui/chart"
 import ChartCard from "@/components/dashboard/ChartCard"
 import { Cell } from "recharts"
@@ -28,29 +29,41 @@ export default function TreadmillVsOutdoor() {
       description="Indoor vs outdoor mileage split"
     >
       <ChartContainer config={config} className="h-60 md:h-80 lg:h-96">
-        <PieChart width={200} height={160}>
-          <ChartTooltip />
+        <ResponsiveContainer>
+          <PieChart>
+            <defs>
+              <linearGradient id="treadmill-gradient-outdoor">
+                <stop offset="0%" stopColor="hsl(var(--chart-5))" stopOpacity={0.8} />
+                <stop offset="100%" stopColor="hsl(var(--chart-5))" stopOpacity={0.5} />
+              </linearGradient>
+              <linearGradient id="treadmill-gradient-indoor">
+                <stop offset="0%" stopColor="hsl(var(--chart-6))" stopOpacity={0.8} />
+                <stop offset="100%" stopColor="hsl(var(--chart-6))" stopOpacity={0.5} />
+              </linearGradient>
+            </defs>
+            <ChartTooltip />
 
-          <ChartLegend verticalAlign="bottom" height={24} />
+            <ChartLegend verticalAlign="bottom" height={24} />
 
-          <Pie
-            data={treadmillData}
-            dataKey="value"
-            nameKey="name"
-            innerRadius={50}
-            outerRadius={70}
-            paddingAngle={4}
-            cornerRadius={8}
-            label={({ percent }) => `${Math.round(percent * 100)}%`}
-          >
-            {treadmillData.map((entry, idx) => (
-              <Cell
-                key={entry.name}
-                fill={idx === 0 ? "hsl(var(--chart-5))" : "hsl(var(--chart-6))"}
-              />
-            ))}
-          </Pie>
-        </PieChart>
+            <Pie
+              data={treadmillData}
+              dataKey="value"
+              nameKey="name"
+              innerRadius="60%"
+              outerRadius="85%"
+              paddingAngle={4}
+              cornerRadius={8}
+              label={({ percent }) => `${Math.round(percent * 100)}%`}
+            >
+              {treadmillData.map((entry, idx) => (
+                <Cell
+                  key={entry.name}
+                  fill={idx === 0 ? "url(#treadmill-gradient-outdoor)" : "url(#treadmill-gradient-indoor)"}
+                />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
       </ChartContainer>
     </ChartCard>
   )


### PR DESCRIPTION
## Summary
- Wrap ReadingStackSplit and TreadmillVsOutdoor pie charts in ResponsiveContainer for proper scaling
- Add gradient fills and percentage-based radii for better visualisation

## Testing
- `npx vitest run src/components/dashboard/__tests__/ReadingStackSplit.test.tsx`
- `npm test` *(cancelled: Test run cancelled; Watching for file changes...)*


------
https://chatgpt.com/codex/tasks/task_e_688ecd2c76908324a9f6331772748ee6