### PR TITLE
Add preferences panel and dismissible intervention log

### DIFF
--- a/src/hooks/__tests__/useFocusHistory.test.tsx
+++ b/src/hooks/__tests__/useFocusHistory.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import useFocusHistory, { FocusHistoryProvider } from "../useFocusHistory";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <FocusHistoryProvider>{children}</FocusHistoryProvider>;
+}
+
+describe("useFocusHistory", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("adds and dismisses events", () => {
+    const { result } = renderHook(() => useFocusHistory(), { wrapper });
+
+    act(() => {
+      result.current.addEvent({ type: "intervention", message: "test" });
+    });
+    expect(result.current.history.length).toBe(1);
+
+    act(() => {
+      result.current.dismissEvent(0);
+    });
+    expect(result.current.history.length).toBe(0);
+    expect(result.current.dismissed).toContain("test");
+  });
+});

--- a/src/pages/FocusHistory.tsx
+++ b/src/pages/FocusHistory.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import useFocusHistory from "@/hooks/useFocusHistory";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { FocusTimeline } from "@/components/visualizations";
 
 export default function FocusHistoryPage() {
-  const { history } = useFocusHistory();
+  const { history, dismissEvent } = useFocusHistory();
 
   return (
     <div className="p-4 space-y-4">
@@ -15,12 +16,23 @@ export default function FocusHistoryPage() {
       ) : (
         <div className="space-y-2">
           {history.map((e, idx) => (
-            <Card key={idx} className="p-4">
-              <div className="text-sm text-muted-foreground">
-                {new Date(e.timestamp).toLocaleString()}
+            <Card key={idx} className="p-4 space-y-2">
+              <div className="flex items-start justify-between">
+                <div>
+                  <div className="text-sm text-muted-foreground">
+                    {new Date(e.timestamp).toLocaleString()}
+                  </div>
+                  <div className="font-medium capitalize">{e.type}</div>
+                  <div>{e.message}</div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => dismissEvent(idx)}
+                >
+                  Dismiss
+                </Button>
               </div>
-              <div className="font-medium capitalize">{e.type}</div>
-              <div>{e.message}</div>
             </Card>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- extend focus history context with persistent dismissed prompts
- allow removing prompts from Focus History page
- skip dismissed messages when generating engagement nudges

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688fb84b8f1c832483d13c5cfc3f1070