### PR TITLE
feat(map): highlight selected state and animate markers

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -1,8 +1,15 @@
-import React, { useMemo, useState } from "react";
-import Map, { Source, Layer, Marker, Popup, MapLayerMouseEvent } from "react-map-gl/maplibre";
+import React, { useMemo, useState, useRef } from "react";
+import Map, {
+  Source,
+  Layer,
+  Marker,
+  Popup,
+  MapLayerMouseEvent,
+  MapRef,
+} from "react-map-gl/maplibre";
 import maplibregl from "maplibre-gl";
 import { feature } from "topojson-client";
-import { geoCentroid } from "d3-geo";
+import { geoCentroid, geoBounds } from "d3-geo";
 import { scaleSequential } from "d3-scale";
 import { interpolateBlues } from "d3-scale-chromatic";
 import { useStateVisits } from "@/hooks/useStateVisits";
@@ -20,6 +27,7 @@ import StateVisitSummary from "./StateVisitSummary";
 import useDebounce from "@/hooks/useDebounce";
 
 import StateVisitCallout from "./StateVisitCallout";
+import { AnimatePresence, motion } from "framer-motion";
 
 
 import statesTopo from "@/lib/us-states.json";
@@ -43,6 +51,8 @@ export default function GeoActivityExplorer() {
 
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 300);
+
+  const mapRef = useRef<MapRef | null>(null);
 
 
   const now = new Date();
@@ -164,7 +174,25 @@ export default function GeoActivityExplorer() {
   };
 
   const selectState = (abbr: string) => {
-    setSelectedState((prev) => (prev === abbr ? null : abbr))
+    setSelectedState((prev) => {
+      const next = prev === abbr ? null : abbr
+      if (next) {
+        const f = (statesGeo.features as any).find(
+          (ft: any) => ft.properties.abbr === next,
+        )
+        if (f) {
+          const [[minLng, minLat], [maxLng, maxLat]] = geoBounds(f as any)
+          mapRef.current?.fitBounds(
+            [
+              [minLng, minLat],
+              [maxLng, maxLat],
+            ],
+            { padding: 20 },
+          )
+        }
+      }
+      return next
+    })
     setExpandedState((prev) => (prev === abbr ? null : abbr))
   }
 
@@ -228,6 +256,7 @@ export default function GeoActivityExplorer() {
       <div className="flex gap-12">
         <div className="relative w-80 h-60">
           <Map
+            ref={mapRef}
             aria-label="state map"
             mapLib={maplibregl}
             mapStyle="https://demotiles.maplibre.org/style.json"
@@ -255,6 +284,17 @@ export default function GeoActivityExplorer() {
                   "fill-outline-color": "hsl(var(--border))",
                 }}
               />
+              {selectedState && (
+                <Layer
+                  id="states-highlight"
+                  type="line"
+                  filter={["==", ["get", "abbr"], selectedState] as any}
+                  paint={{
+                    "line-color": "hsl(var(--primary))",
+                    "line-width": 3,
+                  }}
+                />
+              )}
             </Source>
             {showWeather && weatherKey && (
               <Source
@@ -268,19 +308,25 @@ export default function GeoActivityExplorer() {
                 <Layer id="wx-layer" type="raster" />
               </Source>
             )}
-            {expandedState &&
-              summaryMap[expandedState]?.cities.map((c) => {
-                const coords = CITY_COORDS[c.name]
-                return coords ? (
-                  <Marker key={c.name} longitude={coords[0]} latitude={coords[1]}>
-                    <circle
-                      r={3}
-                      fill="hsl(var(--primary))"
-                      className="transition-transform motion-reduce:transition-none hover:scale-125"
-                    />
-                  </Marker>
-                ) : null
-              })}
+            <AnimatePresence>
+              {expandedState &&
+                summaryMap[expandedState]?.cities.map((c) => {
+                  const coords = CITY_COORDS[c.name]
+                  return coords ? (
+                    <Marker key={c.name} longitude={coords[0]} latitude={coords[1]}>
+                      <motion.circle
+                        r={3}
+                        fill="hsl(var(--primary))"
+                        className="transition-transform motion-reduce:transition-none hover:scale-125"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.3 }}
+                      />
+                    </Marker>
+                  ) : null
+                })}
+            </AnimatePresence>
             {displayedMarkers.map(
               (m: {
                 abbr: string


### PR DESCRIPTION
## Summary
- zoom map to selected state via stored MapRef and bounding boxes
- draw thick contrasting outline around chosen state
- fade city markers in/out during state expansion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688edcc194c08324a91b382db26382e7