### PR TITLE
feat: add risk timeline with confidence bands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import FocusHistoryPage from "@/pages/FocusHistory";
 import InterventionSettingsPage from "@/pages/InterventionSettings";
 
 import PrivacyDashboardPage from "@/pages/PrivacyDashboard";
+import BehavioralCharterMapPage from "@/pages/BehavioralCharterMap";
 
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
@@ -106,6 +107,7 @@ function App() {
               <Route path="charts/radial-chart-grid" element={<RadialChartGridPage />} />
               <Route path="focus-history" element={<FocusHistoryPage />} />
               <Route path="settings" element={<InterventionSettingsPage />} />
+              <Route path="behavioral-charter-map" element={<BehavioralCharterMapPage />} />
             </Route>
           </Routes>
         </Layout>

--- a/src/components/visualizations/index.ts
+++ b/src/components/visualizations/index.ts
@@ -1,4 +1,5 @@
 export { default as BehavioralCharterMap } from "./BehavioralCharterMap";
+export type { Segment } from "./BehavioralCharterMap";
 export { default as TransitionMatrix } from "./TransitionMatrix";
 export { default as CorrelationRippleMatrix } from "./CorrelationRippleMatrix";
 export { default as FocusTimeline } from "./FocusTimeline";

--- a/src/pages/BehavioralCharterMap.tsx
+++ b/src/pages/BehavioralCharterMap.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { BehavioralCharterMap, Segment } from "@/components/visualizations";
+
+const demoSegments: Segment[] = [
+  {
+    time: "2024-01-01T00:00:00Z",
+    state: "reading",
+    probability: 0.8,
+    risk: 0.2,
+    ciLow: 0.1,
+    ciHigh: 0.3,
+  },
+  {
+    time: "2024-01-01T00:30:00Z",
+    state: "writing",
+    probability: 0.5,
+    risk: 0.4,
+    ciLow: 0.3,
+    ciHigh: 0.5,
+  },
+  {
+    time: "2024-01-01T01:00:00Z",
+    state: "idle",
+    probability: 0.2,
+    risk: 0.6,
+    ciLow: 0.5,
+    ciHigh: 0.7,
+    thresholds: [0.5],
+  },
+  {
+    time: "2024-01-01T01:30:00Z",
+    state: "reading",
+    probability: 0.7,
+    risk: 0.3,
+    ciLow: 0.2,
+    ciHigh: 0.4,
+  },
+];
+
+const states = ["reading", "writing", "idle"];
+
+export default function BehavioralCharterMapPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Behavioral Charter Map</h1>
+      <BehavioralCharterMap
+        day="2024-01-01"
+        segments={demoSegments}
+        states={states}
+        riskThresholds={[0.5]}
+      />
+    </div>
+  );
+}
+

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -64,6 +64,11 @@ export const analyticsRoutes: DashboardRoute[] = [
     label: "Intervention Settings",
     description: "Configure reminder preferences",
   },
+  {
+    to: "/dashboard/behavioral-charter-map",
+    label: "Behavioral Charter Map",
+    description: "Timeline of activity segments with risk scores",
+  },
 ];
 
 export const dashboardRoutes: DashboardRouteGroup[] = [


### PR DESCRIPTION
## Summary
- extend Segment with risk score and confidence interval fields
- overlay risk line and band with threshold markers on BehavioralCharterMap
- expose Segment type from visualizations index
- add demo page and routes for BehavioralCharterMap

## Testing
- `npx vitest run` *(fails: expected null to deeply equal [ { date: '2025-07-22', value: 0 } ])*


------
https://chatgpt.com/codex/tasks/task_e_688ecbad35f48324be489f1f1a635c28