### PR TITLE
refactor: add device memory fallback

### DIFF
--- a/src/hooks/useLowEndDevice.ts
+++ b/src/hooks/useLowEndDevice.ts
@@ -9,8 +9,9 @@ export default function useLowEndDevice(): boolean {
 
   useEffect(() => {
     if (typeof navigator === "undefined") return;
-    const cores = navigator.hardwareConcurrency || 4;
-    const memory = (navigator as any).deviceMemory || 4;
+    const nav = navigator as Navigator & { deviceMemory?: number };
+    const cores = nav.hardwareConcurrency ?? 4;
+    const memory = nav.deviceMemory ?? 4;
     if (cores <= 2 || memory <= 2) {
       setLowEnd(true);
     }


### PR DESCRIPTION
## Summary
- detect device memory without using `any`
- default to 4GB when `deviceMemory` is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890178fcd748324ba44407131267720