### PR TITLE
Use slugified labels for stable nav IDs

### DIFF
--- a/src/components/__tests__/nav-section.test.tsx
+++ b/src/components/__tests__/nav-section.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import { Star } from "lucide-react";
+import NavSection from "../nav-section";
+import { slugify } from "@/lib/utils";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { MemoryRouter } from "react-router-dom";
+
+describe("NavSection contentId", () => {
+  const baseProps = {
+    label: "Section",
+    pathname: "",
+    favorites: [] as string[],
+    toggleFavorite: () => {},
+  };
+
+  const groups = [
+    {
+      label: "First Group",
+      icon: Star,
+      items: [{ to: "/first", label: "First" }],
+    },
+    {
+      label: "Second Group",
+      icon: Star,
+      items: [{ to: "/second", label: "Second" }],
+    },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  const renderWithProvider = (props = {}) =>
+    render(
+      <MemoryRouter>
+        <SidebarProvider>
+          <NavSection {...baseProps} {...props} />
+        </SidebarProvider>
+      </MemoryRouter>
+    );
+
+  it("keeps ids stable across rerenders", () => {
+    const { rerender } = renderWithProvider({ groups });
+
+    const firstTrigger = screen.getByText("First Group").closest("button");
+    const firstId = firstTrigger?.getAttribute("aria-controls");
+
+    expect(firstId).toBe(`Section-group-${slugify("First Group")}`);
+
+    rerender(
+      <MemoryRouter>
+        <SidebarProvider>
+          <NavSection {...baseProps} groups={groups} />
+        </SidebarProvider>
+      </MemoryRouter>
+    );
+    const reRenderedTrigger = screen.getByText("First Group").closest("button");
+    expect(reRenderedTrigger?.getAttribute("aria-controls")).toBe(firstId);
+  });
+
+  it("keeps ids stable when groups are reordered", () => {
+    const { rerender } = renderWithProvider({ groups });
+
+    const secondTrigger = screen.getByText("Second Group").closest("button");
+    const secondId = secondTrigger?.getAttribute("aria-controls");
+
+    rerender(
+      <MemoryRouter>
+        <SidebarProvider>
+          <NavSection {...baseProps} groups={[...groups].reverse()} />
+        </SidebarProvider>
+      </MemoryRouter>
+    );
+
+    const secondTriggerReordered = screen
+      .getByText("Second Group")
+      .closest("button");
+    expect(secondTriggerReordered?.getAttribute("aria-controls")).toBe(
+      secondId,
+    );
+  });
+});

--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -14,7 +14,7 @@ import {
   SidebarMenuSubItem,
   SidebarMenuSubButton,
 } from "@/components/ui/sidebar";
-import { cn } from "@/lib/utils";
+import { cn, slugify } from "@/lib/utils";
 import {
   Tooltip,
   TooltipContent,
@@ -101,7 +101,7 @@ export default function NavSection({
           <SidebarMenu>
             {groups.map((group, index) => {
               const GroupIcon = group.icon;
-              const contentId = `${label}-group-${index}`;
+              const contentId = `${label}-group-${slugify(group.label)}`;
               const isOpen = openGroups[group.label] ?? index === 0;
               return (
                 <Collapsible.Root

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,6 +3,14 @@ export function cn(...classes: (string | undefined | false | null)[]) {
   return classes.filter(Boolean).join(" ");
 }
 
+export function slugify(str: string) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 export function minutesSince(date: string | number | Date): number {
   const d = new Date(date)
   return Math.floor((Date.now() - d.getTime()) / 60000)


### PR DESCRIPTION
## Summary
- derive nav group content IDs from slugified group labels instead of array indexes
- expose a `slugify` utility for generating stable ID-friendly strings
- test that nav group IDs stay stable across rerenders and reordering

## Testing
- `npx vitest run src/components/__tests__/nav-section.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688eda7510f88324b4e9b2bb745266fd