### PR TITLE
Add globe auto-rotation with play/pause control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "d3-scale-chromatic": "^3.1.0",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
+        "d3-timer": "^3.0.1",
         "d3-zoom": "^3.0.0",
         "date-fns": "^4.1.0",
         "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
+    "d3-timer": "^3.0.1",
     "d3-zoom": "^3.0.0",
     "date-fns": "^4.1.0",
     "events": "^3.3.0",

--- a/src/components/GlobeRenderer.tsx
+++ b/src/components/GlobeRenderer.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef, useState } from "react";
+import { select } from "d3-selection";
+import { geoOrthographic, geoPath } from "d3-geo";
+import { drag } from "d3-drag";
+import { zoom } from "d3-zoom";
+import { timer, Timer } from "d3-timer";
+
+interface PathData {
+  coordinates: [number, number][];
+}
+
+interface GlobeRendererProps {
+  paths: PathData[];
+  autoRotate?: boolean;
+  strokeWidth?: number;
+}
+
+export default function GlobeRenderer({ paths, autoRotate = false, strokeWidth = 2 }: GlobeRendererProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const projectionRef = useRef(geoOrthographic().scale(180).translate([200, 200]));
+  const pathGeneratorRef = useRef(geoPath(projectionRef.current));
+  const rotationRef = useRef<[number, number, number]>([0, 0, 0]);
+  const timerRef = useRef<Timer | null>(null);
+  const [tick, setTick] = useState(0);
+
+  // helper to (re)start timer when autoRotate true
+  const startTimer = () => {
+    if (!autoRotate) return;
+    timerRef.current = timer(() => {
+      const r = rotationRef.current;
+      r[0] += 0.02; // slow rotation in degrees/ms
+      projectionRef.current.rotate(r);
+      setTick((t) => t + 1);
+    });
+  };
+
+  useEffect(() => {
+    timerRef.current?.stop();
+    if (autoRotate) {
+      startTimer();
+    }
+    return () => {
+      timerRef.current?.stop();
+    };
+  }, [autoRotate]);
+
+  useEffect(() => {
+    const svg = select(svgRef.current);
+
+    const dragBehavior = drag<SVGSVGElement, unknown>()
+      .on("start", () => {
+        timerRef.current?.stop();
+      })
+      .on("drag", (event) => {
+        const rotate = projectionRef.current.rotate();
+        projectionRef.current.rotate([
+          rotate[0] + event.dx * 0.5,
+          rotate[1] - event.dy * 0.5,
+          rotate[2],
+        ]);
+        rotationRef.current = projectionRef.current.rotate() as [number, number, number];
+        setTick((t) => t + 1);
+      })
+      .on("end", () => {
+        rotationRef.current = projectionRef.current.rotate() as [number, number, number];
+        if (autoRotate) startTimer();
+      });
+
+    const zoomBehavior = zoom<SVGSVGElement, unknown>()
+      .on("start", () => {
+        timerRef.current?.stop();
+      })
+      .on("zoom", (event) => {
+        projectionRef.current.scale(180 * event.transform.k);
+        setTick((t) => t + 1);
+      })
+      .on("end", () => {
+        if (autoRotate) startTimer();
+      });
+
+    svg.call(dragBehavior as any);
+    svg.call(zoomBehavior as any);
+  }, [autoRotate]);
+
+  const pathGenerator = pathGeneratorRef.current;
+
+  return (
+    <svg ref={svgRef} className="h-full w-full rounded" viewBox="0 0 400 400">
+      {paths.map((p, idx) => (
+        <path
+          key={idx}
+          d={pathGenerator({ type: "LineString", coordinates: p.coordinates }) || undefined}
+          fill="none"
+          stroke="var(--primary-foreground)"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          opacity={0.8}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -1,20 +1,22 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import useMileageTimeline from '@/hooks/useMileageTimeline'
+import GlobeRenderer from '@/components/GlobeRenderer'
 
 interface MileageGlobeProps {
   weekRange?: [number, number]
-
+  autoRotate?: boolean
 }
 
-export default function MileageGlobe({ weekRange }: MileageGlobeProps) {
+export default function MileageGlobe({ weekRange, autoRotate = false }: MileageGlobeProps) {
   const data = useMileageTimeline(
     undefined,
     weekRange ? { startWeek: weekRange[0], endWeek: weekRange[1] } : undefined,
   )
+  const [worldError, setWorldError] = useState(false)
 
   useEffect(() => {
     // Simulate loading of world data to satisfy tests
-    fetch('/world-110m.json').catch(() => {})
+    fetch('/world-110m.json').catch(() => setWorldError(true))
   }, [])
 
   if (!data) {
@@ -24,24 +26,20 @@ export default function MileageGlobe({ weekRange }: MileageGlobeProps) {
       </div>
     )
   }
+  if (worldError) {
+    return (
+      <div className='flex items-center justify-center h-96 w-full bg-muted text-muted-foreground rounded'>
+        Map unavailable
+      </div>
+    )
+  }
 
   const totalMiles = data.reduce((sum, p) => sum + p.miles, 0)
+  const strokeWidth = Math.max(2, Math.min(10, 1 + totalMiles / 50))
 
   return (
     <div className='relative aspect-square w-full'>
-      <svg className='h-full w-full rounded' preserveAspectRatio='xMidYMid meet'>
-        {data.map((p, idx) => (
-          <path
-            key={idx}
-            d={`M ${p.coordinates.map((c) => c.join(' ')).join(' L ')}`}
-            fill='none'
-            stroke='var(--primary-foreground)'
-            strokeWidth={Math.max(2, Math.min(10, 1 + totalMiles / 50))}
-            strokeLinecap='round'
-            opacity={0.8}
-          />
-        ))}
-      </svg>
+      <GlobeRenderer paths={data} autoRotate={autoRotate} strokeWidth={strokeWidth} />
       <div className='absolute bottom-2 left-2 text-xs text-foreground'>
         Total: {totalMiles} miles
       </div>

--- a/src/hooks/__tests__/useFragilityHistory.test.ts
+++ b/src/hooks/__tests__/useFragilityHistory.test.ts
@@ -10,8 +10,11 @@ vi.mock('@/lib/api', () => ({
   getHourlySteps: vi.fn(),
 }))
 
+vi.useRealTimers()
+
 afterEach(() => {
   vi.clearAllMocks()
+  vi.useRealTimers()
 })
 
 function makeDay(date: string, steps: number): HourlySteps[] {

--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -3,11 +3,13 @@
 import React, { useState, useEffect } from "react";
 import MileageGlobe from "@/components/examples/MileageGlobe";
 import Slider from "@/components/ui/slider";
+import { Button } from "@/components/ui/button";
 import useWeeklyVolumeHistory from "@/hooks/useWeeklyVolumeHistory";
 
 export default function MileageGlobePage() {
   const weekly = useWeeklyVolumeHistory();
   const [range, setRange] = useState<[number, number] | null>(null);
+  const [autoRotate, setAutoRotate] = useState(true);
 
   useEffect(() => {
     if (weekly) {
@@ -41,8 +43,18 @@ export default function MileageGlobePage() {
           />
         </div>
       )}
-      <div className="mx-auto max-w-md">
-        <MileageGlobe weekRange={range ?? undefined} />
+      <div className="mx-auto max-w-md space-y-2">
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setAutoRotate((a) => !a)}
+            aria-label={autoRotate ? "Pause rotation" : "Play rotation"}
+          >
+            {autoRotate ? "Pause" : "Play"}
+          </Button>
+        </div>
+        <MileageGlobe weekRange={range ?? undefined} autoRotate={autoRotate} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use d3-timer in new `GlobeRenderer` to auto-rotate the globe and pause on drag/zoom
- expose `autoRotate` to MileageGlobe and add UI toggle on MileageGlobePage
- ensure world data fetch failure shows "Map unavailable" and stabilize fragility history tests

## Testing
- `npm test -- --run --maxWorkers=1`

------
https://chatgpt.com/codex/tasks/task_e_688ecb43fa508324906fb07aa0093fa9