### PR TITLE
feat: visualize session confidence

### DIFF
--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -12,6 +12,8 @@ export interface SessionPoint {
   pace: number
   paceDelta: number
   heartRate: number
+  /** Confidence in metrics like heart-rate stability (0-1) */
+  confidence: number
   temperature: number
   humidity: number
   wind: number
@@ -109,6 +111,7 @@ export function useRunningSessions(): SessionPoint[] | null {
         ([x, y]: [number, number], idx: number) => {
           const expected = expectedPace(sessions[idx])
           const paceDelta = expected - sessions[idx].pace
+          const hrStability = Math.max(0, 1 - Math.abs(sessions[idx].heartRate - 140) / 50)
           return {
             x,
             y,
@@ -118,6 +121,7 @@ export function useRunningSessions(): SessionPoint[] | null {
             pace: sessions[idx].pace,
             paceDelta,
             heartRate: sessions[idx].heartRate,
+            confidence: hrStability,
             temperature: sessions[idx].weather.temperature,
             humidity: sessions[idx].weather.humidity,
             wind: sessions[idx].weather.wind,


### PR DESCRIPTION
## Summary
- add heart-rate stability-based confidence to running session data
- highlight benchmark runs with filled stars and confidence halos

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689023418f04832483137d9e92f0cdf1