### PR TITLE
Add display mode selection to correlation matrix

### DIFF
--- a/src/components/visualizations/CorrelationRippleMatrix.tsx
+++ b/src/components/visualizations/CorrelationRippleMatrix.tsx
@@ -25,8 +25,7 @@ interface CorrelationRippleMatrixProps {
   showValues?: boolean; // display correlation values in cells
   cellSize?: number; // explicit cell size override
   maxCellSize?: number; // maximum computed cell size
-  upperOnly?: boolean; // only render x >= y cells
-
+  displayMode?: "upper" | "lower" | "full"; // which part of matrix to render
 }
 
 interface CellData {
@@ -71,7 +70,7 @@ export default function CorrelationRippleMatrix({
   showValues = false,
   cellSize: cellSizeProp,
   maxCellSize,
-  upperOnly = false,
+  displayMode = "upper",
 
 }: CorrelationRippleMatrixProps) {
   const [active, setActive] = useState<CellData | null>(null);
@@ -102,7 +101,16 @@ export default function CorrelationRippleMatrix({
 
   const heatData: CellData[] = matrix
     .flatMap((row, y) => row.map((value, x) => ({ x, y, value })))
-    .filter(({ x, y }) => !upperOnly || x >= y);
+    .filter(({ x, y }) => {
+      switch (displayMode) {
+        case "upper":
+          return x >= y;
+        case "lower":
+          return x <= y;
+        default:
+          return true;
+      }
+    });
 
   const colorScale = createColorScale(minValue, maxValue);
 

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import CorrelationRippleMatrix from "@/components/visualizations/CorrelationRippleMatrix";
 import { Button } from "@/components/ui/button";
+import { SimpleSelect } from "@/components/ui/select";
 import {
   getDailySteps,
   getDailySleep,
@@ -27,7 +28,9 @@ interface Metrics extends MetricPoint {
 
 export default function StatisticsPage() {
   const [points, setPoints] = useState<Metrics[]>([]);
-  const [upperOnly, setUpperOnly] = useState(true);
+  const [displayMode, setDisplayMode] = useState<"upper" | "lower" | "full">(
+    "upper",
+  );
   const [showValues, setShowValues] = useState(false);
 
   useEffect(() => {
@@ -94,13 +97,18 @@ export default function StatisticsPage() {
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setUpperOnly((p) => !p)}
-          >
-            {upperOnly ? "Show Full Matrix" : "Show Upper Triangle"}
-          </Button>
+          <SimpleSelect
+            label="Display Mode"
+            value={displayMode}
+            onValueChange={(v) =>
+              setDisplayMode(v as "upper" | "lower" | "full")
+            }
+            options={[
+              { value: "upper", label: "Upper Triangle" },
+              { value: "lower", label: "Lower Triangle" },
+              { value: "full", label: "Full Matrix" },
+            ]}
+          />
           <Button
             variant="outline"
             size="sm"
@@ -112,7 +120,7 @@ export default function StatisticsPage() {
         <CorrelationRippleMatrix
           matrix={matrix}
           labels={labels}
-          upperOnly={upperOnly}
+          displayMode={displayMode}
           showValues={showValues}
           maxCellSize={80}
         />


### PR DESCRIPTION
## Summary
- replace `upperOnly` flag with `displayMode` prop for CorrelationRippleMatrix
- allow filtering of upper, lower, or full matrix based on display mode
- add display mode selector on statistics page

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68901e29ba4883249a1400dc998a0e0b