### PR TITLE
Add motion-safe easing transitions to charts and gauges

### DIFF
--- a/src/components/dashboard/ActivitiesChart.tsx
+++ b/src/components/dashboard/ActivitiesChart.tsx
@@ -17,6 +17,7 @@ import useDashboardFilters from "@/hooks/useDashboardFilters";
 import { Skeleton } from "@/components/ui/skeleton";
 import { chartColors } from "@/lib/chartColors";
 import useSelection from "@/hooks/useSelection";
+import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 const chartConfig = {
   distance: {
@@ -33,6 +34,7 @@ export function ActivitiesChart() {
   const data = useGarminData();
   const { activity, range } = useDashboardFilters();
   const { selected, toggle } = useSelection();
+  const prefersReducedMotion = usePrefersReducedMotion();
   if (!data) return <Skeleton className="h-60 md:col-span-2" />;
   let activities = data.activities;
 
@@ -86,7 +88,10 @@ export function ActivitiesChart() {
             type="monotone"
             dataKey="distance"
             stroke={chartConfig.distance.color}
-            animationDuration={300}
+            animationDuration={prefersReducedMotion ? 0 : 300}
+            animationEasing="ease-in-out"
+            isAnimationActive={!prefersReducedMotion}
+            className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
           />
         )}
         {(!selected.length || selected.includes("duration")) && (
@@ -95,7 +100,10 @@ export function ActivitiesChart() {
             type="monotone"
             dataKey="duration"
             stroke={chartConfig.duration.color}
-            animationDuration={300}
+            animationDuration={prefersReducedMotion ? 0 : 300}
+            animationEasing="ease-in-out"
+            isAnimationActive={!prefersReducedMotion}
+            className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
           />
         )}
       </LineChart>

--- a/src/components/dashboard/AcwrGauge.tsx
+++ b/src/components/dashboard/AcwrGauge.tsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
+import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 export interface AcwrGaugeProps {
   /** Array of daily training load values ordered from oldest to newest */
@@ -29,6 +30,7 @@ export function AcwrGauge({
 }: AcwrGaugeProps) {
   const ratio = useAcwr(loads);
   const normalized = Math.min(Math.max(ratio, 0), 2) / 2; // 0-2 mapped to 0-1
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const radius = size / 2 - strokeWidth / 2;
   const circumference = Math.PI * radius; // half circle
@@ -73,6 +75,12 @@ export function AcwrGauge({
                 strokeDasharray={circumference}
                 strokeDashoffset={offset}
                 strokeLinecap="round"
+                className="motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-in-out hover:opacity-80"
+                style={{
+                  transition: prefersReducedMotion
+                    ? "none"
+                    : "stroke-dashoffset 0.5s cubic-bezier(0.4,0,0.2,1)",
+                }}
               />
             </svg>
             <span className="mt-2 text-lg font-bold tabular-nums">

--- a/src/components/dashboard/BedToRunGauge.tsx
+++ b/src/components/dashboard/BedToRunGauge.tsx
@@ -12,6 +12,7 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
+import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 export interface BedToRunGaugeProps {
   /** Diameter of the gauge in pixels */
@@ -31,6 +32,7 @@ export default function BedToRunGauge({
   safeRange = [0.1, 0.25],
 }: BedToRunGaugeProps) {
   const [ratio, setRatio] = useState<number | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     Promise.all([getSleepSessions(), getRunBikeVolume()]).then(
@@ -93,6 +95,12 @@ export default function BedToRunGauge({
                 strokeDasharray={circumference}
                 strokeDashoffset={offset}
                 strokeLinecap="round"
+                className="motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-in-out hover:opacity-80"
+                style={{
+                  transition: prefersReducedMotion
+                    ? "none"
+                    : "stroke-dashoffset 0.5s cubic-bezier(0.4,0,0.2,1)",
+                }}
               />
             </svg>
             <span className="mt-2 text-lg font-bold tabular-nums">

--- a/src/components/dashboard/CircularFragilityRing.tsx
+++ b/src/components/dashboard/CircularFragilityRing.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import useFragilityIndex from '@/hooks/useFragilityIndex'
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { Skeleton } from '@/components/ui/skeleton'
+import usePrefersReducedMotion from '@/hooks/usePrefersReducedMotion'
 
 export interface CircularFragilityRingProps {
   /** Diameter of the ring in pixels */
@@ -16,10 +17,15 @@ export interface CircularFragilityRingProps {
 export default function CircularFragilityRing({ size = 160, strokeWidth = 12 }: CircularFragilityRingProps) {
   const fragility = useFragilityIndex()
   const [displayIndex, setDisplayIndex] = useState(0)
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   useEffect(() => {
     if (!fragility) return
     const { index } = fragility
+    if (prefersReducedMotion) {
+      setDisplayIndex(index)
+      return
+    }
     setDisplayIndex(0)
     let start: number | null = null
     const duration = 500
@@ -32,7 +38,7 @@ export default function CircularFragilityRing({ size = 160, strokeWidth = 12 }: 
     }
     frame = requestAnimationFrame(animate)
     return () => cancelAnimationFrame(frame)
-  }, [fragility])
+  }, [fragility, prefersReducedMotion])
 
   if (!fragility) return <Skeleton className="h-40" />
   const { index } = fragility
@@ -68,7 +74,12 @@ export default function CircularFragilityRing({ size = 160, strokeWidth = 12 }: 
                 strokeDasharray={circumference}
                 strokeDashoffset={offset}
                 strokeLinecap="round"
-                style={{ transition: 'stroke-dashoffset 0.5s ease, stroke 0.5s ease' }}
+                className="motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-in-out hover:opacity-80"
+                style={{
+                  transition: prefersReducedMotion
+                    ? 'none'
+                    : 'stroke-dashoffset 0.5s cubic-bezier(0.4,0,0.2,1), stroke 0.5s cubic-bezier(0.4,0,0.2,1)',
+                }}
                 transform={`rotate(-90 ${size / 2} ${size / 2})`}
               />
             </svg>

--- a/src/components/dashboard/FragilityGauge.tsx
+++ b/src/components/dashboard/FragilityGauge.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/comp
 import { Skeleton } from '@/components/ui/skeleton'
 import { getFragilityLevel } from '@/lib/fragility'
 import useSelection from '@/hooks/useSelection'
+import usePrefersReducedMotion from '@/hooks/usePrefersReducedMotion'
 
 export interface FragilityGaugeProps {
   /** Diameter of the gauge in pixels */
@@ -19,10 +20,15 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
   const fragility = useFragilityIndex()
   const [displayIndex, setDisplayIndex] = useState(0)
   const { selected, toggle } = useSelection()
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   useEffect(() => {
     if (!fragility) return
     const { index } = fragility
+    if (prefersReducedMotion) {
+      setDisplayIndex(index)
+      return
+    }
     setDisplayIndex(0)
     let start: number | null = null
     const duration = 500
@@ -35,7 +41,7 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
     }
     frame = requestAnimationFrame(animate)
     return () => cancelAnimationFrame(frame)
-  }, [fragility])
+  }, [fragility, prefersReducedMotion])
 
   if (!fragility) return <Skeleton className="h-32" />
   const { index } = fragility
@@ -82,7 +88,12 @@ export default function FragilityGauge({ size = 160, strokeWidth = 12 }: Fragili
                 strokeDasharray={circumference}
                 strokeDashoffset={offset}
                 strokeLinecap="round"
-                style={{ transition: 'stroke-dashoffset 0.5s ease' }}
+                className="motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-in-out hover:opacity-80"
+                style={{
+                  transition: prefersReducedMotion
+                    ? 'none'
+                    : 'stroke-dashoffset 0.5s cubic-bezier(0.4,0,0.2,1)',
+                }}
               />
             </svg>
             <span className="mt-2 text-lg font-bold tabular-nums">

--- a/src/components/dashboard/StepsChart.tsx
+++ b/src/components/dashboard/StepsChart.tsx
@@ -17,6 +17,7 @@ import { useGarminDaysLazy } from "@/hooks/useGarminData";
 import useDashboardFilters from "@/hooks/useDashboardFilters";
 import { Skeleton } from "@/components/ui/skeleton";
 import { chartColors } from "@/lib/chartColors";
+import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 const chartConfig = {
   steps: {
@@ -88,6 +89,7 @@ export interface StepsChartProps {
 export function StepsChart({ active = true }: StepsChartProps = {}) {
   const data = useGarminDaysLazy(active);
   const { range } = useDashboardFilters();
+  const prefersReducedMotion = usePrefersReducedMotion();
   if (!data) return <Skeleton className="h-60 w-full" />;
 
   const days = range === '7d' ? 7 : range === '30d' ? 30 : 90;
@@ -132,11 +134,18 @@ export function StepsChart({ active = true }: StepsChartProps = {}) {
         />
         <YAxis />
         <ChartTooltip content={<StepsTooltip />} />
-        <Bar dataKey="steps" fill={chartConfig.steps.color} animationDuration={300}>
+        <Bar
+          dataKey="steps"
+          fill={chartConfig.steps.color}
+          animationDuration={prefersReducedMotion ? 0 : 300}
+          animationEasing="ease-in-out"
+          isAnimationActive={!prefersReducedMotion}
+        >
           {enriched.map((day) => (
             <Cell
               key={day.date}
               aria-label={`${day.steps.toLocaleString()} steps on ${new Date(day.date).toLocaleDateString()}`}
+              className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
             />
           ))}
         </Bar>

--- a/src/components/dashboard/StepsTrendWithGoal.tsx
+++ b/src/components/dashboard/StepsTrendWithGoal.tsx
@@ -20,6 +20,7 @@ import { useRunningStats } from "@/hooks/useRunningStats";
 import { Info } from "lucide-react";
 import type { TooltipProps } from "recharts";
 import { Skeleton } from "@/components/ui/skeleton";
+import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 export interface StepsTrendWithGoalProps {
   data: GarminDay[];
@@ -85,6 +86,7 @@ export function StepsTrendWithGoal({
       .filter((d) => d.condition === 'Rain' || d.condition === 'Snow' || d.temperature >= 85)
       .map((d) => ({ date: d.date, temp: d.temperature, condition: d.condition }))
   }, [stats])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const chartConfig = {
     steps: { label: "Pace", color: "hsl(var(--chart-1))" },
@@ -178,9 +180,21 @@ export function StepsTrendWithGoal({
             type="monotone"
             stroke={chartConfig.steps.color}
             fill={`url(#${fillStepsId})`}
-            animationDuration={300}
+            animationDuration={prefersReducedMotion ? 0 : 300}
+            animationEasing="ease-in-out"
+            isAnimationActive={!prefersReducedMotion}
+            className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
           />
-        <Line dataKey="avg" type="monotone" stroke={chartConfig.avg.color} dot={false} animationDuration={300} />
+        <Line
+          dataKey="avg"
+          type="monotone"
+          stroke={chartConfig.avg.color}
+          dot={false}
+          animationDuration={prefersReducedMotion ? 0 : 300}
+          animationEasing="ease-in-out"
+          isAnimationActive={!prefersReducedMotion}
+          className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
+        />
       </AreaChart>
       </ChartContainer>
       {weatherNote && (

--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -14,6 +14,7 @@ import useWeeklyVolume from "@/hooks/useWeeklyVolume";
 import { useChartSelection } from "./ChartSelectionContext";
 import { useEffect, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
 function BrushHandle({ x, y, width, height, stroke }: any) {
   const line1 = x + width / 2 - 3;
@@ -47,6 +48,7 @@ export default function WeeklyVolumeChart() {
   const [brushTooltip, setBrushTooltip] = useState<
     { x: number; y: number; start: string; end: string } | null
   >(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     if (data && range.start === null && range.end === null && data.length) {
@@ -98,7 +100,15 @@ export default function WeeklyVolumeChart() {
               }}
             />
             <ChartTooltip />
-            <Bar dataKey="miles" fill="var(--chart-1)" radius={2} animationDuration={300} />
+            <Bar
+              dataKey="miles"
+              fill="var(--chart-1)"
+              radius={2}
+              animationDuration={prefersReducedMotion ? 0 : 300}
+              animationEasing="ease-in-out"
+              isAnimationActive={!prefersReducedMotion}
+              className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
+            />
             <Brush
               dataKey="week"
               height={30}

--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -14,8 +14,6 @@ export default function MileageGlobe({ weekRange, autoRotate = false }: MileageG
   )
   const [worldError, setWorldError] = useState(false)
 
-  const [worldError, setWorldError] = useState(false)
-
   useEffect(() => {
     // Simulate loading of world data to satisfy tests
     fetch('/world-110m.json').catch(() => setWorldError(true))
@@ -28,14 +26,6 @@ export default function MileageGlobe({ weekRange, autoRotate = false }: MileageG
       </div>
     )
   }
-  if (worldError) {
-    return (
-      <div className='flex items-center justify-center h-96 w-full bg-muted text-muted-foreground rounded'>
-        Map unavailable
-      </div>
-    )
-  }
-
   if (worldError) {
     return (
       <div className='flex items-center justify-center h-96 w-full bg-muted text-muted-foreground rounded'>

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -15,10 +15,12 @@ import ChartCard from '@/components/dashboard/ChartCard'
 import type { ChartConfig } from '@/components/ui/chart'
 import useWeeklyVolumeHistory from '@/hooks/useWeeklyVolumeHistory'
 import { Skeleton } from '@/components/ui/skeleton'
+import usePrefersReducedMotion from '@/hooks/usePrefersReducedMotion'
 
 export default function WeeklyVolumeHistoryChart() {
   const data = useWeeklyVolumeHistory()
   const [range, setRange] = useState<[number, number]>([0, 0])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   useEffect(() => {
     if (data) {
@@ -70,7 +72,15 @@ export default function WeeklyVolumeHistoryChart() {
               />
             }
           />
-          <Bar dataKey="miles" fill="var(--color-miles)" radius={2} animationDuration={300} />
+          <Bar
+            dataKey="miles"
+            fill="var(--color-miles)"
+            radius={2}
+            animationDuration={prefersReducedMotion ? 0 : 300}
+            animationEasing="ease-in-out"
+            isAnimationActive={!prefersReducedMotion}
+            className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
+          />
         </BarChart>
       </ChartContainer>
       <div className="mt-4">

--- a/src/components/map/LocationEfficiencyComparison.tsx
+++ b/src/components/map/LocationEfficiencyComparison.tsx
@@ -17,6 +17,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import useLocationEfficiency from '@/hooks/useLocationEfficiency'
 import statesTopo from '@/lib/us-states.json'
 import CITY_COORDS from '@/lib/cityCoords'
+import usePrefersReducedMotion from '@/hooks/usePrefersReducedMotion'
 
 
 const config = {
@@ -37,6 +38,7 @@ export default function LocationEfficiencyComparison() {
   if (!data) return <Skeleton className="h-64" />
 
   const sorted = [...data].sort((a, b) => b.effort - a.effort)
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   return (
     <ChartCard
@@ -79,9 +81,19 @@ export default function LocationEfficiencyComparison() {
               <XAxis dataKey="city" />
               <YAxis />
               <ChartTooltip />
-              <Bar dataKey="effort" fill={config.effort.color} animationDuration={300}>
+              <Bar
+                dataKey="effort"
+                fill={config.effort.color}
+                animationDuration={prefersReducedMotion ? 0 : 300}
+                animationEasing="ease-in-out"
+                isAnimationActive={!prefersReducedMotion}
+              >
                 {sorted.map((l) => (
-                  <Cell key={l.city} aria-label={`Effort for ${l.city}`} />
+                  <Cell
+                    key={l.city}
+                    aria-label={`Effort for ${l.city}`}
+                    className="motion-safe:transition-opacity motion-safe:duration-300 motion-safe:ease-in-out hover:opacity-80"
+                  />
                 ))}
               </Bar>
             </BarChart>


### PR DESCRIPTION
## Summary
- add ease-in-out animations with hover transitions to line and bar charts
- animate gauge arcs with spring-like transitions and respect reduced-motion preferences
- fix duplicate world map state in MileageGlobe example

## Testing
- `npm test -- --run` *(fails: useFragilityHistory > returns ordered fragility points and skips missing days)*

------
https://chatgpt.com/codex/tasks/task_e_688ed03c1cbc8324b9579249815f607c