### PR TITLE
refactor: consolidate routes

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -7,7 +7,12 @@ import {
 } from "@/components/ui/sidebar";
 import { useLocation } from "react-router-dom";
 import { Map as MapIcon, ChartLine } from "lucide-react";
-import { chartRouteGroups, mapRoutes, analyticsRoutes } from "@/routes";
+import {
+  chartRouteGroups,
+  mapRoutes,
+  analyticsRoutes,
+  dashboardRoutes,
+} from "@/routes";
 import NavSection from "@/components/nav-section";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import useFavorites from "@/hooks/useFavorites";
@@ -19,8 +24,7 @@ export default function AppSidebar() {
 
   const allRoutes = React.useMemo(
     () => [
-      ...mapRoutes,
-      ...analyticsRoutes,
+      ...dashboardRoutes.flatMap((g) => g.items),
       ...chartRouteGroups.flatMap((g) => g.items),
     ],
     []

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,6 +14,7 @@ export interface DashboardRoute {
   label: string;
   description?: string;
   tooltip?: string;
+  tags?: string[];
 }
 
 export interface DashboardRouteGroup {
@@ -22,54 +23,6 @@ export interface DashboardRouteGroup {
   items: DashboardRoute[];
 }
 
-
-export const analyticsRoutes: DashboardRoute[] = [
-  {
-    to: "/dashboard/mileage-globe",
-    label: "Global Mileage Map",
-    description: "Visualize mileage across the world using a globe",
-  },
-  {
-    to: "/dashboard/fragility",
-    label: "Fragility Analysis",
-    description: "Review training fragility indicators",
-  },
-  {
-    to: "/dashboard/session-similarity",
-    label: "Session Similarity Analysis",
-    description: "Find training sessions that resemble each other",
-  },
-  {
-    to: "/dashboard/good-day",
-    label: "Good Day Analysis",
-    description: "Identify patterns that contribute to positive days",
-  },
-  {
-    to: "/dashboard/habit-consistency",
-    label: "Habit Consistency Trend",
-    description: "Track how consistently habits are maintained over time",
-  },
-  {
-    to: "/dashboard/statistics",
-    label: "Metric Correlation Matrix",
-    description: "Explore correlations between daily metrics",
-  },
-  {
-    to: "/dashboard/focus-history",
-    label: "Focus History",
-    description: "Review past focus detections and interventions",
-  },
-  {
-    to: "/dashboard/settings",
-    label: "Intervention Settings",
-    description: "Configure reminder preferences",
-  },
-  {
-    to: "/dashboard/behavioral-charter-map",
-    label: "Behavioral Charter Map",
-    description: "Timeline of activity segments with risk scores",
-  },
-];
 
 export const dashboardRoutes: DashboardRouteGroup[] = [
   {
@@ -80,23 +33,73 @@ export const dashboardRoutes: DashboardRouteGroup[] = [
         to: "/dashboard/map",
         label: "State Visits Map",
         description: "View visited states on an interactive map",
+        tags: ["map"],
       },
       {
         to: "/dashboard/route-similarity",
         label: "Route Similarity Analysis",
         description: "Compare routes based on similarity metrics",
+        tags: ["map"],
       },
       {
         to: "/dashboard/route-novelty",
         label: "Route Novelty Analysis",
         description: "Assess how unique a route is compared to known paths",
+        tags: ["map"],
       },
     ],
   },
   {
     label: "Analytics",
     icon: ChartLine,
-    items: analyticsRoutes,
+    items: [
+      {
+        to: "/dashboard/mileage-globe",
+        label: "Global Mileage Map",
+        description: "Visualize mileage across the world using a globe",
+        tags: ["map"],
+      },
+      {
+        to: "/dashboard/fragility",
+        label: "Fragility Analysis",
+        description: "Review training fragility indicators",
+      },
+      {
+        to: "/dashboard/session-similarity",
+        label: "Session Similarity Analysis",
+        description: "Find training sessions that resemble each other",
+      },
+      {
+        to: "/dashboard/good-day",
+        label: "Good Day Analysis",
+        description: "Identify patterns that contribute to positive days",
+      },
+      {
+        to: "/dashboard/habit-consistency",
+        label: "Habit Consistency Trend",
+        description: "Track how consistently habits are maintained over time",
+      },
+      {
+        to: "/dashboard/statistics",
+        label: "Metric Correlation Matrix",
+        description: "Explore correlations between daily metrics",
+      },
+      {
+        to: "/dashboard/focus-history",
+        label: "Focus History",
+        description: "Review past focus detections and interventions",
+      },
+      {
+        to: "/dashboard/settings",
+        label: "Intervention Settings",
+        description: "Configure reminder preferences",
+      },
+      {
+        to: "/dashboard/behavioral-charter-map",
+        label: "Behavioral Charter Map",
+        description: "Timeline of activity segments with risk scores",
+      },
+    ],
   },
   {
     label: "Privacy",
@@ -265,25 +268,11 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
   },
 ];
 
-export const mapRoutes: DashboardRoute[] = [
-  {
-    to: "/dashboard/map",
-    label: "State Visits Map",
-    description: "View visited states on an interactive map",
-  },
-  {
-    to: "/dashboard/route-similarity",
-    label: "Route Similarity Analysis",
-    description: "Compare routes based on similarity metrics",
-  },
-  {
-    to: "/dashboard/route-novelty",
-    label: "Route Novelty Analysis",
-    description: "Assess how unique a route is compared to known paths",
-  },
-  {
-    to: "/dashboard/mileage-globe",
-    label: "Global Mileage Map",
-    description: "Visualize mileage across the world using a globe",
-  },
-];
+const allDashboardRoutes = dashboardRoutes.flatMap((group) => group.items);
+
+export const analyticsRoutes =
+  dashboardRoutes.find((g) => g.label === "Analytics")?.items ?? [];
+
+export const mapRoutes = allDashboardRoutes.filter((route) =>
+  route.tags?.includes("map")
+);


### PR DESCRIPTION
## Summary
- consolidate dashboard routes and derive analytics/map categories by filtering
- update sidebar to consume consolidated route config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ed586e3388324915195fcbd7420d5