### PR TITLE
Add mobile-friendly correlation view with help tooltip

### DIFF
--- a/src/components/statistics/CorrelationList.tsx
+++ b/src/components/statistics/CorrelationList.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+} from "@/components/ui/chart";
+import type { ChartConfig } from "@/components/ui/chart";
+
+interface PairData {
+  label1: string;
+  label2: string;
+  value: number;
+  series: { a: number; b: number }[];
+}
+
+interface CorrelationListProps {
+  pairs: PairData[];
+}
+
+function CorrelationSparkline({
+  data,
+  labels,
+}: {
+  data: { a: number; b: number }[];
+  labels: [string, string];
+}) {
+  const config = {
+    a: { label: labels[0], color: "hsl(var(--chart-1))" },
+    b: { label: labels[1], color: "hsl(var(--chart-2))" },
+  } satisfies ChartConfig;
+
+  const all = data.flatMap((d) => [d.a, d.b]);
+  const min = Math.min(...all);
+  const max = Math.max(...all);
+  const range = max - min || 1;
+  const normalized = data.map((d, i) => ({
+    index: i,
+    a: (d.a - min) / range,
+    b: (d.b - min) / range,
+  }));
+
+  return (
+    <ChartContainer config={config} className="h-12 w-full">
+      <LineChart data={normalized} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+        <XAxis dataKey="index" hide />
+        <YAxis domain={[0, 1]} hide />
+        <Line
+          type="monotone"
+          dataKey="a"
+          stroke={config.a.color}
+          strokeWidth={1.5}
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="b"
+          stroke={config.b.color}
+          strokeWidth={1.5}
+          dot={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+export default function CorrelationList({ pairs }: CorrelationListProps) {
+  return (
+    <div className="space-y-4">
+      {pairs.map((p) => (
+        <div key={`${p.label1}-${p.label2}`} className="space-y-1">
+          <div className="flex justify-between text-sm font-medium">
+            <span>
+              {p.label1} vs {p.label2}
+            </span>
+            <span>{p.value.toFixed(2)}</span>
+          </div>
+          <CorrelationSparkline data={p.series} labels={[p.label1, p.label2]} />
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useState } from "react";
 import CorrelationRippleMatrix from "@/components/visualizations/CorrelationRippleMatrix";
+import CorrelationList from "@/components/statistics/CorrelationList";
 import { Button } from "@/components/ui/button";
+import { HelpCircle } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   getDailySteps,
   getDailySleep,
@@ -29,6 +38,7 @@ export default function StatisticsPage() {
   const [points, setPoints] = useState<Metrics[]>([]);
   const [upperOnly, setUpperOnly] = useState(true);
   const [showValues, setShowValues] = useState(false);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     async function load() {
@@ -68,6 +78,18 @@ export default function StatisticsPage() {
   const keys: (keyof Metrics)[] = ["steps", "sleep", "heartRate", "calories"];
   const matrix = keys.map((k1) => keys.map((k2) => matrixObj?.[k1]?.[k2] ?? 0));
 
+  const pairs = keys.flatMap((k1, i) =>
+    keys.slice(i + 1).map((k2, j) => ({
+      label1: labels[i],
+      label2: labels[i + 1 + j],
+      value: matrixObj?.[k1]?.[k2] ?? 0,
+      series: points.map((p) => ({ a: p[k1], b: p[k2] })),
+    }))
+  );
+  const topPairs = [...pairs]
+    .sort((a, b) => Math.abs(b.value) - Math.abs(a.value))
+    .slice(0, 5);
+
   if (!points.length) {
     return (
       <Card>
@@ -84,7 +106,28 @@ export default function StatisticsPage() {
   return (
     <Card>
       <CardHeader>
-        <h1 className="text-2xl font-bold">Metric Correlations</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Metric Correlations</h1>
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  aria-label="How to read this"
+                >
+                  <HelpCircle className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                Each value represents the correlation coefficient between two
+                metrics. Red indicates positive correlation, blue negative. Tap
+                a cell for a detailed time-series view.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
         <CardDescription>
           Correlation between daily steps, sleep, heart rate, and calories. Red
           squares indicate positive correlation while blue show negative. Color
@@ -93,29 +136,35 @@ export default function StatisticsPage() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setUpperOnly((p) => !p)}
-          >
-            {upperOnly ? "Show Full Matrix" : "Show Upper Triangle"}
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowValues((p) => !p)}
-          >
-            {showValues ? "Hide Values" : "Show Values"}
-          </Button>
-        </div>
-        <CorrelationRippleMatrix
-          matrix={matrix}
-          labels={labels}
-          upperOnly={upperOnly}
-          showValues={showValues}
-          maxCellSize={80}
-        />
+        {isMobile ? (
+          <CorrelationList pairs={topPairs} />
+        ) : (
+          <>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setUpperOnly((p) => !p)}
+              >
+                {upperOnly ? "Show Full Matrix" : "Show Upper Triangle"}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowValues((p) => !p)}
+              >
+                {showValues ? "Hide Values" : "Show Values"}
+              </Button>
+            </div>
+            <CorrelationRippleMatrix
+              matrix={matrix}
+              labels={labels}
+              upperOnly={upperOnly}
+              showValues={showValues}
+              maxCellSize={80}
+            />
+          </>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add help icon on Statistics page that explains correlation matrix
- show top correlations with sparklines on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901e38fc0c832491cd5ac0a64aeda7