### PR TITLE
feat: add session residual chart

### DIFF
--- a/src/components/statistics/SessionDetailDrawer.tsx
+++ b/src/components/statistics/SessionDetailDrawer.tsx
@@ -4,6 +4,18 @@ import Map, { Marker } from "react-map-gl/maplibre"
 import maplibregl from "maplibre-gl"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { SessionPoint } from "@/hooks/useRunningSessions"
+import useSessionTimeseries from "@/hooks/useSessionTimeseries"
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Area,
+  CartesianGrid,
+  Tooltip as ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart"
 
 interface SessionDetailDrawerProps {
   session: SessionPoint | null
@@ -11,6 +23,13 @@ interface SessionDetailDrawerProps {
 }
 
 export default function SessionDetailDrawer({ session, onClose }: SessionDetailDrawerProps) {
+  const series = useSessionTimeseries(session?.id ?? null)
+  const baseline = session ? session.pace + session.paceDelta : 0
+  const chartConfig = {
+    actual: { label: "Actual", color: "hsl(var(--chart-1))" },
+    expected: { label: "Expected", color: "hsl(var(--chart-2))" },
+    temperature: { label: "Temp °F", color: "hsl(var(--chart-3))" },
+  } satisfies ChartConfig
   return (
     <Sheet open={!!session} onOpenChange={(open) => { if (!open) onClose() }}>
       <SheetContent side="right" className="w-80 sm:w-96">
@@ -33,8 +52,10 @@ export default function SessionDetailDrawer({ session, onClose }: SessionDetailD
               </Map>
             </div>
             <div className="grid grid-cols-2 gap-2 text-sm">
-              <span>Pace: {session.pace.toFixed(2)} min/mi</span>
-              <span>Δ Pace: {session.paceDelta.toFixed(2)} min/mi</span>
+              <span className="col-span-2">
+                Expected / Actual / Δ: {baseline.toFixed(2)} / {session.pace.toFixed(2)} / {session.paceDelta.toFixed(2)}
+                {' '}min/mi
+              </span>
               <span>Heart Rate: {session.heartRate} bpm</span>
               <span>Temp: {session.temperature}°F</span>
               <span>Humidity: {session.humidity}%</span>
@@ -42,6 +63,40 @@ export default function SessionDetailDrawer({ session, onClose }: SessionDetailD
               <span>Start Hour: {session.startHour}</span>
               <span>Duration: {session.duration} min</span>
             </div>
+            {series && (
+              <ChartContainer config={chartConfig} className="h-40">
+                <LineChart data={series}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="t" tickLine={false} axisLine={false} />
+                  <YAxis yAxisId="pace" tickLine={false} axisLine={false} />
+                  <YAxis yAxisId="temp" orientation="right" tickLine={false} axisLine={false} />
+                  <ChartTooltip />
+                  <Area
+                    yAxisId="temp"
+                    type="monotone"
+                    dataKey="temperature"
+                    stroke="none"
+                    fill="var(--color-temperature)"
+                    opacity={0.3}
+                  />
+                  <Line
+                    yAxisId="pace"
+                    type="monotone"
+                    dataKey="actual"
+                    stroke="var(--color-actual)"
+                    dot={false}
+                  />
+                  <Line
+                    yAxisId="pace"
+                    type="monotone"
+                    dataKey="expected"
+                    stroke="var(--color-expected)"
+                    strokeDasharray="4 2"
+                    dot={false}
+                  />
+                </LineChart>
+              </ChartContainer>
+            )}
           </div>
         )}
       </SheetContent>

--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -5,6 +5,8 @@ import TSNE from 'tsne-js'
 export interface SessionPoint {
   x: number
   y: number
+  /** Unique session identifier */
+  id: number
   cluster: number
   good: boolean
   pace: number
@@ -110,6 +112,7 @@ export function useRunningSessions(): SessionPoint[] | null {
           return {
             x,
             y,
+            id: sessions[idx].id,
             cluster: labels[idx],
             good: paceDelta > 0,
             pace: sessions[idx].pace,

--- a/src/hooks/useSessionTimeseries.ts
+++ b/src/hooks/useSessionTimeseries.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { getSessionTimeseries, type PaceWeatherPoint } from '@/lib/api'
+
+export default function useSessionTimeseries(sessionId: number | null) {
+  const [data, setData] = useState<PaceWeatherPoint[] | null>(null)
+
+  useEffect(() => {
+    if (sessionId == null) {
+      setData(null)
+      return
+    }
+    getSessionTimeseries(sessionId).then(setData)
+  }, [sessionId])
+
+  return data
+}


### PR DESCRIPTION
## Summary
- show expected, actual and delta paces in session details
- add residual pace chart with weather overlay
- expose mock timeseries API and hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68902152990883249738fa8578c556fd