### PR TITLE
test: add correlation and ripple matrix tests

### DIFF
--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -1,0 +1,52 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import '@testing-library/jest-dom'
+import CorrelationRippleMatrix from '../CorrelationRippleMatrix'
+
+vi.mock('recharts', async () => {
+  const actual: any = await vi.importActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+      <div style={{ width: 200, height: 200 }}>
+        {React.cloneElement(children, { width: 200, height: 200 })}
+      </div>
+    ),
+  }
+})
+
+describe('CorrelationRippleMatrix', () => {
+  it('shows detail chart on cell click', async () => {
+    const matrix = [
+      [1, 0.5],
+      [0.5, 1],
+    ]
+    const labels = ['A', 'B']
+    const drilldown = {
+      '0-1': [
+        { x: 0, y: 1 },
+        { x: 1, y: 2 },
+      ],
+    }
+    const { container } = render(
+      <CorrelationRippleMatrix
+        matrix={matrix}
+        labels={labels}
+        drilldown={drilldown}
+        cellSize={50}
+      />,
+    )
+
+    expect(container.querySelector('div.absolute')).not.toBeInTheDocument()
+
+    const cells = container.querySelectorAll('path.recharts-rectangle')
+    expect(cells.length).toBeGreaterThan(1)
+    await userEvent.click(cells[1] as SVGPathElement)
+    await waitFor(() =>
+      expect(container.querySelector('div.absolute')).toBeInTheDocument(),
+    )
+  })
+})
+

--- a/src/hooks/__tests__/useCorrelationMatrix.test.ts
+++ b/src/hooks/__tests__/useCorrelationMatrix.test.ts
@@ -21,5 +21,22 @@ describe('computeCorrelationMatrix', () => {
     expect(matrix.a.c).toBeCloseTo(-1)
     expect(matrix.b.c).toBeCloseTo(-1)
   })
+
+  it('handles uncorrelated data', () => {
+    interface SamplePoint extends MetricPoint {
+      a: number
+      b: number
+    }
+    const points: SamplePoint[] = [
+      { a: 1, b: 2 },
+      { a: 2, b: 1 },
+      { a: 3, b: 2 },
+      { a: 4, b: 1 },
+      { a: 5, b: 2 },
+    ]
+    const matrix = computeCorrelationMatrix(points)
+    expect(matrix.a.b).toBeCloseTo(0)
+    expect(matrix.b.a).toBeCloseTo(0)
+  })
 })
 


### PR DESCRIPTION
## Summary
- expand computeCorrelationMatrix tests to cover uncorrelated data
- add CorrelationRippleMatrix UI test to ensure detail chart appears on cell click

## Testing
- `npx vitest run src/hooks/__tests__/useCorrelationMatrix.test.ts src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx`
- `npm test` *(fails: useFragilityHistory.test.ts and CorrelationRippleMatrix.test.tsx initially)*

------
https://chatgpt.com/codex/tasks/task_e_688eb66a03508324a5462a54e611c36c