### PR TITLE
Render world polygons on mileage globe

### DIFF
--- a/src/components/GlobeRenderer.tsx
+++ b/src/components/GlobeRenderer.tsx
@@ -4,6 +4,7 @@ import { geoOrthographic, geoPath } from "d3-geo";
 import { drag } from "d3-drag";
 import { zoom } from "d3-zoom";
 import { timer, Timer } from "d3-timer";
+import type { Feature } from "geojson";
 
 interface PathData {
   coordinates: [number, number][];
@@ -13,6 +14,7 @@ interface PathData {
 
 interface GlobeRendererProps {
   paths: PathData[];
+  worldFeatures?: Feature[];
   autoRotate?: boolean;
   strokeWidth?: number;
   onPathMouseEnter?: (p: PathData) => void;
@@ -21,6 +23,7 @@ interface GlobeRendererProps {
 
 export default function GlobeRenderer({
   paths,
+  worldFeatures = [],
   autoRotate = false,
   strokeWidth = 2,
   onPathMouseEnter,
@@ -96,6 +99,15 @@ export default function GlobeRenderer({
 
   return (
     <svg ref={svgRef} className="h-full w-full rounded" viewBox="0 0 400 400">
+      {worldFeatures.map((f, idx) => (
+        <path
+          key={`land-${idx}`}
+          d={pathGenerator(f as any) || undefined}
+          fill="var(--muted)"
+          stroke="var(--muted-foreground)"
+          strokeWidth={0.5}
+        />
+      ))}
       {paths.map((p, idx) => (
         <path
           key={idx}

--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -9,6 +9,17 @@ vi.mock("@/hooks/useMileageTimeline");
 describe("MileageGlobe", () => {
   const mockUseMileageTimeline = useMileageTimeline as unknown as vi.Mock;
   const originalFetch = global.fetch;
+  const mockWorld = {
+    type: "Topology",
+    transform: { scale: [1, 1], translate: [0, 0] },
+    arcs: [[[0, 0], [10, 0], [0, 10], [-10, 0], [0, -10]]],
+    objects: {
+      countries: {
+        type: "GeometryCollection",
+        geometries: [{ type: "Polygon", arcs: [[0]] }],
+      },
+    },
+  };
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -37,16 +48,14 @@ describe("MileageGlobe", () => {
     ]);
 
     global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          type: "Topology",
-          objects: { countries: { type: "GeometryCollection", geometries: [] } },
-        }),
+      json: () => Promise.resolve(mockWorld),
     }) as any;
 
     const { container } = render(<MileageGlobe />);
 
     await waitFor(() => {
+      const land = container.querySelectorAll("path[fill='var(--muted)']");
+      expect(land.length).toBeGreaterThan(0);
       const paths = container.querySelectorAll(
         "path[stroke='var(--primary-foreground)']",
       );
@@ -80,11 +89,7 @@ describe("MileageGlobe", () => {
     ]);
 
     global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          type: "Topology",
-          objects: { countries: { type: "GeometryCollection", geometries: [] } },
-        }),
+      json: () => Promise.resolve(mockWorld),
     }) as any;
 
     const { container } = render(<MileageGlobe />);
@@ -111,11 +116,7 @@ describe("MileageGlobe", () => {
     ]);
 
     global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          type: "Topology",
-          objects: { countries: { type: "GeometryCollection", geometries: [] } },
-        }),
+      json: () => Promise.resolve(mockWorld),
     }) as any;
 
     render(<MileageGlobe />);
@@ -125,7 +126,7 @@ describe("MileageGlobe", () => {
     });
   });
 
-  it("still renders total mileage when world data fails to load", async () => {
+  it("shows map unavailable when world data fails to load", async () => {
     mockUseMileageTimeline.mockReturnValue([
       {
         date: "2024-01-01",
@@ -143,7 +144,7 @@ describe("MileageGlobe", () => {
     render(<MileageGlobe />);
 
     await waitFor(() => {
-      expect(screen.getByText("Total: 5 miles")).toBeInTheDocument();
+      expect(screen.getByText("Map unavailable")).toBeInTheDocument();
     });
   });
 
@@ -161,11 +162,7 @@ describe("MileageGlobe", () => {
     ]);
 
     global.fetch = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          type: "Topology",
-          objects: { countries: { type: "GeometryCollection", geometries: [] } },
-        }),
+      json: () => Promise.resolve(mockWorld),
     }) as any;
 
     const { container } = render(<MileageGlobe />);


### PR DESCRIPTION
## Summary
- Parse world TopoJSON into GeoJSON features and pass to `GlobeRenderer`
- Draw land polygons before rendering mileage paths
- Handle world data fetch failures by showing "Map unavailable"

## Testing
- `npx vitest run src/components/examples/__tests__/MileageGlobe.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688febb6f5d8832481f134c273355de3