### PR TITLE
feat: add responsive navigation menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ The UI sidebar includes configurable behaviour:
 
 See [`components/ui/sidebar.tsx`](components/ui/sidebar.tsx) for implementation details.
 
+## Navbar
+
+The top navigation bar (`src/components/app-navbar.tsx`) uses shadcn/ui's
+`NavigationMenu` primitives to surface dashboard routes. It appears on desktop
+viewports and collapses away on mobile, where the existing sidebar or drawer can
+be opened with the sidebar trigger.
+
 ## State & data hooks
 Keep all API-specific logic (auth, fetch, shape/normalize) inside `src/hooks/useGarminData.ts`. That way components stay pure/presentational.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import AppSidebar from "@/components/app-sidebar";
+import AppNavbar from "@/components/app-navbar";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -10,7 +11,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <SidebarProvider>
           <AppSidebar />
           <main>
-            <SidebarTrigger />
+            <div className="flex items-center justify-between p-4">
+              <SidebarTrigger className="md:hidden" />
+              <AppNavbar className="hidden md:block" />
+            </div>
             {children}
           </main>
         </SidebarProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-navigation-menu": "^1.2.13",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-separator": "^1.0.3",
@@ -1488,6 +1489,42 @@
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.13.tgz",
+      "integrity": "sha512-WG8wWfDiJlSF5hELjwfjSGOXcBR/ZMhBFCGYe8vERpC39CQYZeq1PQ2kaYHdye3V95d06H89KGMsVCIE4LWo3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",

--- a/src/components/app-navbar.tsx
+++ b/src/components/app-navbar.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+import { Link, useLocation } from "react-router-dom"
+
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu"
+import { dashboardRoutes } from "@/routes"
+import { cn } from "@/lib/utils"
+
+interface AppNavbarProps {
+  className?: string
+}
+
+export default function AppNavbar({ className }: AppNavbarProps) {
+  const { pathname } = useLocation()
+  const routes = React.useMemo(
+    () => dashboardRoutes.flatMap((g) => g.items),
+    []
+  )
+
+  return (
+    <NavigationMenu className={className}>
+      <NavigationMenuList>
+        {routes.map((route) => {
+          const active = pathname === route.to
+          return (
+            <NavigationMenuItem key={route.to}>
+              <NavigationMenuLink asChild>
+                <Link
+                  to={route.to}
+                  className={cn(
+                    navigationMenuTriggerStyle(),
+                    active && "bg-accent text-accent-foreground"
+                  )}
+                >
+                  {route.label}
+                </Link>
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+          )
+        })}
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import AppSidebar from "@/components/app-sidebar";
+import AppNavbar from "@/components/app-navbar";
 import CommandPalette from "@/components/ui/CommandPalette";
 import { Button } from "@/components/ui/button";
 import {
@@ -133,9 +134,10 @@ export default function Layout({ children }: LayoutProps) {
         <SidebarInset>
           <header className="flex items-center justify-between p-4">
             <div className="flex items-center gap-2">
-              <SidebarTrigger />
+              <SidebarTrigger className="md:hidden" />
               <Breadcrumbs />
             </div>
+            <AppNavbar className="hidden md:block" />
             <div className="flex items-center gap-2">
               <ActionMenu />
               <TooltipProvider delayDuration={100}>

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
+import { cva } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const NavigationMenu = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    ref={ref}
+    className={cn("relative z-10 flex max-w-max flex-1 items-center justify-center", className)}
+    {...props}
+  />
+))
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
+
+const NavigationMenuList = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    ref={ref}
+    className={cn("group flex flex-1 list-none items-center justify-center", className)}
+    {...props}
+  />
+))
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+)
+
+const NavigationMenuLink = NavigationMenuPrimitive.Link
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+}


### PR DESCRIPTION
## Summary
- add shadcn-based `AppNavbar` with route highlighting
- wire navbar into both Next.js and React Router layouts
- document responsive navbar behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f7e6be34083248b43980702d732d8