### PR TITLE
feat: add privacy data controls

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,13 +5,19 @@ This project collects a small set of information to power analytics and mapping 
 ## Data Categories
 
 ### Focus Labels
-Tags describing reading or activity focus are stored to highlight trends and surface relevant insights. These labels help the application customise charts and recommendations.
+Tags describing reading or activity focus are stored to highlight trends and surface relevant insights.
+**Use:** These labels help the application customise charts and recommendations.
+**Retention:** Entries older than the configured retention window are removed automatically.
 
 ### Location History
-Latitude/longitude fixes are stored locally so the application can build visit summaries and route visualisations. Location data never leaves the device unless exported manually.
+Latitude/longitude fixes are stored locally so the application can build visit summaries and route visualisations.
+**Use:** Provides visit summaries and route visualisations.
+**Retention:** Old fixes are purged automatically after the configured period. Location data never leaves the device unless exported manually.
 
 ### App Usage
 Basic usage information such as chart selections or feature toggles is kept to remember preferences and improve usability.
+**Use:** Remembers preferences and improves usability.
+**Retention:** Preferences can be cleared at any time from the privacy dashboard.
 
 ## Retention Policy
 All locally stored data is subject to a configurable retention period (30 days by default). Entries older than the selected window are purged automatically.

--- a/src/components/settings/Privacy.tsx
+++ b/src/components/settings/Privacy.tsx
@@ -7,6 +7,11 @@ import {
   purgeOldLocationData,
   setRetentionDays,
 } from "@/lib/locationStore";
+import {
+  clearFocusHistory,
+  exportFocusHistory,
+  purgeOldFocusHistory,
+} from "@/hooks/useFocusHistory";
 
 export default function Privacy() {
   const [backgroundLocation, setBackgroundLocation] = useState(false);
@@ -28,20 +33,24 @@ export default function Privacy() {
   }
 
   async function exportData() {
-    const data = await exportLocationData();
+    const data = {
+      location: await exportLocationData(),
+      focus: exportFocusHistory(),
+    };
     const blob = new Blob([JSON.stringify(data, null, 2)], {
       type: "application/json",
     });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "location-data.json";
+    a.download = "privacy-data.json";
     a.click();
     URL.revokeObjectURL(url);
   }
 
   async function clearHistory() {
     await clearLocationData();
+    clearFocusHistory();
   }
 
   function updateRetention(e: React.ChangeEvent<HTMLInputElement>) {
@@ -49,6 +58,7 @@ export default function Privacy() {
     setRetention(days);
     setRetentionDays(days);
     purgeOldLocationData(days);
+    purgeOldFocusHistory(days);
   }
 
   return (

--- a/src/hooks/__tests__/useFocusHistory.test.tsx
+++ b/src/hooks/__tests__/useFocusHistory.test.tsx
@@ -25,4 +25,18 @@ describe("useFocusHistory", () => {
     expect(result.current.history.length).toBe(0);
     expect(result.current.dismissed).toContain("test");
   });
+
+  it("purges events outside retention window", async () => {
+    localStorage.setItem("loc:retentionDays", "1");
+    const old = {
+      timestamp: Date.now() - 2 * 86400000,
+      type: "detection" as const,
+      message: "old",
+    };
+    const encoded = btoa(JSON.stringify([old]));
+    localStorage.setItem("focus_history", encoded);
+    const { result } = renderHook(() => useFocusHistory(), { wrapper });
+    await act(async () => {});
+    expect(result.current.history.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- document data categories and their retention rules
- support retention, export, and deletion for focus history
- extend privacy dashboard to manage location and focus data

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688fba47b1a88324806fb7215e057ac3