### PR TITLE
feat: enhance reading stack split tooltip

### DIFF
--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -2,29 +2,38 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { vi, describe, it, expect } from "vitest";
 import React from "react";
-import ReadingStackSplit from "../ReadingStackSplit";
+import ReadingStackSplit, { ReadingTooltip } from "../ReadingStackSplit";
+import { ChartContainer } from "@/components/ui/chart";
 
 vi.mock("recharts", async () => {
   const actual: any = await vi.importActual("recharts");
   return {
     ...actual,
-    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => (
+    ResponsiveContainer: ({ children }: { children: any }) => (
       <div style={{ width: 800, height: 400 }}>
-        {React.cloneElement(children, { width: 800, height: 400 })}
+        {typeof children === "function"
+          ? children({ width: 800, height: 400 })
+          : React.cloneElement(children, { width: 800, height: 400 })}
       </div>
     ),
   };
 });
 
+const mockUseReadingMediumTotals = vi.fn();
+
 vi.mock("@/hooks/useReadingMediumTotals", () => ({
   __esModule: true,
-  default: () => [
-    { medium: "phone", minutes: 30 },
-    { medium: "kindle", minutes: 60 },
-  ],
+  default: () => mockUseReadingMediumTotals(),
 }));
 
 describe("ReadingStackSplit", () => {
+  beforeEach(() => {
+    mockUseReadingMediumTotals.mockReturnValue([
+      { medium: "phone", minutes: 30 },
+      { medium: "kindle", minutes: 60 },
+    ]);
+  });
+
   it("renders chart title and icons", () => {
     const { container } = render(<ReadingStackSplit />);
     expect(screen.getByText(/Reading Stack Split/)).toBeInTheDocument();
@@ -34,5 +43,34 @@ describe("ReadingStackSplit", () => {
     expect(container.querySelector("svg.lucide-book-open")).toBeInTheDocument();
     expect(screen.getByText("90")).toBeInTheDocument();
     expect(container.querySelector("svg.lucide-book")).toBeInTheDocument();
+  });
+
+  it("tooltip displays medium, minutes and percentage", () => {
+    const payload = [
+      { name: "minutes", value: 30, payload: { medium: "phone", minutes: 30 } },
+    ] as any;
+    render(
+      <ChartContainer
+        config={{ minutes: { label: "Minutes" }, phone: { label: "Phone" } }}
+      >
+        {() => <ReadingTooltip active payload={payload} total={90} />}
+      </ChartContainer>
+    );
+    expect(screen.getByText("Phone")).toBeInTheDocument();
+    expect(screen.getByText(/30/)).toBeInTheDocument();
+    expect(screen.getByText(/33%/)).toBeInTheDocument();
+  });
+
+  it("filters out media with zero minutes", () => {
+    mockUseReadingMediumTotals.mockReturnValue([
+      { medium: "phone", minutes: 30 },
+      { medium: "tablet", minutes: 0 },
+      { medium: "kindle", minutes: 60 },
+    ]);
+    const { container } = render(<ReadingStackSplit />);
+    expect(screen.queryByText("Tablet")).not.toBeInTheDocument();
+    expect(
+      container.querySelector("svg.lucide-tablet")
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add custom tooltip displaying medium minutes and percentage in ReadingStackSplit
- ignore zero-minute media when rendering pie slices
- test tooltip output and zero-value filtering

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_688edda910848324b84bb9bb025de94a