### PR TITLE
feat: accordion-style persisted groups

### DIFF
--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -112,6 +112,9 @@ export default function NavSection({
   }
 
   if (groups?.length) {
+    const openGroupLabel = Object.keys(openGroups).find(
+      (key) => openGroups[key]
+    );
     return (
       <SidebarGroup>
         <SidebarGroupLabel>{label}</SidebarGroupLabel>
@@ -120,7 +123,9 @@ export default function NavSection({
             {groups.map((group, index) => {
               const GroupIcon = group.icon;
               const contentId = `${label}-group-${slugify(group.label)}`;
-              const isOpen = openGroups[group.label] ?? index === 0;
+              const isOpen = openGroupLabel
+                ? openGroupLabel === group.label
+                : index === 0;
               return (
                 <Collapsible.Root
                   key={group.label}

--- a/src/hooks/__tests__/usePersistedGroups.test.tsx
+++ b/src/hooks/__tests__/usePersistedGroups.test.tsx
@@ -19,4 +19,15 @@ describe("usePersistedGroups", () => {
     const stored = JSON.parse(localStorage.getItem("test_key") || "{}");
     expect(stored["Group A"]).toBe(true);
   });
+
+  it("only keeps one group open at a time", () => {
+    const { result } = renderHook(() => usePersistedGroups("test_key"));
+    act(() => {
+      result.current.handleOpenChange("Group A")(true);
+      result.current.handleOpenChange("Group B")(true);
+    });
+    expect(result.current.openGroups).toEqual({ "Group B": true });
+    const stored = JSON.parse(localStorage.getItem("test_key") || "{}");
+    expect(stored).toEqual({ "Group B": true });
+  });
 });

--- a/src/hooks/usePersistedGroups.ts
+++ b/src/hooks/usePersistedGroups.ts
@@ -18,8 +18,8 @@ export function usePersistedGroups(storageKey: string) {
 
   const handleOpenChange = useCallback(
     (groupLabel: string) => (open: boolean) => {
-      setOpenGroups((prev) => {
-        const next = { ...prev, [groupLabel]: open };
+      setOpenGroups(() => {
+        const next = open ? { [groupLabel]: true } : {};
         try {
           if (typeof window !== "undefined") {
             localStorage.setItem(storageKey, JSON.stringify(next));


### PR DESCRIPTION
## Summary
- ensure only one navigation group can be open at a time and persist selection
- add tests for single-open persisted groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f76116a8c83248ab62169416218c6