### PR TITLE
feat: allow non-responsive chart container

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -233,6 +233,7 @@ export default function GeoActivityExplorer() {
         config={legendConfig}
         title="State Visits"
         className="h-60 md:h-80 lg:h-96 space-y-6"
+        disableResponsive
       >
       <>
       <div className="flex gap-4 mb-4">

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -70,8 +70,9 @@ const ChartContainer = React.forwardRef<
     >["children"]
     title?: string
     subtitle?: string
+    disableResponsive?: boolean
   }
->(({ id, className, children, config, title, subtitle, ...props }, ref) => {
+>(({ id, className, children, config, title, subtitle, disableResponsive = false, ...props }, ref) => {
   const uniqueId = React.useId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
 
@@ -91,9 +92,13 @@ const ChartContainer = React.forwardRef<
         )}
         <ChartStyle id={chartId} config={config} />
         <div className="flex-1">
-          <RechartsPrimitive.ResponsiveContainer>
-            {children}
-          </RechartsPrimitive.ResponsiveContainer>
+          {disableResponsive ? (
+            children
+          ) : (
+            <RechartsPrimitive.ResponsiveContainer>
+              {children}
+            </RechartsPrimitive.ResponsiveContainer>
+          )}
         </div>
       </div>
     </ChartContext.Provider>


### PR DESCRIPTION
## Summary
- add `disableResponsive` prop for ChartContainer to bypass Recharts wrapper
- render GeoActivityExplorer inside a non-responsive chart container so map and controls aren't wrapped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688faa3a824c832488cf7ac7eaa6bb2f