### PR TITLE
feat: add playback controls for mileage globe

### DIFF
--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -4,18 +4,52 @@ import React, { useState, useEffect } from "react";
 import MileageGlobe from "@/components/examples/MileageGlobe";
 import Slider from "@/components/ui/slider";
 import { Button } from "@/components/ui/button";
+import { SimpleSelect } from "@/components/ui/select";
 import useWeeklyVolumeHistory from "@/hooks/useWeeklyVolumeHistory";
 
 export default function MileageGlobePage() {
   const weekly = useWeeklyVolumeHistory();
-  const [range, setRange] = useState<[number, number] | null>(null);
+  const [startWeek, setStartWeek] = useState<number | null>(null);
+  const [playIndex, setPlayIndex] = useState<number | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState("1");
   const [autoRotate, setAutoRotate] = useState(true);
 
+  // initialise range and playback index to the last year of data
   useEffect(() => {
     if (weekly) {
-      setRange([Math.max(0, weekly.length - 52), weekly.length - 1]);
+      const start = Math.max(0, weekly.length - 52);
+      setStartWeek(start);
+      setPlayIndex(start);
     }
   }, [weekly]);
+
+  // advance playback when playing
+  useEffect(() => {
+    if (!playing || playIndex === null || startWeek === null || !weekly) return;
+    const end = weekly.length - 1;
+    const interval = setInterval(() => {
+      setPlayIndex((idx) => {
+        if (idx === null) return idx;
+        if (idx >= end) {
+          setPlaying(false);
+          return idx;
+        }
+        return idx + 1;
+      });
+    }, 800 / parseFloat(speed));
+    return () => clearInterval(interval);
+  }, [playing, speed, startWeek, playIndex, weekly]);
+
+  const handleScrub = (val: number[]) => {
+    setPlayIndex(val[0]);
+    setPlaying(false);
+  };
+
+  const caption =
+    weekly && playIndex !== null
+      ? `${new Date(weekly[playIndex].week).toLocaleDateString()}: ${weekly[playIndex].miles} miles`
+      : "";
 
   return (
     <div className="space-y-4">
@@ -25,36 +59,54 @@ export default function MileageGlobePage() {
         mouse wheel or touchpad to zoom. Total mileage for the selected period is shown
         below the globe.
       </p>
-      {weekly && range && (
+      {weekly && startWeek !== null && playIndex !== null && (
         <div className="space-y-2">
-          <label className="text-sm font-medium">
-            Week range: {new Date(weekly[range[0]].week).toLocaleDateString()} -
-            {" "}
-            {new Date(weekly[range[1]].week).toLocaleDateString()}
-          </label>
+          <label className="text-sm font-medium">{caption}</label>
           <Slider
-            numberOfThumbs={2}
-            min={0}
+            min={startWeek}
             max={weekly.length - 1}
             step={1}
-            value={range}
-            onValueChange={(val) => setRange(val as [number, number])}
-            className="w-48"
+            value={[playIndex]}
+            onValueChange={handleScrub}
+            className="w-64"
           />
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setPlaying((p) => !p)}
+              aria-label={playing ? "Pause playback" : "Play playback"}
+            >
+              {playing ? "Pause" : "Play"}
+            </Button>
+            <SimpleSelect
+              value={speed}
+              onValueChange={(v) => setSpeed(v)}
+              options={[
+                { value: "0.5", label: "0.5x" },
+                { value: "1", label: "1x" },
+                { value: "2", label: "2x" },
+              ]}
+              label="Speed"
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setAutoRotate((a) => !a)}
+              aria-label={autoRotate ? "Pause rotation" : "Play rotation"}
+            >
+              {autoRotate ? "Rotating" : "Static"}
+            </Button>
+          </div>
         </div>
       )}
       <div className="mx-auto max-w-md space-y-2">
-        <div className="flex justify-end">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setAutoRotate((a) => !a)}
-            aria-label={autoRotate ? "Pause rotation" : "Play rotation"}
-          >
-            {autoRotate ? "Pause" : "Play"}
-          </Button>
-        </div>
-        <MileageGlobe weekRange={range ?? undefined} autoRotate={autoRotate} />
+        <MileageGlobe
+          weekRange={
+            startWeek !== null && playIndex !== null ? [startWeek, playIndex] : undefined
+          }
+          autoRotate={autoRotate}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add playback slider with play/pause, speed control and auto-rotate toggle
- animate activity paths drawing on the globe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ffa20c1e48324baff5afb3ecf32f5