### PR TITLE
test: add route metrics edge cases

### DIFF
--- a/src/lib/__tests__/routeMetrics.test.ts
+++ b/src/lib/__tests__/routeMetrics.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { computeRouteMetrics } from '../routeMetrics'
+import type { LatLon } from '../api'
+
+describe('computeRouteMetrics - DTW similarity', () => {
+  it('returns perfect similarity for identical single-point routes', () => {
+    const route: LatLon[] = [{ lat: 0, lon: 0 }]
+    const metrics = computeRouteMetrics(route, route)
+    expect(metrics.overlapSimilarity).toBe(1)
+    expect(metrics.dtwSimilarity).toBe(1)
+    expect(metrics.maxSimilarity).toBe(1)
+  })
+
+  it('computes expected DTW similarity for diverging simple routes', () => {
+    const a: LatLon[] = [
+      { lat: 0, lon: 0 },
+      { lat: 0, lon: 1 },
+    ]
+    const b: LatLon[] = [
+      { lat: 0, lon: 0 },
+      { lat: 0, lon: 2 },
+    ]
+    const metrics = computeRouteMetrics(a, b)
+    expect(metrics.overlapSimilarity).toBeCloseTo(1 / 3)
+    expect(metrics.dtwSimilarity).toBeCloseTo(0.8)
+    expect(metrics.maxSimilarity).toBeCloseTo(0.8)
+  })
+})
+
+describe('computeRouteMetrics - overlap vs DTW dominance', () => {
+  it('uses overlap similarity when higher than DTW', () => {
+    const a: LatLon[] = [
+      { lat: 0, lon: 0 },
+      { lat: 0, lon: 1 },
+    ]
+    const b: LatLon[] = [
+      { lat: 0, lon: 1 },
+      { lat: 0, lon: 0 },
+    ]
+    const metrics = computeRouteMetrics(a, b)
+    expect(metrics.overlapSimilarity).toBe(1)
+    expect(metrics.dtwSimilarity).toBeCloseTo(2 / 3)
+    expect(metrics.maxSimilarity).toBe(1)
+  })
+
+  it('handles single-point routes with different points', () => {
+    const a: LatLon[] = [{ lat: 0, lon: 0 }]
+    const b: LatLon[] = [{ lat: 0, lon: 1 }]
+    const metrics = computeRouteMetrics(a, b)
+    expect(metrics.overlapSimilarity).toBe(0)
+    expect(metrics.dtwSimilarity).toBeCloseTo(2 / 3)
+    expect(metrics.maxSimilarity).toBeCloseTo(2 / 3)
+  })
+
+  it('handles empty routes', () => {
+    const metrics = computeRouteMetrics([], [])
+    expect(metrics.overlapSimilarity).toBe(0)
+    expect(metrics.dtwSimilarity).toBeNaN()
+    expect(metrics.maxSimilarity).toBeNaN()
+  })
+})


### PR DESCRIPTION
## Summary
- add computeRouteMetrics unit tests for DTW and overlap dominance
- cover empty and single-point route edge cases

## Testing
- `npm test` *(fails: CircularFragilityRing & FragilityGauge tests)*
- `npx vitest run src/lib/__tests__/routeMetrics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688ed3e1b4108324a14e09754cf72fda