### PR TITLE
feat: add favorites to global nav

### DIFF
--- a/src/hooks/__tests__/useFavorites.test.tsx
+++ b/src/hooks/__tests__/useFavorites.test.tsx
@@ -19,4 +19,11 @@ describe("useFavorites", () => {
     const stored = localStorage.getItem("favorites");
     expect(stored).toBe(JSON.stringify(["/foo"]));
   });
+
+  it("syncs across hook instances", () => {
+    const hook1 = renderHook(() => useFavorites());
+    const hook2 = renderHook(() => useFavorites());
+    act(() => hook1.result.current.toggleFavorite("/bar"));
+    expect(hook2.result.current.favorites).toEqual(["/bar"]);
+  });
 });


### PR DESCRIPTION
## Summary
- add favorites support to global navigation and expose star toggles
- sync favorites across components via custom event
- test hook synchronization across multiple instances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fade9d2a48324be6cfd06a3141174