### PR TITLE
feat: include correlation significance in matrix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "date-fns": "^4.1.0",
         "events": "^3.3.0",
         "framer-motion": "^12.23.12",
+        "jstat": "^1.9.6",
         "lucide-react": "^0.534.0",
         "maplibre-gl": "^3.6.0",
         "react": "^18.2.0",
@@ -6757,6 +6758,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jstat": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.9.6.tgz",
+      "integrity": "sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug=="
     },
     "node_modules/jsts": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "recharts": "^2.15.4",
     "swr": "^2.3.4",
     "topojson-client": "^3.1.0",
-    "tsne-js": "^1.0.3"
+    "tsne-js": "^1.0.3",
+    "jstat": "^1.9.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -20,8 +20,14 @@ vi.mock('recharts', async () => {
 describe('CorrelationRippleMatrix', () => {
   it('shows detail chart on cell click', async () => {
     const matrix = [
-      [1, 0.5],
-      [0.5, 1],
+      [
+        { value: 1, n: 10, p: 0 },
+        { value: 0.5, n: 10, p: 0.2 },
+      ],
+      [
+        { value: 0.5, n: 10, p: 0.2 },
+        { value: 1, n: 10, p: 0 },
+      ],
     ]
     const labels = ['A', 'B']
     const drilldown = {
@@ -43,6 +49,7 @@ describe('CorrelationRippleMatrix', () => {
 
     const cells = container.querySelectorAll('path.recharts-rectangle')
     expect(cells.length).toBeGreaterThan(1)
+    expect(cells[1]).toHaveAttribute('opacity', '0.3')
     await userEvent.click(cells[1] as SVGPathElement, { skipHover: true })
     await waitFor(() =>
       expect(container.querySelector('div.absolute')).toBeInTheDocument(),

--- a/src/hooks/__tests__/useCorrelationMatrix.test.ts
+++ b/src/hooks/__tests__/useCorrelationMatrix.test.ts
@@ -16,10 +16,13 @@ describe('computeCorrelationMatrix', () => {
       { a: 5, b: 10, c: 1 },
     ]
     const matrix = computeCorrelationMatrix(points)
-    expect(matrix.a.a).toBeCloseTo(1)
-    expect(matrix.a.b).toBeCloseTo(1)
-    expect(matrix.a.c).toBeCloseTo(-1)
-    expect(matrix.b.c).toBeCloseTo(-1)
+    expect(matrix.a.a.value).toBeCloseTo(1)
+    expect(matrix.a.a.n).toBe(5)
+    expect(matrix.a.a.p).toBe(0)
+    expect(matrix.a.b.value).toBeCloseTo(1)
+    expect(matrix.a.b.p).toBe(0)
+    expect(matrix.a.c.value).toBeCloseTo(-1)
+    expect(matrix.b.c.value).toBeCloseTo(-1)
   })
 
   it('handles uncorrelated data', () => {
@@ -35,8 +38,10 @@ describe('computeCorrelationMatrix', () => {
       { a: 5, b: 2 },
     ]
     const matrix = computeCorrelationMatrix(points)
-    expect(matrix.a.b).toBeCloseTo(0)
-    expect(matrix.b.a).toBeCloseTo(0)
+    expect(matrix.a.b.value).toBeCloseTo(0)
+    expect(matrix.a.b.n).toBe(5)
+    expect(matrix.a.b.p).toBeGreaterThan(0.1)
+    expect(matrix.b.a.value).toBeCloseTo(0)
   })
 })
 

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -66,7 +66,9 @@ export default function StatisticsPage() {
   const matrixObj = useCorrelationMatrix(points);
   const labels = ["Steps", "Sleep", "Heart Rate", "Calories"];
   const keys: (keyof Metrics)[] = ["steps", "sleep", "heartRate", "calories"];
-  const matrix = keys.map((k1) => keys.map((k2) => matrixObj?.[k1]?.[k2] ?? 0));
+  const matrix = keys.map((k1) =>
+    keys.map((k2) => matrixObj?.[k1]?.[k2] ?? { value: 0, n: 0, p: 1 }),
+  );
 
   if (!points.length) {
     return (


### PR DESCRIPTION
## Summary
- calculate sample size and p-value for each pair in `useCorrelationMatrix`
- dim non-significant cells and support optional sparklines in `CorrelationRippleMatrix`
- adjust statistics page and tests for new matrix structure

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68901e3575dc832495fb8a6f7eea8e60