### PR TITLE
feat: add optional route badges

### DIFF
--- a/src/components/__tests__/nav-section.test.tsx
+++ b/src/components/__tests__/nav-section.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { Star } from "lucide-react";
 import NavSection from "../nav-section";
 import { slugify } from "@/lib/utils";
@@ -11,6 +12,8 @@ describe("NavSection contentId", () => {
     pathname: "",
     favorites: [] as string[],
     toggleFavorite: () => {},
+    highlighted: null as string | null,
+    setHighlighted: () => {},
   };
 
   const groups = [
@@ -92,5 +95,12 @@ describe("NavSection contentId", () => {
     expect(secondTriggerReordered?.getAttribute("aria-controls")).toBe(
       secondId,
     );
+  });
+
+  it("renders badges next to route labels", () => {
+    renderWithProvider({
+      routes: [{ to: "/badge", label: "With Badge", badge: "Beta" }],
+    });
+    expect(screen.getByText("Beta")).toBeInTheDocument();
   });
 });

--- a/src/components/global-navigation.tsx
+++ b/src/components/global-navigation.tsx
@@ -22,6 +22,7 @@ import {
 import useFavorites from "@/hooks/useFavorites";
 import useRecentViews from "@/hooks/useRecentViews";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 
 function RouteList({
   routes,
@@ -43,8 +44,11 @@ function RouteList({
             >
               <route.icon className="mr-2 h-5 w-5" />
               <div className="flex-1">
-                <div className="text-sm font-medium leading-none">
+                <div className="text-sm font-medium leading-none flex items-center gap-2">
                   {route.label}
+                  {route.badge && (
+                    <Badge variant={route.badge}>{route.badge}</Badge>
+                  )}
                 </div>
                 <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
                   {route.description}

--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -20,6 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
 import type { DashboardRoute, DashboardRouteGroup } from "@/routes";
 import usePersistedGroups from "@/hooks/usePersistedGroups";
 
@@ -87,7 +88,12 @@ export default function NavSection({
                         >
                           <NavLink to={route.to} className="flex w-full items-center">
                             {Icon && <Icon className="mr-2 h-4 w-4" />}
-                            <span className="flex-1">{route.label}</span>
+                            <span className="flex flex-1 items-center gap-2">
+                              {route.label}
+                              {route.badge && (
+                                <Badge variant={route.badge}>{route.badge}</Badge>
+                              )}
+                            </span>
                             <Star
                               className={cn(
                                 "ml-auto h-4 w-4",
@@ -173,7 +179,12 @@ export default function NavSection({
                                     to={route.to}
                                     className="flex w-full items-center"
                                   >
-                                    <span className="flex-1">{route.label}</span>
+                                    <span className="flex flex-1 items-center gap-2">
+                                      {route.label}
+                                      {route.badge && (
+                                        <Badge variant={route.badge}>{route.badge}</Badge>
+                                      )}
+                                    </span>
                                     <Star
                                       className={cn(
                                         "ml-auto h-4 w-4",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,13 +4,23 @@ import { cn } from "@/lib/utils";
 export interface BadgeProps {
   className?: string;
   children: React.ReactNode;
+  variant?: string;
 }
 
-export function Badge({ className, children }: BadgeProps) {
+export function Badge({ className, children, variant = "default" }: BadgeProps) {
+  const variants: Record<string, string> = {
+    default: "bg-muted text-muted-foreground",
+    secondary: "bg-secondary text-secondary-foreground",
+    destructive: "bg-destructive text-destructive-foreground",
+    outline: "text-foreground border",
+  };
+  const variantClass = variants[variant] ?? variants["default"];
+
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground",
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        variantClass,
         className
       )}
     >

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -17,6 +17,7 @@ export interface DashboardRoute {
   description: string;
   tooltip?: string;
   tags?: string[];
+  badge?: string;
 }
 
 export interface DashboardRouteGroup {


### PR DESCRIPTION
## Summary
- allow routes to specify optional `badge`
- show route badges in menu and global navigation
- add test coverage for route badges

## Testing
- `npx vitest run` *(fails: Cannot read properties of null (reading 'find') in ReadingProbabilityTimeline test)*

------
https://chatgpt.com/codex/tasks/task_e_688fe9aee2788324ba7f5b42f2872262