### PR TITLE
Replace reading emoji with icon

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -20,6 +20,7 @@ import {
   Tablet,
   BookOpen,
   BookOpenText,
+  Book,
   HelpCircle,
   type LucideIcon,
 } from "lucide-react";
@@ -116,15 +117,23 @@ export default function ReadingStackSplit() {
                 content={({ viewBox }) => {
                   const { cx, cy } = viewBox as { cx: number; cy: number };
                   return (
-                    <text
-                      x={cx}
-                      y={cy}
-                      textAnchor="middle"
-                      dominantBaseline="middle"
-                      className="text-xl font-bold fill-foreground"
+                    <g
+                      transform={`translate(${cx}, ${cy})`}
+                      className="fill-foreground"
                     >
-                      {`${total} 📚`}
-                    </text>
+                      <text
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        className="text-xl font-bold"
+                      >
+                        {total}
+                      </text>
+                      <Book
+                        x={12}
+                        y={-12}
+                        className="h-5 w-5 text-foreground"
+                      />
+                    </g>
                   );
                 }}
               />

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -32,6 +32,7 @@ describe("ReadingStackSplit", () => {
     expect(screen.getByText("Kindle")).toBeInTheDocument();
     expect(container.querySelector("svg.lucide-smartphone")).toBeInTheDocument();
     expect(container.querySelector("svg.lucide-book-open")).toBeInTheDocument();
-    expect(screen.getByText("90 📚")).toBeInTheDocument();
+    expect(screen.getByText("90")).toBeInTheDocument();
+    expect(container.querySelector("svg.lucide-book")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- replace emoji label with numeric total plus book icon in ReadingStackSplit chart
- update ReadingStackSplit test to expect icon instead of emoji

## Testing
- `npm test -- src/components/dashboard/__tests__/ReadingStackSplit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688ecfdde0748324bf7a6831d1681940