### PR TITLE
Handle errors in training consistency hook

### DIFF
--- a/src/components/dashboard/TrainingEntropyHeatmap.tsx
+++ b/src/components/dashboard/TrainingEntropyHeatmap.tsx
@@ -7,7 +7,14 @@ import useTrainingConsistency from "@/hooks/useTrainingConsistency";
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export default function TrainingEntropyHeatmap() {
-  const data = useTrainingConsistency();
+  const { data, error } = useTrainingConsistency();
+
+  if (error)
+    return (
+      <div className="h-64 flex items-center justify-center text-sm text-destructive">
+        Failed to load training data
+      </div>
+    );
 
   if (!data) return <Skeleton className="h-64" />;
 

--- a/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import React from 'react'
 import '@testing-library/jest-dom'
 import TrainingEntropyHeatmap from '../TrainingEntropyHeatmap'
@@ -16,18 +16,35 @@ vi.mock('recharts', async () => {
   }
 })
 
-vi.mock('@/hooks/useTrainingConsistency', () => ({
-  __esModule: true,
-  default: () => ({
-    sessions: [],
-    heatmap: [{ day: 0, hour: 0, count: 1 }],
-    weeklyEntropy: [0.2],
-  }),
-}))
+vi.mock('@/hooks/useTrainingConsistency')
+import useTrainingConsistency from '@/hooks/useTrainingConsistency'
+const mockUseTrainingConsistency = useTrainingConsistency as unknown as vi.Mock
+
+beforeEach(() => {
+  mockUseTrainingConsistency.mockReturnValue({
+    data: {
+      sessions: [],
+      heatmap: [{ day: 0, hour: 0, count: 1 }],
+      weeklyEntropy: [0.2],
+    },
+    error: null,
+  })
+})
 
 describe('TrainingEntropyHeatmap', () => {
   it('renders chart title', () => {
     render(<TrainingEntropyHeatmap />)
     expect(screen.getByText(/Training Consistency/)).toBeInTheDocument()
+  })
+
+  it('renders error message', () => {
+    mockUseTrainingConsistency.mockReturnValueOnce({
+      data: null,
+      error: new Error('boom'),
+    })
+    render(<TrainingEntropyHeatmap />)
+    expect(
+      screen.getByText(/Failed to load training data/),
+    ).toBeInTheDocument()
   })
 })

--- a/src/components/statistics/HabitConsistencyHeatmap.tsx
+++ b/src/components/statistics/HabitConsistencyHeatmap.tsx
@@ -10,7 +10,14 @@ import { Link } from "react-router-dom"
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
 export default function HabitConsistencyHeatmap() {
-  const data = useTrainingConsistency()
+  const { data, error } = useTrainingConsistency()
+
+  if (error)
+    return (
+      <div className="h-64 flex items-center justify-center text-sm text-destructive">
+        Failed to load training data
+      </div>
+    )
 
   if (!data) return <Skeleton className="h-64" />
 

--- a/src/hooks/useTrainingConsistency.ts
+++ b/src/hooks/useTrainingConsistency.ts
@@ -13,6 +13,11 @@ export interface TrainingConsistency {
   weeklyEntropy: number[]
 }
 
+export interface UseTrainingConsistencyResult {
+  data: TrainingConsistency | null
+  error: Error | null
+}
+
 function computeHeatmap(sessions: RunningSession[]): TrainingHeatmapCell[] {
   const bins = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0))
   sessions.forEach((s) => {
@@ -57,14 +62,15 @@ function computeWeeklyEntropy(sessions: RunningSession[]): number[] {
     .map((k) => shannonEntropy(weeks[k]))
 }
 
-export default function useTrainingConsistency(): TrainingConsistency | null {
+export default function useTrainingConsistency(): UseTrainingConsistencyResult {
   const [sessions, setSessions] = useState<RunningSession[] | null>(null)
+  const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
-    getRunningSessions().then(setSessions)
+    getRunningSessions().then(setSessions).catch((e) => setError(e as Error))
   }, [])
 
-  return useMemo(() => {
+  const data = useMemo(() => {
     if (!sessions) return null
     return {
       sessions,
@@ -72,4 +78,6 @@ export default function useTrainingConsistency(): TrainingConsistency | null {
       weeklyEntropy: computeWeeklyEntropy(sessions),
     }
   }, [sessions])
+
+  return { data, error }
 }


### PR DESCRIPTION
## Summary
- catch running-session fetch errors in `useTrainingConsistency`
- surface error state in HabitConsistency and TrainingEntropy heatmaps
- test error UI for `TrainingEntropyHeatmap`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689024443a9c8324becbf97f433841b5