### PR TITLE
Refactor correlation matrix legend

### DIFF
--- a/src/components/visualizations/CorrelationRippleMatrix.tsx
+++ b/src/components/visualizations/CorrelationRippleMatrix.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { scaleDiverging } from "d3-scale";
 import { interpolateHcl } from "d3-interpolate";
+import Legend from "./Legend";
 
 interface CorrelationRippleMatrixProps {
   matrix: number[][]; // correlation values between -1 and 1
@@ -116,8 +117,6 @@ export default function CorrelationRippleMatrix({
   const legendGradient = `linear-gradient(to right, ${colorScale(
     minValue
   )}, ${colorScale(0)}, ${colorScale(maxValue)})`;
-  const minLabel = Number(minValue).toFixed(1);
-  const maxLabel = Number(maxValue).toFixed(1);
 
   return (
     <div className="w-full">
@@ -230,17 +229,11 @@ export default function CorrelationRippleMatrix({
           }
         `}</style>
       </div>
-      <div className="mt-2">
-        <div
-          className="h-2 w-full rounded"
-          style={{ background: legendGradient }}
-        />
-        <div className="mt-1 flex justify-between text-[10px] text-muted-foreground">
-          <span>{minLabel}</span>
-          <span>0</span>
-          <span>{maxLabel}</span>
-        </div>
-      </div>
+      <Legend
+        minValue={minValue}
+        maxValue={maxValue}
+        gradient={legendGradient}
+      />
     </div>
   );
 }

--- a/src/components/visualizations/Legend.tsx
+++ b/src/components/visualizations/Legend.tsx
@@ -1,0 +1,42 @@
+
+interface LegendProps {
+  minValue: number;
+  maxValue: number;
+  gradient: string;
+}
+
+export default function Legend({ minValue, maxValue, gradient }: LegendProps) {
+  const ticks = [minValue, -0.5, 0, 0.5, maxValue]
+    .filter((t, i, arr) => t >= minValue && t <= maxValue && arr.indexOf(t) === i);
+  const range = maxValue - minValue || 1;
+
+  return (
+    <div className="mt-4 flex w-full flex-col items-center">
+      <div className="relative h-2 w-64 rounded" style={{ background: gradient }}>
+        {ticks.map((t) => (
+          <div
+            key={t}
+            className="h-3 w-px bg-gray-700"
+            style={{
+              position: "absolute",
+              top: "-0.25rem",
+              left: `${((t - minValue) / range) * 100}%`,
+            }}
+          />
+        ))}
+      </div>
+      <div className="mt-1 flex w-64 justify-between text-[10px] text-muted-foreground">
+        {ticks.map((t) => (
+          <span key={t}>{t.toFixed(1)}</span>
+        ))}
+      </div>
+      <div className="mt-1 flex w-64 justify-between text-[10px] text-muted-foreground">
+        <span>Strong Negative</span>
+        <span>No Correlation</span>
+        <span>Strong Positive</span>
+      </div>
+      <div className="mt-1 text-[10px] text-muted-foreground">Pearson r</div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract correlation legend into reusable `Legend` component
- center legend and add descriptive labels and Pearson r note
- show tick markers for key correlation cutoffs

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68901e3189808324a5176e1d11918ac5