### PR TITLE
feat: fetch reading medium totals

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -73,9 +73,15 @@ export function ReadingTooltip(
 
 export default function ReadingStackSplit() {
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
-  const data = useReadingMediumTotals();
+  const { data, isLoading, error } = useReadingMediumTotals();
 
-  if (!data) return <Skeleton className="h-64" />;
+  if (isLoading) return <Skeleton className="h-64" />;
+  if (error || !data)
+    return (
+      <div className="h-64 flex items-center justify-center text-sm text-destructive">
+        Failed to load reading data
+      </div>
+    );
 
   const filtered = data.filter((d) => d.minutes > 0);
 

--- a/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
+++ b/src/components/dashboard/__tests__/ReadingStackSplit.test.tsx
@@ -28,10 +28,14 @@ vi.mock("@/hooks/useReadingMediumTotals", () => ({
 
 describe("ReadingStackSplit", () => {
   beforeEach(() => {
-    mockUseReadingMediumTotals.mockReturnValue([
-      { medium: "phone", minutes: 30 },
-      { medium: "kindle", minutes: 60 },
-    ]);
+    mockUseReadingMediumTotals.mockReturnValue({
+      data: [
+        { medium: "phone", minutes: 30 },
+        { medium: "kindle", minutes: 60 },
+      ],
+      isLoading: false,
+      error: null,
+    });
   });
 
   it("renders chart title and icons", () => {
@@ -62,11 +66,15 @@ describe("ReadingStackSplit", () => {
   });
 
   it("filters out media with zero minutes", () => {
-    mockUseReadingMediumTotals.mockReturnValue([
-      { medium: "phone", minutes: 30 },
-      { medium: "tablet", minutes: 0 },
-      { medium: "kindle", minutes: 60 },
-    ]);
+    mockUseReadingMediumTotals.mockReturnValue({
+      data: [
+        { medium: "phone", minutes: 30 },
+        { medium: "tablet", minutes: 0 },
+        { medium: "kindle", minutes: 60 },
+      ],
+      isLoading: false,
+      error: null,
+    });
     const { container } = render(<ReadingStackSplit />);
     expect(screen.queryByText("Tablet")).not.toBeInTheDocument();
     expect(

--- a/src/components/examples/RadialChartGrid.tsx
+++ b/src/components/examples/RadialChartGrid.tsx
@@ -34,9 +34,15 @@ const labels: Record<string, string> = {
 }
 
 export default function ChartRadialGrid() {
-  const data = useReadingMediumTotals()
+  const { data, isLoading, error } = useReadingMediumTotals()
 
-  if (!data) return <Skeleton className='h-64' />
+  if (isLoading) return <Skeleton className='h-64' />
+  if (error || !data)
+    return (
+      <div className='h-64 flex items-center justify-center text-sm text-destructive'>
+        Failed to load reading data
+      </div>
+    )
 
   const labelledData = data.map((d) => ({
     ...d,

--- a/src/hooks/__tests__/useReadingMediumTotals.test.ts
+++ b/src/hooks/__tests__/useReadingMediumTotals.test.ts
@@ -1,0 +1,28 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import useReadingMediumTotals from "../useReadingMediumTotals"
+import type { ReadingMediumTotal } from "@/lib/api"
+
+describe("useReadingMediumTotals", () => {
+  it("fetches data and updates loading state", async () => {
+    const mockData: ReadingMediumTotal[] = [
+      { medium: "phone", minutes: 30 },
+    ]
+    const fetcher = vi.fn().mockResolvedValue(mockData)
+    const { result } = renderHook(() => useReadingMediumTotals({ fetcher }))
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual(mockData)
+    expect(result.current.error).toBeNull()
+    expect(fetcher).toHaveBeenCalled()
+  })
+
+  it("handles fetch errors", async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error("fail"))
+    const { result } = renderHook(() => useReadingMediumTotals({ fetcher }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeTruthy()
+    expect(result.current.data).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- fetch reading medium totals from API and expose loading/error states
- handle loading and failure in reading charts
- cover new hook with tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688f7cc0cae083248da38f9e29df9067