### PR TITLE
feat: track and show recent views

### DIFF
--- a/src/components/global-navigation.tsx
+++ b/src/components/global-navigation.tsx
@@ -20,6 +20,7 @@ import {
   type DashboardRoute,
 } from "@/routes";
 import useFavorites from "@/hooks/useFavorites";
+import useRecentViews from "@/hooks/useRecentViews";
 import { cn } from "@/lib/utils";
 
 function RouteList({
@@ -73,6 +74,7 @@ function RouteList({
 
 export default function GlobalNavigation() {
   const { favorites, toggleFavorite } = useFavorites();
+  const { recentViews } = useRecentViews();
 
   const insightsRoutes = React.useMemo(
     () => dashboardRoutes.find((g) => g.label === "Privacy")?.items ?? [],
@@ -95,12 +97,32 @@ export default function GlobalNavigation() {
     [favorites, allRoutes],
   );
 
+  const recentRoutes = React.useMemo(
+    () =>
+      recentViews
+        .map((to) => allRoutes.find((r) => r.to === to))
+        .filter(Boolean) as typeof allRoutes,
+    [recentViews, allRoutes],
+  );
+
   const renderFavorites = () =>
     favoriteRoutes.length > 0 && (
       <div className="mb-4">
         <h4 className="mb-2 font-medium leading-none">Favorites</h4>
         <RouteList
           routes={favoriteRoutes}
+          favorites={favorites}
+          toggleFavorite={toggleFavorite}
+        />
+      </div>
+    );
+
+  const renderRecent = () =>
+    recentRoutes.length > 0 && (
+      <div className="mb-4">
+        <h4 className="mb-2 font-medium leading-none">Recent</h4>
+        <RouteList
+          routes={recentRoutes}
           favorites={favorites}
           toggleFavorite={toggleFavorite}
         />
@@ -114,6 +136,7 @@ export default function GlobalNavigation() {
           <NavigationMenuTrigger>Analytics</NavigationMenuTrigger>
           <NavigationMenuContent className="p-4">
             {renderFavorites()}
+            {renderRecent()}
             <RouteList
               routes={analyticsRoutes}
               favorites={favorites}
@@ -125,6 +148,7 @@ export default function GlobalNavigation() {
           <NavigationMenuTrigger>Charts</NavigationMenuTrigger>
           <NavigationMenuContent className="p-4">
             {renderFavorites()}
+            {renderRecent()}
             {chartRouteGroups.map((group) => (
               <div key={group.label} className="mb-4 last:mb-0">
                 <h4 className="mb-2 font-medium leading-none">
@@ -143,6 +167,7 @@ export default function GlobalNavigation() {
           <NavigationMenuTrigger>Maps</NavigationMenuTrigger>
           <NavigationMenuContent className="p-4">
             {renderFavorites()}
+            {renderRecent()}
             <RouteList
               routes={mapRoutes}
               favorites={favorites}
@@ -154,6 +179,7 @@ export default function GlobalNavigation() {
           <NavigationMenuTrigger>Insights/Personal</NavigationMenuTrigger>
           <NavigationMenuContent className="p-4">
             {renderFavorites()}
+            {renderRecent()}
             <RouteList
               routes={insightsRoutes}
               favorites={favorites}
@@ -165,6 +191,7 @@ export default function GlobalNavigation() {
           <NavigationMenuTrigger>Settings/Tools</NavigationMenuTrigger>
           <NavigationMenuContent className="p-4">
             {renderFavorites()}
+            {renderRecent()}
             <RouteList
               routes={settingsRoutes}
               favorites={favorites}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -21,6 +21,7 @@ import {
   ChartActionsProvider,
   useChartActions,
 } from "@/hooks/useChartActions";
+import useRecentViews from "@/hooks/useRecentViews";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -125,6 +126,12 @@ function ActionMenu() {
 
 export default function Layout({ children }: LayoutProps) {
   const [open, setOpen] = React.useState(false);
+  const location = useLocation();
+  const { addRecentView } = useRecentViews();
+
+  React.useEffect(() => {
+    addRecentView(location.pathname);
+  }, [location.pathname, addRecentView]);
 
   return (
     <ChartActionsProvider>

--- a/src/hooks/useRecentViews.ts
+++ b/src/hooks/useRecentViews.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback, useEffect } from "react";
+
+const STORAGE_KEY = "recentViews";
+const STORAGE_EVENT = "recentViews:update";
+const MAX_RECENT_VIEWS = 5;
+
+/**
+ * Manages a list of recently viewed route paths persisted in localStorage.
+ *
+ * Defaults to an empty array on the server for SSR safety.
+ */
+export function useRecentViews() {
+  const [recentViews, setRecentViews] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const sync = () => {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        setRecentViews(stored ? (JSON.parse(stored) as string[]) : []);
+      } catch {
+        setRecentViews([]);
+      }
+    };
+    window.addEventListener("storage", sync);
+    window.addEventListener(STORAGE_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(STORAGE_EVENT, sync);
+    };
+  }, []);
+
+  const addRecentView = useCallback((path: string) => {
+    setRecentViews((prev) => {
+      const next = [path, ...prev.filter((p) => p !== path)].slice(
+        0,
+        MAX_RECENT_VIEWS,
+      );
+      try {
+        if (typeof window !== "undefined") {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+          window.dispatchEvent(new Event(STORAGE_EVENT));
+        }
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  return { recentViews, addRecentView } as const;
+}
+
+export default useRecentViews;
+


### PR DESCRIPTION
## Summary
- add `useRecentViews` hook for localStorage-backed recent path tracking
- record path changes in `Layout` to update recent views
- display a Recent section in global navigation above route groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fb301ffb083249dcac3acfb03f551