### PR TITLE
fix: delay storage event

### DIFF
--- a/src/hooks/useRecentViews.ts
+++ b/src/hooks/useRecentViews.ts
@@ -47,7 +47,7 @@ export function useRecentViews() {
       try {
         if (typeof window !== "undefined") {
           localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-          window.dispatchEvent(new Event(STORAGE_EVENT));
+          setTimeout(() => window.dispatchEvent(new Event(STORAGE_EVENT)), 0);
         }
       } catch {
         // ignore


### PR DESCRIPTION
## Summary
- delay recent view storage sync so other components update after render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688feee84214832488f47d55d3d38a67