### PR TITLE
feat: add global navigation menu

### DIFF
--- a/src/components/global-navigation.tsx
+++ b/src/components/global-navigation.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+import { Link } from "react-router-dom";
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+} from "@/components/ui/navigation-menu";
+import {
+  analyticsRoutes,
+  chartRouteGroups,
+  mapRoutes,
+  settingsRoutes,
+  dashboardRoutes,
+  type DashboardRoute,
+} from "@/routes";
+
+function RouteList({ routes }: { routes: DashboardRoute[] }) {
+  return (
+    <ul className="grid gap-3 md:w-[400px] lg:w-[500px] lg:grid-cols-2">
+      {routes.map((route) => (
+        <li key={route.to}>
+          <NavigationMenuLink asChild>
+            <Link
+              to={route.to}
+              className="block rounded-md p-3 hover:bg-accent hover:text-accent-foreground"
+            >
+              <div className="text-sm font-medium leading-none">
+                {route.label}
+              </div>
+              {route.description && (
+                <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+                  {route.description}
+                </p>
+              )}
+            </Link>
+          </NavigationMenuLink>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function GlobalNavigation() {
+  const insightsRoutes = React.useMemo(
+    () =>
+      dashboardRoutes.find((g) => g.label === "Privacy")?.items ?? [],
+    []
+  );
+
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Analytics</NavigationMenuTrigger>
+          <NavigationMenuContent className="p-4">
+            <RouteList routes={analyticsRoutes} />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Charts</NavigationMenuTrigger>
+          <NavigationMenuContent className="p-4">
+            {chartRouteGroups.map((group) => (
+              <div key={group.label} className="mb-4 last:mb-0">
+                <h4 className="mb-2 font-medium leading-none">
+                  {group.label}
+                </h4>
+                <RouteList routes={group.items} />
+              </div>
+            ))}
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Maps</NavigationMenuTrigger>
+          <NavigationMenuContent className="p-4">
+            <RouteList routes={mapRoutes} />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Insights/Personal</NavigationMenuTrigger>
+          <NavigationMenuContent className="p-4">
+            <RouteList routes={insightsRoutes} />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Settings/Tools</NavigationMenuTrigger>
+          <NavigationMenuContent className="p-4">
+            <RouteList routes={settingsRoutes} />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+      <NavigationMenuIndicator />
+      <NavigationMenuViewport />
+    </NavigationMenu>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -16,6 +16,7 @@ import {
   SidebarTrigger,
   SidebarInset,
 } from "@/components/ui/sidebar";
+import GlobalNavigation from "@/components/global-navigation";
 import {
   ChartActionsProvider,
   useChartActions,
@@ -134,6 +135,7 @@ export default function Layout({ children }: LayoutProps) {
           <header className="flex items-center justify-between p-4">
             <div className="flex items-center gap-2">
               <SidebarTrigger />
+              <GlobalNavigation />
               <Breadcrumbs />
             </div>
             <div className="flex items-center gap-2">

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import * as React from "react";
+import { cva } from "class-variance-authority";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+
+import { cn } from "@/lib/utils";
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50"
+);
+
+const NavigationMenu = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <NavigationMenuPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </NavigationMenuPrimitive.Root>
+));
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
+
+const NavigationMenuList = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.List
+    ref={ref}
+    className={cn(
+      "group flex flex-1 list-none items-center justify-center gap-1",
+      className
+    )}
+    {...props}
+  />
+));
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
+
+const NavigationMenuItem = NavigationMenuPrimitive.Item;
+
+const NavigationMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Trigger
+    ref={ref}
+    className={cn(navigationMenuTriggerStyle(), className)}
+    {...props}
+  />
+));
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
+
+const NavigationMenuContent = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Content
+    ref={ref}
+    className={cn(
+      "data-[motion=from-start]:animate-in data-[motion=from-end]:animate-in data-[motion=to-start]:animate-out data-[motion=to-end]:animate-out",
+      className
+    )}
+    {...props}
+  />
+));
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
+
+const NavigationMenuLink = NavigationMenuPrimitive.Link;
+
+const NavigationMenuViewport = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
+>(({ className, ...props }, ref) => (
+  <div className="absolute left-0 top-full flex justify-center">
+    <NavigationMenuPrimitive.Viewport
+      className={cn(
+        "origin-top-center relative mt-1 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 sm:w-[var(--radix-navigation-menu-viewport-width)]",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  </div>
+));
+NavigationMenuViewport.displayName =
+  NavigationMenuPrimitive.Viewport.displayName;
+
+const NavigationMenuIndicator = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Indicator
+    ref={ref}
+    className={cn(
+      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out",
+      className
+    )}
+    {...props}
+  >
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+  </NavigationMenuPrimitive.Indicator>
+));
+NavigationMenuIndicator.displayName =
+  NavigationMenuPrimitive.Indicator.displayName;
+
+export {
+  navigationMenuTriggerStyle,
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuViewport,
+  NavigationMenuIndicator,
+};
+


### PR DESCRIPTION
## Summary
- add Shadcn NavigationMenu primitives
- create GlobalNavigation component driven by existing route data
- mount global navigation in layout header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688faaccf6048324a42cc9ccc4a059ea