### PR TITLE
fix: limit navigation menu width

### DIFF
--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -17,7 +17,7 @@ const NavigationMenu = React.forwardRef<
   <NavigationMenuPrimitive.Root
     ref={ref}
     className={cn(
-      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      "relative z-10 flex max-w-max items-center justify-center",
       className
     )}
     {...props}
@@ -34,7 +34,7 @@ const NavigationMenuList = React.forwardRef<
   <NavigationMenuPrimitive.List
     ref={ref}
     className={cn(
-      "group flex flex-1 list-none items-center justify-center gap-1",
+      "group flex list-none items-center justify-center gap-1",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- remove flex-1 growth from NavigationMenu so it only occupies space needed
- adjust NavigationMenuList to prevent menu from expanding

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689009dd8e9c8324940af3f6902b2731