### PR TITLE
feat: add GoodDay insights panel

### DIFF
--- a/src/components/statistics/GoodDayInsights.tsx
+++ b/src/components/statistics/GoodDayInsights.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { Card } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import GoodDaySparkline from "./GoodDaySparkline"
+import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions"
+
+interface GoodDayInsightsProps {
+  sessions?: SessionPoint[] | null
+  onSelect?: (s: SessionPoint) => void
+}
+
+export default function GoodDayInsights({ sessions: propSessions, onSelect }: GoodDayInsightsProps) {
+  const hookSessions = useRunningSessions()
+  const sessions = propSessions ?? hookSessions
+
+  if (!sessions) return <Skeleton className="h-32" />
+  if (!sessions.length) return null
+
+  const good = sessions.filter((s) => s.good)
+  if (!good.length) return null
+
+  // Top improvements
+  const top = [...good].sort((a, b) => b.paceDelta - a.paceDelta).slice(0, 3)
+
+  // Time-of-day clusters
+  const clusterDefs = [
+    { label: "Night", range: [0, 5] as [number, number] },
+    { label: "Morning", range: [5, 12] as [number, number] },
+    { label: "Afternoon", range: [12, 17] as [number, number] },
+    { label: "Evening", range: [17, 24] as [number, number] },
+  ]
+  const clusters = clusterDefs
+    .map(({ label, range }) => ({
+      label,
+      count: sessions.filter((s) => s.startHour >= range[0] && s.startHour < range[1]).length,
+    }))
+    .filter((c) => c.count > 0)
+    .sort((a, b) => b.count - a.count)
+
+  // Recent trend change
+  const sorted = [...good].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+  )
+  const last = sorted.slice(-7)
+  const prev = sorted.slice(-14, -7)
+  const lastAvg = last.reduce((sum, s) => sum + s.paceDelta, 0) / last.length
+  const prevAvg = prev.length
+    ? prev.reduce((sum, s) => sum + s.paceDelta, 0) / prev.length
+    : lastAvg
+  const trendChange = lastAvg - prevAvg
+
+  const now = new Date()
+  const trendData = Array.from({ length: 30 }, (_, i) => {
+    const day = new Date(now)
+    day.setDate(now.getDate() - (29 - i))
+    const key = day.toISOString().slice(0, 10)
+    const count = good.filter((s) => s.start.slice(0, 10) === key).length
+    return { date: key, count }
+  })
+
+  return (
+    <Card className="p-4 space-y-4 text-sm">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="space-y-1">
+          <div>
+            Recent pace delta: {lastAvg.toFixed(2)} min/mi (
+            {trendChange >= 0 ? "+" : ""}
+            {trendChange.toFixed(2)} vs prev 7 runs)
+          </div>
+        </div>
+        <div className="sm:w-40 w-full">
+          <GoodDaySparkline data={trendData} />
+        </div>
+      </div>
+      {clusters.length > 0 && (
+        <div>
+          <h2 className="font-medium">Time of day clusters</h2>
+          <div className="flex gap-2 flex-wrap">
+            {clusters.map((c) => (
+              <span key={c.label} className="px-2 py-1 bg-muted rounded">
+                {c.label}: {c.count}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      {top.length > 0 && (
+        <div>
+          <h2 className="font-medium">Top improvements</h2>
+          <ol className="list-decimal pl-4 space-y-1">
+            {top.map((s) => (
+              <li key={s.id}>
+                <button
+                  className="hover:underline"
+                  onClick={() => onSelect?.(s)}
+                >
+                  {new Date(s.start).toLocaleDateString()}: {s.paceDelta.toFixed(2)} min/mi faster
+                </button>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </Card>
+  )
+}
+

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -2,6 +2,7 @@ export { default as ActivityByTime } from "./ActivityByTime";
 export { default as AvgDailyMileageRadar } from "./AvgDailyMileageRadar";
 export { default as GoodDayMap } from "./GoodDayMap";
 export { default as GoodDaySparkline } from "./GoodDaySparkline";
+export { default as GoodDayInsights } from "./GoodDayInsights";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";

--- a/src/pages/GoodDay.tsx
+++ b/src/pages/GoodDay.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo, useState } from "react";
-import { GoodDayMap, GoodDaySparkline } from "@/components/statistics";
+import { GoodDayMap, GoodDayInsights } from "@/components/statistics";
 import SessionDetailDrawer from "@/components/statistics/SessionDetailDrawer";
 import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions";
 import { SimpleSelect } from "@/components/ui/select";
 import Slider from "@/components/ui/slider";
-import { Card } from "@/components/ui/card";
 
 export default function GoodDayPage() {
   const sessions = useRunningSessions();
@@ -17,33 +16,6 @@ export default function GoodDayPage() {
     [sessions],
   );
 
-  const stats = useMemo(() => {
-    if (!sessions) return null;
-    const goodSessions = sessions.filter((s) => s.good);
-    if (!goodSessions.length)
-      return { count: 0, mean: 0, max: 0, percent: 0, top: [], trend: [] };
-    const deltas = goodSessions.map((s) => s.paceDelta);
-    const count = goodSessions.length;
-    const mean = deltas.reduce((sum, d) => sum + d, 0) / count;
-    const best = goodSessions.reduce((a, b) => (b.paceDelta > a.paceDelta ? b : a));
-    const baselineAvg =
-      goodSessions.reduce((sum, s) => sum + s.pace + s.paceDelta, 0) / count;
-    const percent = baselineAvg ? (mean / baselineAvg) * 100 : 0;
-    const top = [...goodSessions]
-      .sort((a, b) => b.paceDelta - a.paceDelta)
-      .slice(0, 3);
-    const now = new Date();
-    const trend = Array.from({ length: 30 }, (_, i) => {
-      const day = new Date(now);
-      day.setDate(now.getDate() - (29 - i));
-      const key = day.toISOString().slice(0, 10);
-      const c = goodSessions.filter(
-        (s) => s.start && s.start.slice(0, 10) === key,
-      ).length;
-      return { date: key, count: c };
-    });
-    return { count, mean, max: best.paceDelta, percent, top, trend };
-  }, [sessions]);
 
   return (
     <div className="p-4 space-y-4">
@@ -51,41 +23,7 @@ export default function GoodDayPage() {
       <p className="text-sm text-muted-foreground">
         Sessions that exceeded expectations are highlighted below.
       </p>
-      {stats && (
-        <Card className="p-4 text-sm space-y-2">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-            <div className="space-y-1">
-              <div>Good sessions: {stats.count}</div>
-              <div>
-                Avg Δ Pace: {stats.mean.toFixed(2)} min/mi (
-                {stats.percent.toFixed(0)}% faster than expected)
-              </div>
-              <div>Best run: {stats.max.toFixed(2)} min/mi faster</div>
-            </div>
-            <div className="sm:w-40 w-full">
-              <GoodDaySparkline data={stats.trend} />
-            </div>
-          </div>
-          {stats.top.length > 0 && (
-            <div>
-              <h2 className="font-medium mt-2">Top improvements</h2>
-              <ol className="list-decimal pl-4 space-y-1">
-                {stats.top.map((s) => (
-                  <li key={s.start}>
-                    <button
-                      className="hover:underline"
-                      onClick={() => setActive(s)}
-                    >
-                      {new Date(s.start).toLocaleDateString()}: {s.paceDelta.toFixed(2)}
-                      {" "}min/mi faster
-                    </button>
-                  </li>
-                ))}
-              </ol>
-            </div>
-          )}
-        </Card>
-      )}
+      <GoodDayInsights sessions={sessions} onSelect={setActive} />
       {sessions && (
         <div className="flex gap-4 flex-wrap items-center">
           <SimpleSelect


### PR DESCRIPTION
## Summary
- analyze running sessions to show top improvements, time-of-day clusters, and pace trends
- embed GoodDay insights panel on GoodDay page and export from statistics index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68902b3b3fc48324a2f95100585b7678