### PR TITLE
fix: prevent nav menu from closing on mount

### DIFF
--- a/src/components/global-navigation.tsx
+++ b/src/components/global-navigation.tsx
@@ -132,6 +132,7 @@ export default function GlobalNavigation() {
 
   const [menuValue, setMenuValue] = React.useState<string | undefined>();
   const closeMenu = React.useCallback(() => setMenuValue(undefined), []);
+  const firstRender = React.useRef(true);
 
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -145,6 +146,10 @@ export default function GlobalNavigation() {
   }, []);
 
   React.useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
     closeMenu();
   }, [location.pathname, closeMenu]);
 


### PR DESCRIPTION
## Summary
- avoid triggering closeMenu on initial render by skipping first effect run

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689021ff86f4832491cee5ba75628640