### PR TITLE
feat: add top-level tab navigation

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -6,11 +6,9 @@ import {
   SidebarFooter,
 } from "@/components/ui/sidebar";
 import { useLocation } from "react-router-dom";
-import { Map as MapIcon, ChartLine, Settings as SettingsIcon } from "lucide-react";
+import { Settings as SettingsIcon } from "lucide-react";
 import {
   chartRouteGroups,
-  mapRoutes,
-  analyticsRoutes,
   settingsRoutes,
   dashboardRoutes,
 } from "@/routes";
@@ -18,7 +16,11 @@ import NavSection from "@/components/nav-section";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import useFavorites from "@/hooks/useFavorites";
 
-export default function AppSidebar() {
+interface AppSidebarProps {
+  activeCategory: string;
+}
+
+export default function AppSidebar({ activeCategory }: AppSidebarProps) {
   const { pathname } = useLocation();
 
   const { favorites, toggleFavorite } = useFavorites();
@@ -39,6 +41,11 @@ export default function AppSidebar() {
     [favorites, allRoutes]
   );
 
+  const dashboardGroups = React.useMemo(
+    () => dashboardRoutes.filter((g) => g.label !== "Settings"),
+    []
+  );
+
   return (
     <TooltipProvider>
       <Sidebar>
@@ -53,7 +60,16 @@ export default function AppSidebar() {
               toggleFavorite={toggleFavorite}
             />
           )}
-          {chartRouteGroups.length > 0 && (
+          {activeCategory === "dashboard" && dashboardGroups.length > 0 && (
+            <NavSection
+              label="Dashboard"
+              groups={dashboardGroups}
+              pathname={pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+            />
+          )}
+          {activeCategory === "charts" && chartRouteGroups.length > 0 && (
             <NavSection
               label="Charts"
               groups={chartRouteGroups}
@@ -62,31 +78,11 @@ export default function AppSidebar() {
               toggleFavorite={toggleFavorite}
             />
           )}
-          {analyticsRoutes.length > 0 && (
-            <NavSection
-              label="Analytics"
-              routes={analyticsRoutes}
-              icon={ChartLine}
-              pathname={pathname}
-              favorites={favorites}
-              toggleFavorite={toggleFavorite}
-            />
-          )}
-          {settingsRoutes.length > 0 && (
+          {activeCategory === "settings" && settingsRoutes.length > 0 && (
             <NavSection
               label="Settings"
               routes={settingsRoutes}
               icon={SettingsIcon}
-              pathname={pathname}
-              favorites={favorites}
-              toggleFavorite={toggleFavorite}
-            />
-          )}
-          {mapRoutes.length > 0 && (
-            <NavSection
-              label="Maps"
-              routes={mapRoutes}
-              icon={MapIcon}
               pathname={pathname}
               favorites={favorites}
               toggleFavorite={toggleFavorite}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import ThemeToggle from "@/components/ui/theme-toggle";
 import AppSidebar from "@/components/app-sidebar";
 import CommandPalette from "@/components/ui/CommandPalette";
@@ -122,39 +122,75 @@ function ActionMenu() {
   );
 }
 
+function TopNav({ activeCategory }: { activeCategory: string }) {
+  const navigate = useNavigate();
+  const categories = [
+    { value: "dashboard", label: "Dashboard", to: "/dashboard" },
+    {
+      value: "charts",
+      label: "Charts",
+      to: "/dashboard/charts/area-chart-interactive",
+    },
+    { value: "settings", label: "Settings", to: "/dashboard/settings" },
+  ];
+  return (
+    <nav className="flex gap-2">
+      {categories.map((cat) => (
+        <Button
+          key={cat.value}
+          variant={activeCategory === cat.value ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => navigate(cat.to)}
+        >
+          {cat.label}
+        </Button>
+      ))}
+    </nav>
+  );
+}
+
 export default function Layout({ children }: LayoutProps) {
   const [open, setOpen] = React.useState(false);
+  const location = useLocation();
+  const activeCategory = React.useMemo(() => {
+    if (location.pathname.startsWith("/dashboard/charts")) return "charts";
+    if (location.pathname.startsWith("/dashboard/settings")) return "settings";
+    return "dashboard";
+  }, [location.pathname]);
 
   return (
     <ChartActionsProvider>
       <SidebarProvider>
-        <AppSidebar />
+        <AppSidebar activeCategory={activeCategory} />
         <CommandPalette open={open} setOpen={setOpen} />
         <SidebarInset>
-          <header className="flex items-center justify-between p-4">
-            <div className="flex items-center gap-2">
-              <SidebarTrigger />
-              <Breadcrumbs />
+          <header className="flex flex-col gap-2 p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <SidebarTrigger />
+                <TopNav activeCategory={activeCategory} />
+              </div>
+              <div className="flex items-center gap-2">
+                <ActionMenu />
+                <TooltipProvider delayDuration={100}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setOpen(true)}
+                      >
+                        <Command className="h-4 w-4" />
+                        <span className="sr-only">Open command palette</span>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Ctrl/⌘+K</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <ThemeToggle />
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <ActionMenu />
-              <TooltipProvider delayDuration={100}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setOpen(true)}
-                    >
-                      <Command className="h-4 w-4" />
-                      <span className="sr-only">Open command palette</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Ctrl/⌘+K</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <ThemeToggle />
-            </div>
+            <Breadcrumbs />
           </header>
           <main className="flex-1 p-4 pt-0">{children}</main>
         </SidebarInset>


### PR DESCRIPTION
## Summary
- add top navigation tabs for Dashboard, Charts and Settings
- filter sidebar content based on the selected top-level tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7d3c00a48324936d25b788132257