### PR TITLE
Use tsne-js run for training

### DIFF
--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -98,9 +98,7 @@ export function useRunningSessions(): SessionPoint[] | null {
         s.pace,
       ])
       model.init({ data: input, type: 'dense' })
-      for (let i = 0; i < 250; i++) {
-        model.step()
-      }
+      model.run()
       const output = model.getOutputScaled()
       const labels = kMeans(output, 3)
       const data = output.map(


### PR DESCRIPTION
## Summary
- use tsne-js's run method to train the TSNE model instead of manual step loop

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688faf4063f08324847ace8e6287fd00