### PR TITLE
feat: enrich state visit callouts

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -25,6 +25,8 @@ import StateVisitCallout from "./StateVisitCallout";
 import statesTopo from "@/lib/us-states.json";
 import CITY_COORDS from "@/lib/cityCoords";
 import { fipsToAbbr } from "@/lib/stateCodes";
+import { formatDate, formatMiles } from "@/lib/format";
+import { Bike, Footprints } from "lucide-react";
 
 // OpenWeatherMap API key for precipitation tiles. This key is specific to the
 // app and can be replaced by setting VITE_WEATHER_KEY if needed.
@@ -167,6 +169,31 @@ export default function GeoActivityExplorer() {
     setSelectedState((prev) => (prev === abbr ? null : abbr))
     setExpandedState((prev) => (prev === abbr ? null : abbr))
   }
+
+  const selectedDetails = useMemo(() => {
+    if (!selectedState) return null
+    const s = summaryMap[selectedState]
+    if (!s) return null
+    const last = [...s.log].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    )[0]
+    const mostCity = s.cities.reduce(
+      (prev, curr) => (curr.days > prev.days ? curr : prev),
+      s.cities[0] || null,
+    )
+    const runMiles = s.log
+      .filter((l) => l.type === "run")
+      .reduce((acc, l) => acc + l.miles, 0)
+    const bikeMiles = s.log
+      .filter((l) => l.type === "bike")
+      .reduce((acc, l) => acc + l.miles, 0)
+    return {
+      lastDate: last?.date,
+      mostCity: mostCity?.name,
+      runMiles,
+      bikeMiles,
+    }
+  }, [selectedState, summaryMap])
 
   return (
     <>
@@ -324,7 +351,27 @@ export default function GeoActivityExplorer() {
                 <div className="flex flex-col gap-1 text-xs">
                   <span className="flex gap-2">
                     <Badge>{summaryMap[selectedState].totalDays}d</Badge>
-                    <Badge>{summaryMap[selectedState].totalMiles}mi</Badge>
+                    <Badge>{formatMiles(summaryMap[selectedState].totalMiles)}</Badge>
+                  </span>
+                  {selectedDetails?.lastDate && (
+                    <span>Last: {formatDate(selectedDetails.lastDate)}</span>
+                  )}
+                  {selectedDetails?.mostCity && (
+                    <span>Top city: {selectedDetails.mostCity}</span>
+                  )}
+                  <span className="flex gap-1">
+                    {selectedDetails?.runMiles ? (
+                      <Badge className="flex items-center gap-1">
+                        <Footprints className="h-3 w-3" />
+                        {formatMiles(selectedDetails.runMiles)}
+                      </Badge>
+                    ) : null}
+                    {selectedDetails?.bikeMiles ? (
+                      <Badge className="flex items-center gap-1">
+                        <Bike className="h-3 w-3" />
+                        {formatMiles(selectedDetails.bikeMiles)}
+                      </Badge>
+                    ) : null}
                   </span>
                   <button onClick={() => setSelectedState(null)}>Close</button>
                 </div>
@@ -342,7 +389,7 @@ export default function GeoActivityExplorer() {
               />
             }
           />
-          <StateVisitCallout />
+          <StateVisitCallout onSelectState={selectState} />
         </div>
 
         <div className="flex-1">

--- a/src/components/map/StateVisitCallout.tsx
+++ b/src/components/map/StateVisitCallout.tsx
@@ -1,17 +1,58 @@
 import React, { useMemo } from "react";
+import { Bike, Footprints } from "lucide-react";
+import { feature } from "topojson-client";
 import { useStateVisits } from "@/hooks/useStateVisits";
 import { Skeleton } from "@/components/ui/skeleton";
+import statesTopo from "@/lib/us-states.json";
+import { fipsToAbbr } from "@/lib/stateCodes";
+import { formatDate, formatMiles } from "@/lib/format";
 
-export default function StateVisitCallout() {
+const stateNames: Record<string, string> = (() => {
+  const fc = feature(
+    statesTopo as any,
+    (statesTopo as any).objects.states
+  ) as any;
+  const map: Record<string, string> = {};
+  fc.features.forEach((f: any) => {
+    const abbr = fipsToAbbr[f.id as string];
+    if (abbr) map[abbr] = f.properties.name as string;
+  });
+  return map;
+})();
+
+interface StateVisitCalloutProps {
+  onSelectState?: (code: string) => void;
+}
+
+export default function StateVisitCallout({
+  onSelectState,
+}: StateVisitCalloutProps) {
   const visits = useStateVisits();
 
   const latest = useMemo(() => {
     if (!visits) return null;
-    let entry: { date: string; type: string; miles: number; stateCode: string } | null = null;
+    let entry:
+      | {
+          date: string;
+          type: string;
+          miles: number;
+          stateCode: string;
+          stateName: string;
+          formattedDate: string;
+          formattedMiles: string;
+        }
+      | null = null;
     visits.forEach((state) => {
       state.log.forEach((l) => {
         if (!entry || new Date(l.date) > new Date(entry.date)) {
-          entry = { ...l, stateCode: state.stateCode };
+          const stateName = stateNames[state.stateCode] || state.stateCode;
+          entry = {
+            ...l,
+            stateCode: state.stateCode,
+            stateName,
+            formattedDate: formatDate(l.date),
+            formattedMiles: formatMiles(l.miles),
+          };
         }
       });
     });
@@ -21,16 +62,23 @@ export default function StateVisitCallout() {
   if (!visits) return <Skeleton className="h-4 w-full" />;
   if (!latest) return null;
 
-  const { type, miles, stateCode } = latest as {
-    type: string;
-    miles: number;
-    stateCode: string;
-  };
-  const message = `Latest ${type}: ${miles}mi in ${stateCode}`;
+  const { type, stateCode, stateName, formattedDate, formattedMiles } = latest;
+  const Icon = type === "run" ? Footprints : Bike;
 
   return (
-    <div className="absolute bottom-2 left-2 rounded bg-background/80 px-2 text-xs text-muted-foreground">
-      {message}
+    <div className="absolute bottom-2 left-2 flex items-center gap-2 rounded bg-background/80 px-2 py-1 text-xs text-muted-foreground">
+      <Icon className="h-3 w-3" />
+      <span>
+        {formattedDate} - {formattedMiles} in {stateName}
+      </span>
+      {onSelectState && (
+        <button
+          className="underline"
+          onClick={() => onSelectState(stateCode)}
+        >
+          View
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/map/__tests__/StateVisitCallout.test.tsx
+++ b/src/components/map/__tests__/StateVisitCallout.test.tsx
@@ -31,7 +31,13 @@ vi.mock("@/hooks/useStateVisits", () => ({
 
 describe("StateVisitCallout", () => {
   it("shows latest activity", () => {
-    render(<div className="relative h-10"><StateVisitCallout /></div>);
-    expect(screen.getByText("Latest bike: 10mi in CA")).toBeInTheDocument();
+    render(
+      <div className="relative h-10">
+        <StateVisitCallout onSelectState={() => {}} />
+      </div>
+    );
+    expect(screen.getByText(/Feb 1, 2025/)).toBeInTheDocument();
+    expect(screen.getByText(/10mi in California/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /View/ })).toBeInTheDocument();
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,9 @@
+import { format } from 'date-fns';
+
+export function formatDate(date: string | Date, fmt = 'MMM d, yyyy') {
+  return format(new Date(date), fmt);
+}
+
+export function formatMiles(miles: number) {
+  return `${miles}mi`;
+}


### PR DESCRIPTION
## Summary
- include last visit, top city, and activity split in state popups
- enhance latest-visit callout with icons, formatted date, and map link
- add shared date and mileage formatting helpers

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688ede31bbdc83248195dd59d29d20e8