### PR TITLE
feat: add hooks for sidebar persistence

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -10,36 +10,12 @@ import { Map as MapIcon, ChartLine } from "lucide-react";
 import { chartRouteGroups, mapRoutes, analyticsRoutes } from "@/routes";
 import NavSection from "@/components/nav-section";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import useFavorites from "@/hooks/useFavorites";
 
 export default function AppSidebar() {
   const { pathname } = useLocation();
 
-  const FAVORITES_KEY = "favorites";
-  const [favorites, setFavorites] = React.useState<string[]>(() => {
-    if (typeof window === "undefined") return [];
-    try {
-      const stored = localStorage.getItem(FAVORITES_KEY);
-      return stored ? JSON.parse(stored) : [];
-    } catch {
-      return [];
-    }
-  });
-
-  const toggleFavorite = (to: string) => {
-    setFavorites((prev) => {
-      const next = prev.includes(to)
-        ? prev.filter((r) => r !== to)
-        : [...prev, to];
-      try {
-        if (typeof window !== "undefined") {
-          localStorage.setItem(FAVORITES_KEY, JSON.stringify(next));
-        }
-      } catch {
-        // ignore
-      }
-      return next;
-    });
-  };
+  const { favorites, toggleFavorite } = useFavorites();
 
   const allRoutes = React.useMemo(
     () => [

--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -21,6 +21,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { DashboardRoute, DashboardRouteGroup } from "@/routes";
+import usePersistedGroups from "@/hooks/usePersistedGroups";
 
 interface NavSectionProps {
   label: string;
@@ -42,29 +43,7 @@ export default function NavSection({
   toggleFavorite,
 }: NavSectionProps) {
   const storageKey = `nav_section_state_${label}`;
-  const [openGroups, setOpenGroups] = React.useState<Record<string, boolean>>(() => {
-    if (typeof window === "undefined") return {};
-    try {
-      const stored = localStorage.getItem(storageKey);
-      return stored ? JSON.parse(stored) : {};
-    } catch {
-      return {};
-    }
-  });
-
-  const handleOpenChange = (groupLabel: string) => (open: boolean) => {
-    setOpenGroups((prev) => {
-      const next = { ...prev, [groupLabel]: open };
-      try {
-        if (typeof window !== "undefined") {
-          localStorage.setItem(storageKey, JSON.stringify(next));
-        }
-      } catch {
-        // ignore
-      }
-      return next;
-    });
-  };
+  const { openGroups, handleOpenChange } = usePersistedGroups(storageKey);
 
   if (routes?.length) {
     return (

--- a/src/hooks/__tests__/useFavorites.test.tsx
+++ b/src/hooks/__tests__/useFavorites.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act } from "@testing-library/react";
+import useFavorites from "../useFavorites";
+import { describe, it, expect, beforeEach } from "vitest";
+
+describe("useFavorites", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty array by default", () => {
+    const { result } = renderHook(() => useFavorites());
+    expect(result.current.favorites).toEqual([]);
+  });
+
+  it("toggles and persists favorites", () => {
+    const { result } = renderHook(() => useFavorites());
+    act(() => result.current.toggleFavorite("/foo"));
+    expect(result.current.favorites).toEqual(["/foo"]);
+    const stored = localStorage.getItem("favorites");
+    expect(stored).toBe(JSON.stringify(["/foo"]));
+  });
+});

--- a/src/hooks/__tests__/usePersistedGroups.test.tsx
+++ b/src/hooks/__tests__/usePersistedGroups.test.tsx
@@ -1,0 +1,22 @@
+import { renderHook, act } from "@testing-library/react";
+import usePersistedGroups from "../usePersistedGroups";
+import { describe, it, expect, beforeEach } from "vitest";
+
+describe("usePersistedGroups", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns empty map by default", () => {
+    const { result } = renderHook(() => usePersistedGroups("test_key"));
+    expect(result.current.openGroups).toEqual({});
+  });
+
+  it("persists group state", () => {
+    const { result } = renderHook(() => usePersistedGroups("test_key"));
+    act(() => result.current.handleOpenChange("Group A")(true));
+    expect(result.current.openGroups["Group A"]).toBe(true);
+    const stored = JSON.parse(localStorage.getItem("test_key") || "{}");
+    expect(stored["Group A"]).toBe(true);
+  });
+});

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from "react";
+
+const STORAGE_KEY = "favorites";
+
+/**
+ * Hook managing a list of favorite route paths persisted to localStorage.
+ *
+ * Defaults to an empty array on the server to avoid hydration mismatches.
+ */
+export function useFavorites() {
+  const [favorites, setFavorites] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  const toggleFavorite = useCallback((to: string) => {
+    setFavorites((prev) => {
+      const next = prev.includes(to)
+        ? prev.filter((r) => r !== to)
+        : [...prev, to];
+      try {
+        if (typeof window !== "undefined") {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        }
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  return { favorites, toggleFavorite } as const;
+}
+
+export default useFavorites;

--- a/src/hooks/usePersistedGroups.ts
+++ b/src/hooks/usePersistedGroups.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback } from "react";
+
+/**
+ * Persists a map of group labels to their open/closed state in localStorage.
+ *
+ * Returns an empty object on the server for SSR safety.
+ */
+export function usePersistedGroups(storageKey: string) {
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      const stored = localStorage.getItem(storageKey);
+      return stored ? (JSON.parse(stored) as Record<string, boolean>) : {};
+    } catch {
+      return {};
+    }
+  });
+
+  const handleOpenChange = useCallback(
+    (groupLabel: string) => (open: boolean) => {
+      setOpenGroups((prev) => {
+        const next = { ...prev, [groupLabel]: open };
+        try {
+          if (typeof window !== "undefined") {
+            localStorage.setItem(storageKey, JSON.stringify(next));
+          }
+        } catch {
+          // ignore
+        }
+        return next;
+      });
+    },
+    [storageKey]
+  );
+
+  return { openGroups, handleOpenChange } as const;
+}
+
+export default usePersistedGroups;


### PR DESCRIPTION
## Summary
- abstract favorite routes to `useFavorites`
- store nav group open state via `usePersistedGroups`
- refactor sidebar components to use new hooks

## Testing
- `npm test` *(fails: CircularFragilityRing & FragilityGauge style expectations)*

------
https://chatgpt.com/codex/tasks/task_e_688ed3cd2ac0832489cbc443a8f1ea6e