### PR TITLE
feat: add configurable palette to correlation matrix

### DIFF
--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -48,5 +48,26 @@ describe('CorrelationRippleMatrix', () => {
       expect(container.querySelector('div.absolute')).toBeInTheDocument(),
     )
   })
+
+  it('uses colorblind palette when specified', () => {
+    const matrix = [
+      [1, -1],
+      [-1, 1],
+    ]
+    const labels = ['A', 'B']
+    const { container } = render(
+      <CorrelationRippleMatrix
+        matrix={matrix}
+        labels={labels}
+        palette="colorblind"
+        cellSize={50}
+      />,
+    )
+
+    const legend = container.querySelector('.mt-2 .h-2') as HTMLDivElement
+    const bg = legend.style.background.replace(/\s/g, '')
+    expect(bg).toContain('rgb(0,68,27)')
+    expect(bg).toContain('rgb(64,0,75)')
+  })
 })
 


### PR DESCRIPTION
## Summary
- make correlation matrix color scale configurable with RdBu or PRGn palettes
- expose `palette` prop and apply selection to legend
- test colorblind palette output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68901b6246408324be044dd3aa2cdf14