### PR TITLE
feat: add risk timeline with confidence bands

### DIFF
--- a/src/components/visualizations/index.ts
+++ b/src/components/visualizations/index.ts
@@ -1,4 +1,5 @@
 export { default as BehavioralCharterMap } from "./BehavioralCharterMap";
+export type { Segment } from "./BehavioralCharterMap";
 export { default as TransitionMatrix } from "./TransitionMatrix";
 export { default as CorrelationRippleMatrix } from "./CorrelationRippleMatrix";
 export { default as FocusTimeline } from "./FocusTimeline";


### PR DESCRIPTION
## Summary
- extend Segment with risk score and confidence interval fields
- overlay risk line and band with threshold markers on BehavioralCharterMap
- expose Segment type from visualizations index

## Testing
- `npx vitest run` *(fails: expected null to deeply equal [ …(2) ])*

------
https://chatgpt.com/codex/tasks/task_e_688ecbad35f48324be489f1f1a635c28