### PR TITLE
fix(spotify): handle now playing errors

### DIFF
--- a/src/lib/__tests__/spotify.test.ts
+++ b/src/lib/__tests__/spotify.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getSpotifyNowPlaying, setSpotifyAccessToken } from '../spotify'
+
+describe('getSpotifyNowPlaying', () => {
+  it('returns null when fetch rejects', async () => {
+    setSpotifyAccessToken('token')
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('fail'))
+
+    const result = await getSpotifyNowPlaying()
+
+    expect(fetchSpy).toHaveBeenCalled()
+    expect(result).toBeNull()
+    fetchSpy.mockRestore()
+  })
+})

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -97,7 +97,7 @@ export async function getSpotifyRecentPlays(
 
 export async function getSpotifyNowPlaying(): Promise<SpotifyNowPlaying | null> {
   try {
-    return fetchSpotify<SpotifyNowPlaying>('/me/player/currently-playing')
+    return await fetchSpotify<SpotifyNowPlaying>('/me/player/currently-playing')
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- await fetch in getSpotifyNowPlaying so errors are caught
- add regression test ensuring failures return null

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68901712074483248eeb39ed381c8fdb