### PR TITLE
Enable React Router v7 future flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ import { SelectionProvider } from "@/hooks/useSelection";
 
 function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <DashboardFiltersProvider>
         <SelectionProvider>
         <Layout>

--- a/src/components/__tests__/nav-section.test.tsx
+++ b/src/components/__tests__/nav-section.test.tsx
@@ -49,7 +49,7 @@ describe("NavSection contentId", () => {
 
   const renderWithProvider = (props = {}) =>
     render(
-      <MemoryRouter>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <SidebarProvider>
           <NavSection {...baseProps} {...props} />
         </SidebarProvider>
@@ -65,7 +65,7 @@ describe("NavSection contentId", () => {
     expect(firstId).toBe(`Section-group-${slugify("First Group")}`);
 
     rerender(
-      <MemoryRouter>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <SidebarProvider>
           <NavSection {...baseProps} groups={groups} />
         </SidebarProvider>
@@ -82,7 +82,7 @@ describe("NavSection contentId", () => {
     const secondId = secondTrigger?.getAttribute("aria-controls");
 
     rerender(
-      <MemoryRouter>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <SidebarProvider>
           <NavSection {...baseProps} groups={[...groups].reverse()} />
         </SidebarProvider>

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -7,7 +7,10 @@ import Dashboard from "../Dashboard";
 describe("Dashboard", () => {
   it("renders nested routes", () => {
     render(
-      <MemoryRouter initialEntries={["/dashboard/test"]}>
+      <MemoryRouter
+        initialEntries={["/dashboard/test"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <Routes>
           <Route path="/dashboard" element={<Dashboard />}>
             <Route path="test" element={<div>Test Route</div>} />


### PR DESCRIPTION
## Summary
- enable v7 future flags on `BrowserRouter`
- update router usage in tests to opt-in to React Router v7 behavior

## Testing
- `npm test`
- `npm run build` *(fails: [vite]: Rollup failed to resolve import "@radix-ui/react-navigation-menu")*


------
https://chatgpt.com/codex/tasks/task_e_688feeee3ad483248835a354f5eb1e2e