### PR TITLE
Enhance Good Day summary with sparkline and top runs

### DIFF
--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -30,9 +30,10 @@ interface GoodDayMapProps {
   data: SessionPoint[] | null
   condition?: string | null
   hourRange?: [number, number]
+  onSelect?: (s: SessionPoint) => void
 }
 
-export default function GoodDayMap({ data, condition, hourRange = [0, 23] }: GoodDayMapProps) {
+export default function GoodDayMap({ data, condition, hourRange = [0, 23], onSelect }: GoodDayMapProps) {
   const [sampleData, setSampleData] = useState<SessionPoint[] | null>(null)
   const [hoverRange, setHoverRange] = useState<[number, number] | null>(null)
   const [active, setActive] = useState<SessionPoint | null>(null)
@@ -265,13 +266,13 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23] }: Goo
             data={colored}
             shape={AnimatedStar}
             isAnimationActive={false}
-            onClick={(data) => setActive(data as SessionPoint)}
+            onClick={(data) => (onSelect ? onSelect(data as SessionPoint) : setActive(data as SessionPoint))}
             cursor="pointer"
           />
         </ScatterChart>
       </ChartContainer>
       <PaceDeltaHistogram bins={bins} onHover={setHoverRange} />
-      <SessionDetailDrawer session={active} onClose={() => setActive(null)} />
+      {!onSelect && <SessionDetailDrawer session={active} onClose={() => setActive(null)} />}
     </ChartCard>
   )
 }

