### PR TITLE
feat: group metrics and show boundaries in correlation matrix

### DIFF
--- a/src/components/visualizations/CorrelationRippleMatrix.tsx
+++ b/src/components/visualizations/CorrelationRippleMatrix.tsx
@@ -19,6 +19,7 @@ interface CorrelationRippleMatrixProps {
   matrix: number[][]; // correlation values between -1 and 1
   labels: string[]; // axis labels
   drilldown?: Record<string, { x: number; y: number }[]>; // optional mini chart data
+  groups?: { label: string; size: number }[]; // metric groups for background bands
 
   minValue?: number; // lower bound for color scale
   maxValue?: number; // upper bound for color scale
@@ -64,6 +65,7 @@ function createColorScale(minValue = -1, maxValue = 1) {
 export default function CorrelationRippleMatrix({
   matrix,
   labels,
+  groups,
   drilldown = {},
 
   minValue = -1,
@@ -78,6 +80,19 @@ export default function CorrelationRippleMatrix({
   const [hovered, setHovered] = useState<CellData | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [cellSize, setCellSize] = useState<number>(cellSizeProp ?? DEFAULT_CELL_SIZE);
+
+  const groupBounds = groups
+    ? groups.reduce<{ label: string; size: number; start: number }[]>(
+        (acc, g) => {
+          const start = acc.length
+            ? acc[acc.length - 1].start + acc[acc.length - 1].size
+            : 0;
+          acc.push({ ...g, start });
+          return acc;
+        },
+        [],
+      )
+    : [];
 
   useEffect(() => {
     if (cellSizeProp !== undefined) return;
@@ -122,6 +137,50 @@ export default function CorrelationRippleMatrix({
   return (
     <div className="w-full">
       <div ref={containerRef} className="relative w-full aspect-square">
+        {groupBounds.length > 0 && (
+          <svg className="absolute inset-0 w-full h-full pointer-events-none">
+            {groupBounds.map((g, i) => (
+              <g key={g.label}>
+                <rect
+                  x={g.start * cellSize}
+                  y={0}
+                  width={g.size * cellSize}
+                  height={labels.length * cellSize}
+                  fill={i % 2 === 0 ? "#000" : "#fff"}
+                  opacity={0.03}
+                />
+                <rect
+                  x={0}
+                  y={g.start * cellSize}
+                  width={labels.length * cellSize}
+                  height={g.size * cellSize}
+                  fill={i % 2 === 0 ? "#000" : "#fff"}
+                  opacity={0.03}
+                />
+              </g>
+            ))}
+            {groupBounds.slice(1).map((g, i) => (
+              <g key={`line-${i}`}>
+                <line
+                  x1={g.start * cellSize}
+                  x2={g.start * cellSize}
+                  y1={0}
+                  y2={labels.length * cellSize}
+                  stroke="#bbb"
+                  strokeWidth={1}
+                />
+                <line
+                  x1={0}
+                  x2={labels.length * cellSize}
+                  y1={g.start * cellSize}
+                  y2={g.start * cellSize}
+                  stroke="#bbb"
+                  strokeWidth={1}
+                />
+              </g>
+            ))}
+          </svg>
+        )}
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart
             margin={{ top: 20, right: 20, bottom: 20, left: 20 }}

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -25,6 +25,33 @@ interface Metrics extends MetricPoint {
   calories: number;
 }
 
+interface MetricConfig {
+  key: keyof Metrics;
+  label: string;
+}
+
+interface MetricGroup {
+  label: string;
+  metrics: MetricConfig[];
+}
+
+const METRIC_GROUPS: MetricGroup[] = [
+  {
+    label: "Activity",
+    metrics: [
+      { key: "steps", label: "Steps" },
+      { key: "calories", label: "Calories" },
+    ],
+  },
+  {
+    label: "Recovery",
+    metrics: [
+      { key: "sleep", label: "Sleep" },
+      { key: "heartRate", label: "Heart Rate" },
+    ],
+  },
+];
+
 export default function StatisticsPage() {
   const [points, setPoints] = useState<Metrics[]>([]);
   const [upperOnly, setUpperOnly] = useState(true);
@@ -64,9 +91,13 @@ export default function StatisticsPage() {
   }, []);
 
   const matrixObj = useCorrelationMatrix(points);
-  const labels = ["Steps", "Sleep", "Heart Rate", "Calories"];
-  const keys: (keyof Metrics)[] = ["steps", "sleep", "heartRate", "calories"];
+
+  const labels = METRIC_GROUPS.flatMap((g) => g.metrics.map((m) => m.label));
+  const keys: (keyof Metrics)[] = METRIC_GROUPS.flatMap((g) =>
+    g.metrics.map((m) => m.key),
+  );
   const matrix = keys.map((k1) => keys.map((k2) => matrixObj?.[k1]?.[k2] ?? 0));
+  const groups = METRIC_GROUPS.map((g) => ({ label: g.label, size: g.metrics.length }));
 
   if (!points.length) {
     return (
@@ -112,6 +143,7 @@ export default function StatisticsPage() {
         <CorrelationRippleMatrix
           matrix={matrix}
           labels={labels}
+          groups={groups}
           upperOnly={upperOnly}
           showValues={showValues}
           maxCellSize={80}


### PR DESCRIPTION
## Summary
- group metrics into Activity and Recovery categories
- highlight metric groups in correlation ripple matrix with background bands and boundary lines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901e37f6b083248781ae643ea3d303