### PR TITLE
feat: allow importing routes

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1169,11 +1169,27 @@ const mockMadisonRoutes: Route[] = [
   },
 ];
 
+const uploadedRoutes: Route[] = [];
+
+export async function saveRoute(route: Route): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      uploadedRoutes.push({ ...route, points: [...route.points] });
+      resolve();
+    }, 100);
+  });
+}
+
 export async function getMockRoutes(): Promise<Route[]> {
   return new Promise((resolve) => {
-    setTimeout(() =>
-      resolve(mockMadisonRoutes.map((r) => ({ ...r, points: [...r.points] }))),
-    200);
+    setTimeout(
+      () =>
+        resolve([
+          ...mockMadisonRoutes.map((r) => ({ ...r, points: [...r.points] })),
+          ...uploadedRoutes.map((r) => ({ ...r, points: [...r.points] })),
+        ]),
+      200,
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- add GPX/GeoJSON parsing and upload button to RouteSimilarity
- support saving uploaded routes in mock API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688faf1266448324adfb772299275390