### PR TITLE
feat: add types for Spotify playback

### DIFF
--- a/src/hooks/useRunSoundtrack.ts
+++ b/src/hooks/useRunSoundtrack.ts
@@ -5,6 +5,8 @@ import {
   getSpotifyNowPlaying,
   getAudioFeatures,
   type SpotifyTrack,
+  type SpotifyRecentPlay,
+  type SpotifyTrackItem,
 } from '@/lib/spotify'
 
 export interface RunTrack extends SpotifyTrack {
@@ -15,7 +17,7 @@ export interface RunTrack extends SpotifyTrack {
 
 export interface RunSoundtrackState {
   window: RunWindow
-  nowPlaying: any | null
+  nowPlaying: SpotifyTrackItem | null
   topTracks: RunTrack[]
 }
 
@@ -32,12 +34,12 @@ export default function useRunSoundtrack(): RunSoundtrackState | null {
       ])
       const start = new Date(window.start).getTime()
       const end = new Date(window.end).getTime()
-      const plays = recent.items.filter((p: any) => {
+      const plays: SpotifyRecentPlay[] = recent.items.filter((p) => {
         const t = new Date(p.played_at).getTime()
         return t >= start && t <= end
       })
-      const counts: Record<string, { track: any; count: number }> = {}
-      plays.forEach((p: any) => {
+      const counts: Record<string, { track: SpotifyTrackItem; count: number }> = {}
+      plays.forEach((p) => {
         const id = p.track.id
         if (!counts[id]) counts[id] = { track: p.track, count: 0 }
         counts[id].count++
@@ -56,7 +58,7 @@ export default function useRunSoundtrack(): RunSoundtrackState | null {
         withFeatures.push({
           id: item.track.id,
           name: item.track.name,
-          artists: item.track.artists.map((a: any) => a.name).join(', '),
+          artists: item.track.artists.map((a) => a.name).join(', '),
           uri: item.track.uri,
           playCount: item.count,
           tempo,
@@ -65,7 +67,8 @@ export default function useRunSoundtrack(): RunSoundtrackState | null {
       }
 
       if (active) {
-        setState({ window, nowPlaying: now?.item ?? null, topTracks: withFeatures })
+        const nowPlaying: SpotifyTrackItem | null = now?.item ?? null
+        setState({ window, nowPlaying, topTracks: withFeatures })
       }
     }
     fetchData()

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -5,6 +5,33 @@ export interface SpotifyTrack {
   uri: string
 }
 
+export interface SpotifyArtist {
+  name: string
+}
+
+export interface SpotifyImage {
+  url: string
+}
+
+export interface SpotifyTrackItem {
+  id: string
+  name: string
+  artists: SpotifyArtist[]
+  uri: string
+  album?: {
+    images?: SpotifyImage[]
+  }
+}
+
+export interface SpotifyRecentPlay {
+  track: SpotifyTrackItem
+  played_at: string
+}
+
+export interface SpotifyNowPlaying {
+  item: SpotifyTrackItem | null
+}
+
 let accessToken: string | null = null
 let tokenExpiry = 0
 
@@ -60,16 +87,17 @@ async function fetchSpotify<T>(endpoint: string): Promise<T> {
   return res.json() as Promise<T>
 }
 
-export async function getSpotifyRecentPlays(limit = 50) {
-  type Response = { items: { track: any; played_at: string }[] }
-  return fetchSpotify<Response>(
+export async function getSpotifyRecentPlays(
+  limit = 50,
+): Promise<{ items: SpotifyRecentPlay[] }> {
+  return fetchSpotify<{ items: SpotifyRecentPlay[] }>(
     `/me/player/recently-played?limit=${limit}`,
   )
 }
 
-export async function getSpotifyNowPlaying() {
+export async function getSpotifyNowPlaying(): Promise<SpotifyNowPlaying | null> {
   try {
-    return fetchSpotify<any>('/me/player/currently-playing')
+    return fetchSpotify<SpotifyNowPlaying>('/me/player/currently-playing')
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- type Spotify recent play and now playing payloads
- refactor run soundtrack hook to use new interfaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890178263ac8324b7e2453e54ff7194