--- a/src/components/statistics/GoodDaySparkline.tsx
+++ b/src/components/statistics/GoodDaySparkline.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import type { ChartConfig } from "@/components/ui/chart"
+
+interface TrendPoint {
+  date: string
+  count: number
+}
+
+interface GoodDaySparklineProps {
+  data: TrendPoint[]
+}
+
+export default function GoodDaySparkline({ data }: GoodDaySparklineProps) {
+  const config = {
+    count: { label: "Good sessions", color: "hsl(var(--chart-1))" },
+  } satisfies ChartConfig
+
+  return (
+    <ChartContainer config={config} className="h-16 w-full">
+      <LineChart data={data} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+        <XAxis dataKey="date" hide />
+        <YAxis allowDecimals={false} hide />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <Line
+          type="monotone"
+          dataKey="count"
+          stroke={config.count.color}
+          strokeWidth={2}
+          dot={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -1,6 +1,7 @@
 export { default as ActivityByTime } from "./ActivityByTime";
 export { default as AvgDailyMileageRadar } from "./AvgDailyMileageRadar";
 export { default as GoodDayMap } from "./GoodDayMap";
+export { default as GoodDaySparkline } from "./GoodDaySparkline";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";

--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -18,6 +18,8 @@ export interface SessionPoint {
   lat: number
   lon: number
   condition: string
+  /** ISO timestamp when the session started */
+  start: string
 }
 
 function kMeans(data: number[][], k: number, iterations = 10): number[] {
@@ -121,6 +123,7 @@ export function useRunningSessions(): SessionPoint[] | null {
             lat: sessions[idx].lat,
             lon: sessions[idx].lon,
             condition: sessions[idx].weather.condition,
+            start: sessions[idx].start ?? sessions[idx].date,
           }
         },
       )

--- a/src/pages/GoodDay.tsx
+++ b/src/pages/GoodDay.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
-import { GoodDayMap } from "@/components/statistics";
-import { useRunningSessions } from "@/hooks/useRunningSessions";
+import { GoodDayMap, GoodDaySparkline } from "@/components/statistics";
+import SessionDetailDrawer from "@/components/statistics/SessionDetailDrawer";
+import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions";
 import { SimpleSelect } from "@/components/ui/select";
 import Slider from "@/components/ui/slider";
 import { Card } from "@/components/ui/card";
@@ -9,6 +10,7 @@ export default function GoodDayPage() {
   const sessions = useRunningSessions();
   const [condition, setCondition] = useState("all");
   const [hourRange, setHourRange] = useState<[number, number]>([0, 23]);
+  const [active, setActive] = useState<SessionPoint | null>(null);
 
   const conditions = useMemo(
     () => (sessions ? Array.from(new Set(sessions.map((s) => s.condition))) : []),
@@ -19,12 +21,28 @@ export default function GoodDayPage() {
     if (!sessions) return null;
     const goodSessions = sessions.filter((s) => s.good);
     if (!goodSessions.length)
-      return { count: 0, mean: 0, max: 0 };
+      return { count: 0, mean: 0, max: 0, percent: 0, top: [], trend: [] };
     const deltas = goodSessions.map((s) => s.paceDelta);
     const count = goodSessions.length;
     const mean = deltas.reduce((sum, d) => sum + d, 0) / count;
-    const max = Math.max(...deltas);
-    return { count, mean, max };
+    const best = goodSessions.reduce((a, b) => (b.paceDelta > a.paceDelta ? b : a));
+    const baselineAvg =
+      goodSessions.reduce((sum, s) => sum + s.pace + s.paceDelta, 0) / count;
+    const percent = baselineAvg ? (mean / baselineAvg) * 100 : 0;
+    const top = [...goodSessions]
+      .sort((a, b) => b.paceDelta - a.paceDelta)
+      .slice(0, 3);
+    const now = new Date();
+    const trend = Array.from({ length: 30 }, (_, i) => {
+      const day = new Date(now);
+      day.setDate(now.getDate() - (29 - i));
+      const key = day.toISOString().slice(0, 10);
+      const c = goodSessions.filter(
+        (s) => s.start && s.start.slice(0, 10) === key,
+      ).length;
+      return { date: key, count: c };
+    });
+    return { count, mean, max: best.paceDelta, percent, top, trend };
   }, [sessions]);
 
   return (
@@ -34,10 +52,38 @@ export default function GoodDayPage() {
         Sessions that exceeded expectations are highlighted below.
       </p>
       {stats && (
-        <Card className="p-4 text-sm space-y-1">
-          <div>Good sessions: {stats.count}</div>
-          <div>Avg Δ Pace: {stats.mean.toFixed(2)} min/mi</div>
-          <div>Max Δ Pace: {stats.max.toFixed(2)} min/mi</div>
+        <Card className="p-4 text-sm space-y-2">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div className="space-y-1">
+              <div>Good sessions: {stats.count}</div>
+              <div>
+                Avg Δ Pace: {stats.mean.toFixed(2)} min/mi (
+                {stats.percent.toFixed(0)}% faster than expected)
+              </div>
+              <div>Best run: {stats.max.toFixed(2)} min/mi faster</div>
+            </div>
+            <div className="sm:w-40 w-full">
+              <GoodDaySparkline data={stats.trend} />
+            </div>
+          </div>
+          {stats.top.length > 0 && (
+            <div>
+              <h2 className="font-medium mt-2">Top improvements</h2>
+              <ol className="list-decimal pl-4 space-y-1">
+                {stats.top.map((s) => (
+                  <li key={s.start}>
+                    <button
+                      className="hover:underline"
+                      onClick={() => setActive(s)}
+                    >
+                      {new Date(s.start).toLocaleDateString()}: {s.paceDelta.toFixed(2)}
+                      {" "}min/mi faster
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
         </Card>
       )}
       {sessions && (
@@ -83,7 +129,9 @@ export default function GoodDayPage() {
         data={sessions}
         condition={condition === "all" ? null : condition}
         hourRange={hourRange}
+        onSelect={setActive}
       />
+      <SessionDetailDrawer session={active} onClose={() => setActive(null)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add comparative stats, sparkline trend, and top improvement list to Good Day page
- expose session selection from GoodDayMap for page-level drawer control
- capture session start timestamps in running session hook

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68900d701ba88324a9b22ba045128e50