### PR TITLE
feat: add fragility index card

### DIFF
--- a/src/components/dashboard/FragilityIndexCard.tsx
+++ b/src/components/dashboard/FragilityIndexCard.tsx
@@ -1,0 +1,23 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import CircularFragilityRing from './CircularFragilityRing'
+import FragilityBreakdown from './FragilityBreakdown'
+import FragilityIndexSparkline from './FragilityIndexSparkline'
+
+export default function FragilityIndexCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Fragility Index</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center space-y-2">
+        <div className="flex items-center space-x-4">
+          <CircularFragilityRing />
+          <FragilityBreakdown />
+        </div>
+        <div className="w-full max-w-sm">
+          <FragilityIndexSparkline />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -30,6 +30,7 @@ export { default as FragilityGauge } from "./FragilityGauge";
 export { default as CircularFragilityRing } from "./CircularFragilityRing";
 export { default as FragilityIndexSparkline } from "./FragilityIndexSparkline";
 export { default as FragilityBreakdown } from "./FragilityBreakdown";
+export { default as FragilityIndexCard } from "./FragilityIndexCard";
 export { default as FragilityPreviewSparkline } from "./FragilityPreviewSparkline";
 
 export { default as TrainingEntropyHeatmap } from "./TrainingEntropyHeatmap";

--- a/src/pages/Fragility.tsx
+++ b/src/pages/Fragility.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CircularFragilityRing, FragilityIndexSparkline, FragilityBreakdown } from "@/components/dashboard";
+import { FragilityIndexCard } from "@/components/dashboard";
 import { FRAGILITY_LEVELS } from "@/lib/fragility";
 
 export default function FragilityPage() {
@@ -20,15 +20,7 @@ export default function FragilityPage() {
           </li>
         ))}
       </ul>
-      <div className="flex flex-col items-center space-y-2">
-        <div className="flex items-center space-x-4">
-          <CircularFragilityRing />
-          <FragilityBreakdown />
-        </div>
-        <div className="w-full max-w-sm">
-          <FragilityIndexSparkline />
-        </div>
-      </div>
+      <FragilityIndexCard />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `FragilityIndexCard` to present fragility ring, breakdown and sparkline in a unified card
- export `FragilityIndexCard` and use it on the Fragility page for a cleaner layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689020efc1d88324baf25b35e4e49bfc