### PR TITLE
feat: add palette options and cell gap

### DIFF
--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -69,5 +69,26 @@ describe('CorrelationRippleMatrix', () => {
     expect(bg).toContain('rgb(0,68,27)')
     expect(bg).toContain('rgb(64,0,75)')
   })
+
+  it('supports viridis palette', () => {
+    const matrix = [
+      [1, -1],
+      [-1, 1],
+    ]
+    const labels = ['A', 'B']
+    const { container } = render(
+      <CorrelationRippleMatrix
+        matrix={matrix}
+        labels={labels}
+        palette="viridis"
+        cellSize={50}
+      />, 
+    )
+
+    const legend = container.querySelector('.mt-2 .h-2') as HTMLDivElement
+    const bg = legend.style.background.replace(/\s/g, '')
+    expect(bg).toContain('#440154')
+    expect(bg).toContain('#fde725')
+  })
 })
 


### PR DESCRIPTION
## Summary
- add multiple palette options including viridis and magma to correlation matrix
- allow adjusting cell gap for subtle borders between cells
- test viridis palette rendering

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68901e2620608324951e9cb40a601056