### PR TITLE
feat(sidebar): add reusable nav section component

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -3,56 +3,16 @@ import {
   Sidebar,
   SidebarHeader,
   SidebarContent,
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarGroupContent,
   SidebarFooter,
-  SidebarMenu,
-  SidebarMenuItem,
-  SidebarMenuButton,
-  SidebarMenuSub,
-  SidebarMenuSubItem,
-  SidebarMenuSubButton,
 } from "@/components/ui/sidebar";
-import { NavLink, useLocation } from "react-router-dom";
-import { Map as MapIcon, ChevronRight, Star, ChartLine } from "lucide-react";
-import * as Collapsible from "@radix-ui/react-collapsible";
+import { useLocation } from "react-router-dom";
+import { Map as MapIcon, ChartLine } from "lucide-react";
 import { chartRouteGroups, mapRoutes, analyticsRoutes } from "@/routes";
-import { cn } from "@/lib/utils";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-  TooltipProvider,
-} from "@/components/ui/tooltip";
+import NavSection from "@/components/nav-section";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 export default function AppSidebar() {
   const { pathname } = useLocation();
-
-  const SIDEBAR_STATE_KEY = "sidebar_group_state";
-  const [openGroups, setOpenGroups] = React.useState<Record<string, boolean>>(() => {
-    if (typeof window === "undefined") return {};
-    try {
-      const stored = localStorage.getItem(SIDEBAR_STATE_KEY);
-      return stored ? JSON.parse(stored) : {};
-    } catch {
-      return {};
-    }
-  });
-
-  const handleOpenChange = (label: string) => (open: boolean) => {
-    setOpenGroups((prev) => {
-      const next = { ...prev, [label]: open };
-      try {
-        if (typeof window !== "undefined") {
-          localStorage.setItem(SIDEBAR_STATE_KEY, JSON.stringify(next));
-        }
-      } catch {
-        // ignore
-      }
-      return next;
-    });
-  };
 
   const FAVORITES_KEY = "favorites";
   const [favorites, setFavorites] = React.useState<string[]>(() => {
@@ -89,6 +49,7 @@ export default function AppSidebar() {
     ],
     []
   );
+
   const favoriteRoutes = React.useMemo(
     () =>
       favorites
@@ -102,226 +63,48 @@ export default function AppSidebar() {
       <Sidebar>
         <SidebarHeader />
         <SidebarContent>
-        {favoriteRoutes.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel>Favorites</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {favoriteRoutes.map((route) => (
-                  <SidebarMenuItem key={route.to}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <SidebarMenuButton
-                          asChild
-                          isActive={pathname === route.to}
-                          className="justify-start"
-                        >
-                          <NavLink
-                            to={route.to}
-                            className="flex w-full items-center"
-                          >
-                            <span className="flex-1">{route.label}</span>
-                            <Star
-                              className="ml-auto h-4 w-4 fill-yellow-400 text-yellow-400"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                toggleFavorite(route.to);
-                              }}
-                            />
-                          </NavLink>
-                        </SidebarMenuButton>
-                      </TooltipTrigger>
-                      {route.description && (
-                        <TooltipContent side="right">
-                          {route.description}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
-        {chartRouteGroups.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel>Charts</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {chartRouteGroups.map((group, index) => {
-                  const Icon = group.icon;
-                  const contentId = `chart-group-${index}`;
-                  const isOpen = openGroups[group.label] ?? index === 0;
-                  return (
-                    <Collapsible.Root
-                      key={group.label}
-                      open={isOpen}
-                      onOpenChange={handleOpenChange(group.label)}
-                    >
-                      <SidebarMenuItem>
-                        <Collapsible.Trigger asChild>
-                          <SidebarMenuButton
-                            className="justify-start"
-                            aria-expanded={isOpen}
-                            aria-controls={contentId}
-                          >
-                            <Icon className="mr-2 h-4 w-4" />
-                            {group.label}
-                            <ChevronRight className="ml-auto transition-transform data-[state=open]:rotate-90" />
-                          </SidebarMenuButton>
-                        </Collapsible.Trigger>
-                        <Collapsible.Content id={contentId}>
-                          <SidebarMenuSub>
-                            {group.items.map((route) => (
-                              <SidebarMenuSubItem key={route.to}>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <SidebarMenuSubButton
-                                      asChild
-                                      isActive={pathname === route.to}
-                                      className="justify-start"
-                                    >
-                                      <NavLink
-                                        to={route.to}
-                                        className="flex w-full items-center"
-                                      >
-                                        <span className="flex-1">
-                                          {route.label}
-                                        </span>
-                                        <Star
-                                          className={cn(
-                                            "ml-auto h-4 w-4",
-                                            favorites.includes(route.to)
-                                              ? "fill-yellow-400 text-yellow-400"
-                                              : "text-muted-foreground"
-                                          )}
-                                          onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            toggleFavorite(route.to);
-                                          }}
-                                        />
-                                      </NavLink>
-                                    </SidebarMenuSubButton>
-                                  </TooltipTrigger>
-                                  {route.description && (
-                                    <TooltipContent side="right">
-                                      {route.description}
-                                    </TooltipContent>
-                                  )}
-                                </Tooltip>
-                              </SidebarMenuSubItem>
-                            ))}
-                          </SidebarMenuSub>
-                        </Collapsible.Content>
-                      </SidebarMenuItem>
-                    </Collapsible.Root>
-                  );
-                })}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
-        {analyticsRoutes.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel>Analytics</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {analyticsRoutes.map((route) => (
-                  <SidebarMenuItem key={route.to}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <SidebarMenuButton
-                          asChild
-                          isActive={pathname === route.to}
-                          className="justify-start"
-                        >
-                          <NavLink
-                            to={route.to}
-                            className="flex w-full items-center"
-                          >
-                            <ChartLine className="mr-2 h-4 w-4" />
-                            <span className="flex-1">{route.label}</span>
-                            <Star
-                              className={cn(
-                                "ml-auto h-4 w-4",
-                                favorites.includes(route.to)
-                                  ? "fill-yellow-400 text-yellow-400"
-                                  : "text-muted-foreground"
-                              )}
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                toggleFavorite(route.to);
-                              }}
-                            />
-                          </NavLink>
-                        </SidebarMenuButton>
-                      </TooltipTrigger>
-                      {route.description && (
-                        <TooltipContent side="right">
-                          {route.description}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
-        {mapRoutes.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel>Maps</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {mapRoutes.map((route) => (
-                  <SidebarMenuItem key={route.to}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <SidebarMenuButton
-                          asChild
-                          isActive={pathname === route.to}
-                          className="justify-start"
-                        >
-                          <NavLink
-                            to={route.to}
-                            className="flex w-full items-center"
-                          >
-                            <MapIcon className="mr-2" />
-                            <span className="flex-1">{route.label}</span>
-                            <Star
-                              className={cn(
-                                "ml-auto h-4 w-4",
-                                favorites.includes(route.to)
-                                  ? "fill-yellow-400 text-yellow-400"
-                                  : "text-muted-foreground"
-                              )}
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                toggleFavorite(route.to);
-                              }}
-                            />
-                          </NavLink>
-                        </SidebarMenuButton>
-                      </TooltipTrigger>
-                      {route.description && (
-                        <TooltipContent side="right">
-                          {route.description}
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
-      </SidebarContent>
-      <SidebarFooter />
-    </Sidebar>
+          {favoriteRoutes.length > 0 && (
+            <NavSection
+              label="Favorites"
+              routes={favoriteRoutes}
+              pathname={pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+            />
+          )}
+          {chartRouteGroups.length > 0 && (
+            <NavSection
+              label="Charts"
+              groups={chartRouteGroups}
+              pathname={pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+            />
+          )}
+          {analyticsRoutes.length > 0 && (
+            <NavSection
+              label="Analytics"
+              routes={analyticsRoutes}
+              icon={ChartLine}
+              pathname={pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+            />
+          )}
+          {mapRoutes.length > 0 && (
+            <NavSection
+              label="Maps"
+              routes={mapRoutes}
+              icon={MapIcon}
+              pathname={pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+            />
+          )}
+        </SidebarContent>
+        <SidebarFooter />
+      </Sidebar>
     </TooltipProvider>
   );
 }
+

--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { ChevronRight, Star } from "lucide-react";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import type { LucideIcon } from "lucide-react";
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+  SidebarMenuSubButton,
+} from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { DashboardRoute, DashboardRouteGroup } from "@/routes";
+
+interface NavSectionProps {
+  label: string;
+  routes?: DashboardRoute[];
+  groups?: DashboardRouteGroup[];
+  icon?: LucideIcon;
+  pathname: string;
+  favorites: string[];
+  toggleFavorite: (to: string) => void;
+}
+
+export default function NavSection({
+  label,
+  routes,
+  groups,
+  icon: Icon,
+  pathname,
+  favorites,
+  toggleFavorite,
+}: NavSectionProps) {
+  const storageKey = `nav_section_state_${label}`;
+  const [openGroups, setOpenGroups] = React.useState<Record<string, boolean>>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      const stored = localStorage.getItem(storageKey);
+      return stored ? JSON.parse(stored) : {};
+    } catch {
+      return {};
+    }
+  });
+
+  const handleOpenChange = (groupLabel: string) => (open: boolean) => {
+    setOpenGroups((prev) => {
+      const next = { ...prev, [groupLabel]: open };
+      try {
+        if (typeof window !== "undefined") {
+          localStorage.setItem(storageKey, JSON.stringify(next));
+        }
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  };
+
+  if (routes?.length) {
+    return (
+      <SidebarGroup>
+        <SidebarGroupLabel>{label}</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {routes.map((route) => (
+              <SidebarMenuItem key={route.to}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={pathname === route.to}
+                      className="justify-start"
+                    >
+                      <NavLink to={route.to} className="flex w-full items-center">
+                        {Icon && <Icon className="mr-2 h-4 w-4" />}
+                        <span className="flex-1">{route.label}</span>
+                        <Star
+                          className={cn(
+                            "ml-auto h-4 w-4",
+                            favorites.includes(route.to)
+                              ? "fill-yellow-400 text-yellow-400"
+                              : "text-muted-foreground"
+                          )}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            toggleFavorite(route.to);
+                          }}
+                        />
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </TooltipTrigger>
+                  {route.description && (
+                    <TooltipContent side="right">
+                      {route.description}
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    );
+  }
+
+  if (groups?.length) {
+    return (
+      <SidebarGroup>
+        <SidebarGroupLabel>{label}</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {groups.map((group, index) => {
+              const GroupIcon = group.icon;
+              const contentId = `${label}-group-${index}`;
+              const isOpen = openGroups[group.label] ?? index === 0;
+              return (
+                <Collapsible.Root
+                  key={group.label}
+                  open={isOpen}
+                  onOpenChange={handleOpenChange(group.label)}
+                >
+                  <SidebarMenuItem>
+                    <Collapsible.Trigger asChild>
+                      <SidebarMenuButton
+                        className="justify-start"
+                        aria-expanded={isOpen}
+                        aria-controls={contentId}
+                      >
+                        <GroupIcon className="mr-2 h-4 w-4" />
+                        {group.label}
+                        <ChevronRight className="ml-auto transition-transform data-[state=open]:rotate-90" />
+                      </SidebarMenuButton>
+                    </Collapsible.Trigger>
+                    <Collapsible.Content id={contentId}>
+                      <SidebarMenuSub>
+                        {group.items.map((route) => (
+                          <SidebarMenuSubItem key={route.to}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <SidebarMenuSubButton
+                                  asChild
+                                  isActive={pathname === route.to}
+                                  className="justify-start"
+                                >
+                                  <NavLink
+                                    to={route.to}
+                                    className="flex w-full items-center"
+                                  >
+                                    <span className="flex-1">{route.label}</span>
+                                    <Star
+                                      className={cn(
+                                        "ml-auto h-4 w-4",
+                                        favorites.includes(route.to)
+                                          ? "fill-yellow-400 text-yellow-400"
+                                          : "text-muted-foreground"
+                                      )}
+                                      onClick={(e) => {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        toggleFavorite(route.to);
+                                      }}
+                                    />
+                                  </NavLink>
+                                </SidebarMenuSubButton>
+                              </TooltipTrigger>
+                              {route.description && (
+                                <TooltipContent side="right">
+                                  {route.description}
+                                </TooltipContent>
+                              )}
+                            </Tooltip>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    </Collapsible.Content>
+                  </SidebarMenuItem>
+                </Collapsible.Root>
+              );
+            })}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    );
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- create `NavSection` component for sidebar groups
- replace repeated sidebar sections with `NavSection`

## Testing
- `npm test` *(fails: expect(...).toHaveStyle)*

------
https://chatgpt.com/codex/tasks/task_e_688ed286d4288324b10a89fb6cf22ab9