### PR TITLE
Handle errors in state visits hook

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -38,7 +38,7 @@ const weatherKey =
   import.meta.env.VITE_WEATHER_KEY || "37744b6f778e02303a56b9cf3c6da8e0";
 
 export default function GeoActivityExplorer() {
-  const data = useStateVisits();
+  const { data, loading, error, refetch } = useStateVisits();
   const [expandedState, setExpandedState] = useState<string | null>(null);
   const [selectedState, setSelectedState] = useState<string | null>(null);
   const [hoveredState, setHoveredState] = useState<string | null>(null);
@@ -164,8 +164,23 @@ export default function GeoActivityExplorer() {
     [stateMarkers, filteredStates],
   )
 
-  if (!data) {
+  if (loading) {
     return <Skeleton className="h-60 w-full" />;
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-60 w-full flex-col items-center justify-center text-sm">
+        <p>Failed to load state visits.</p>
+        <button className="underline" onClick={refetch}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return null;
   }
 
   const toggleState = (abbr: string) => {

--- a/src/components/map/StateVisitCallout.tsx
+++ b/src/components/map/StateVisitCallout.tsx
@@ -27,7 +27,7 @@ interface StateVisitCalloutProps {
 export default function StateVisitCallout({
   onSelectState,
 }: StateVisitCalloutProps) {
-  const visits = useStateVisits();
+  const { data: visits, loading } = useStateVisits();
 
   const latest = useMemo(() => {
     if (!visits) return null;
@@ -59,7 +59,8 @@ export default function StateVisitCallout({
     return entry;
   }, [visits]);
 
-  if (!visits) return <Skeleton className="h-4 w-full" />;
+  if (loading) return <Skeleton className="h-4 w-full" />;
+  if (!visits) return null;
   if (!latest) return null;
 
   const { type, stateCode, stateName, formattedDate, formattedMiles } = latest;

--- a/src/components/map/StateVisitSummary.tsx
+++ b/src/components/map/StateVisitSummary.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export default function StateVisitSummary() {
-  const states = useStateVisits();
+  const { data: states, loading, error, refetch } = useStateVisits();
   const insights = useInsights();
 
   const summary = useMemo(() => {
@@ -20,7 +20,19 @@ export default function StateVisitSummary() {
     return { totalStates, totalMiles, favorite: favorite.stateCode };
   }, [states]);
 
-  if (!summary) return <Skeleton className="h-4 w-full" />;
+  if (loading) return <Skeleton className="h-4 w-full" />;
+
+  if (error)
+    return (
+      <div className="text-xs">
+        Failed to load state visits.{" "}
+        <button className="underline" onClick={refetch}>
+          Retry
+        </button>
+      </div>
+    );
+
+  if (!summary) return null;
 
   return (
     <div className="flex gap-2 flex-wrap text-xs mb-2">

--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -29,28 +29,33 @@ vi.mock("recharts", async () => {
 });
 
 vi.mock("@/hooks/useStateVisits", () => ({
-  useStateVisits: () => [
-    {
-      stateCode: "CA",
-      visited: true,
-      totalDays: 10,
-      totalMiles: 100,
-      cities: [{ name: "LA", days: 4, miles: 40 }],
-      log: [
-        { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
-      ],
-    },
-    {
-      stateCode: "TX",
-      visited: true,
-      totalDays: 5,
-      totalMiles: 50,
-      cities: [{ name: "Austin", days: 5, miles: 50 }],
-      log: [
-        { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
-      ],
-    },
-  ],
+  useStateVisits: () => ({
+    data: [
+      {
+        stateCode: "CA",
+        visited: true,
+        totalDays: 10,
+        totalMiles: 100,
+        cities: [{ name: "LA", days: 4, miles: 40 }],
+        log: [
+          { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
+        ],
+      },
+      {
+        stateCode: "TX",
+        visited: true,
+        totalDays: 5,
+        totalMiles: 50,
+        cities: [{ name: "Austin", days: 5, miles: 50 }],
+        log: [
+          { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
+        ],
+      },
+    ],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
 }));
 
 vi.mock("@/hooks/useInsights", () => ({

--- a/src/components/map/__tests__/StateVisitCallout.test.tsx
+++ b/src/components/map/__tests__/StateVisitCallout.test.tsx
@@ -4,29 +4,34 @@ import { vi } from "vitest";
 import "@testing-library/jest-dom";
 
 vi.mock("@/hooks/useStateVisits", () => ({
-  useStateVisits: () => [
-    {
-      stateCode: "CA",
-      visited: true,
-      totalDays: 0,
-      totalMiles: 0,
-      cities: [],
-      log: [
-        { date: "2025-01-01", type: "run", miles: 5 },
-        { date: "2025-02-01", type: "bike", miles: 10 },
-      ],
-    },
-    {
-      stateCode: "TX",
-      visited: true,
-      totalDays: 0,
-      totalMiles: 0,
-      cities: [],
-      log: [
-        { date: "2024-12-31", type: "run", miles: 3 },
-      ],
-    },
-  ],
+  useStateVisits: () => ({
+    data: [
+      {
+        stateCode: "CA",
+        visited: true,
+        totalDays: 0,
+        totalMiles: 0,
+        cities: [],
+        log: [
+          { date: "2025-01-01", type: "run", miles: 5 },
+          { date: "2025-02-01", type: "bike", miles: 10 },
+        ],
+      },
+      {
+        stateCode: "TX",
+        visited: true,
+        totalDays: 0,
+        totalMiles: 0,
+        cities: [],
+        log: [
+          { date: "2024-12-31", type: "run", miles: 3 },
+        ],
+      },
+    ],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
 }));
 
 describe("StateVisitCallout", () => {

--- a/src/hooks/useStateVisits.ts
+++ b/src/hooks/useStateVisits.ts
@@ -1,13 +1,36 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getStateVisits } from "@/lib/api";
 import type { StateVisit } from "@/lib/types";
 
-export function useStateVisits(): StateVisit[] | null {
-  const [data, setData] = useState<StateVisit[] | null>(null);
+interface UseStateVisitsResult {
+  data: StateVisit[] | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
 
-  useEffect(() => {
-    getStateVisits().then(setData);
+export function useStateVisits(): UseStateVisitsResult {
+  const [data, setData] = useState<StateVisit[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchVisits = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getStateVisits();
+      setData(result);
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  return data;
+  useEffect(() => {
+    fetchVisits();
+  }, [fetchVisits]);
+
+  return { data, loading, error, refetch: fetchVisits };
 }
+


### PR DESCRIPTION
## Summary
- track loading and error state in useStateVisits
- show retry messaging in GeoActivityExplorer and StateVisitSummary
- adjust callouts and tests for new hook API

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6890068fdc7c83248d819b7301b9ceb7