### PR TITLE
feat: add extra mock routes

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1151,6 +1151,22 @@ const mockMadisonRoutes: Route[] = [
       { lat: 43.074, lon: -89.384 },
     ],
   },
+  {
+    name: "Monona Bay Loop",
+    points: [
+      { lat: 43.067, lon: -89.395 },
+      { lat: 43.068, lon: -89.392 },
+      { lat: 43.069, lon: -89.389 },
+    ],
+  },
+  {
+    name: "UW Arboretum Ride",
+    points: [
+      { lat: 43.047, lon: -89.429 },
+      { lat: 43.0485, lon: -89.423 },
+      { lat: 43.05, lon: -89.417 },
+    ],
+  },
 ];
 
 export async function getMockRoutes(): Promise<Route[]> {


### PR DESCRIPTION
## Summary
- extend mock Madison routes with Monona Bay Loop and UW Arboretum Ride

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fae1cb27c8324a3aad61354af2302