### PR TITLE
Seed telemetry with sample route runs

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -42,6 +42,76 @@ const initialRouteRuns: RouteRun[] = [
     dtwSimilarity: 0.5,
     overlapSimilarity: 0.4,
   },
+  {
+    id: 4,
+    name: "Capitol Circle",
+    timestamp: "2024-07-04T10:00:00.000Z",
+    points: [
+      { lat: 43.074, lon: -89.384 },
+      { lat: 43.075, lon: -89.385 },
+      { lat: 43.076, lon: -89.386 },
+      { lat: 43.077, lon: -89.387 },
+    ],
+    novelty: 0.7,
+    dtwSimilarity: 0.2,
+    overlapSimilarity: 0.1,
+  },
+  {
+    id: 5,
+    name: "Arboretum Trek",
+    timestamp: "2024-07-05T10:00:00.000Z",
+    points: [
+      { lat: 43.058, lon: -89.417 },
+      { lat: 43.059, lon: -89.418 },
+      { lat: 43.06, lon: -89.419 },
+      { lat: 43.061, lon: -89.42 },
+    ],
+    novelty: 0.8,
+    dtwSimilarity: 0.1,
+    overlapSimilarity: 0.1,
+  },
+  {
+    id: 6,
+    name: "Monona Bay Loop",
+    timestamp: "2024-07-06T10:00:00.000Z",
+    points: [
+      { lat: 43.066, lon: -89.379 },
+      { lat: 43.067, lon: -89.38 },
+      { lat: 43.068, lon: -89.381 },
+      { lat: 43.069, lon: -89.382 },
+    ],
+    novelty: 0.5,
+    dtwSimilarity: 0.35,
+    overlapSimilarity: 0.2,
+  },
+  {
+    id: 7,
+    name: "Goodman Park Jog",
+    timestamp: "2024-07-07T10:00:00.000Z",
+    points: [
+      { lat: 43.051, lon: -89.39 },
+      { lat: 43.052, lon: -89.391 },
+      { lat: 43.053, lon: -89.392 },
+      { lat: 43.054, lon: -89.393 },
+    ],
+    novelty: 0.4,
+    dtwSimilarity: 0.45,
+    overlapSimilarity: 0.3,
+  },
+  {
+    id: 8,
+    name: "Allied Drive Dash",
+    timestamp: "2024-07-08T10:00:00.000Z",
+    points: [
+      { lat: 43.037, lon: -89.42 },
+      { lat: 43.038, lon: -89.421 },
+      { lat: 43.039, lon: -89.422 },
+      { lat: 43.04, lon: -89.423 },
+    ],
+    novelty: 0.2,
+    dtwSimilarity: 0.55,
+    overlapSimilarity: 0.5,
+  },
 ]
 
 const routeRuns: RouteRun[] = [...initialRouteRuns]
@@ -56,5 +126,5 @@ export async function trackRouteRun(run: RouteRun): Promise<void> {
 }
 
 export async function fetchRouteRunHistory(): Promise<RouteRun[]> {
-  return routeRuns
+  return routeRuns.map((r) => ({ ...r, points: [...r.points] }))
 }


### PR DESCRIPTION
## Summary
- Seed telemetry with eight sample route runs around Madison, WI
- Return cloned seeded runs from `fetchRouteRunHistory` and restore them on reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fabc28210832488b43abe9aff8f6d