### PR TITLE
refactor: modularize routes

### DIFF
--- a/src/components/global-navigation.tsx
+++ b/src/components/global-navigation.tsx
@@ -20,7 +20,7 @@ import {
   settingsRoutes,
   dashboardRoutes,
   type DashboardRoute,
-} from "@/routes";
+} from "@/routes/index";
 import useFavorites from "@/hooks/useFavorites";
 import useRecentViews from "@/hooks/useRecentViews";
 import { cn } from "@/lib/utils";

--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -21,7 +21,7 @@ import {
   TooltipTrigger,
 } from "@/ui/tooltip";
 import { Badge } from "@/ui/badge";
-import type { DashboardRoute, DashboardRouteGroup } from "@/routes";
+import type { DashboardRoute, DashboardRouteGroup } from "@/routes/index";
 import usePersistedGroups from "@/hooks/usePersistedGroups";
 
 interface NavSectionProps {

--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Dialog, DialogContent } from "@/ui/dialog";
-import { dashboardRoutes } from "@/routes";
+import { dashboardRoutes } from "@/routes/index";
 
 interface CommandPaletteProps {
   open?: boolean;

--- a/src/features/analytics/routes.ts
+++ b/src/features/analytics/routes.ts
@@ -1,0 +1,54 @@
+import { ChartLine } from "lucide-react";
+import { withIcon, type DashboardRouteGroup } from "@/routes/types";
+
+export const analyticsRoutes = withIcon(ChartLine, [
+  {
+    to: "/dashboard/mileage-globe",
+    label: "Global Mileage Map",
+    description: "Visualize mileage across the world using a globe",
+    tags: ["map"],
+  },
+  {
+    to: "/dashboard/fragility",
+    label: "Fragility Analysis",
+    description: "Review training fragility indicators",
+    preview: 'fragility',
+  },
+  {
+    to: "/dashboard/session-similarity",
+    label: "Session Similarity Analysis",
+    description: "Find training sessions that resemble each other",
+  },
+  {
+    to: "/dashboard/good-day",
+    label: "Good Day Analysis",
+    description: "Identify patterns that contribute to positive days",
+  },
+  {
+    to: "/dashboard/habit-consistency",
+    label: "Habit Consistency Trend",
+    description: "Track how consistently habits are maintained over time",
+  },
+  {
+    to: "/dashboard/statistics",
+    label: "Metric Correlation Matrix",
+    description: "Explore correlations between daily metrics",
+  },
+  {
+    to: "/dashboard/focus-history",
+    label: "Focus History",
+    description: "Review past focus detections and interventions",
+  },
+  {
+    to: "/dashboard/behavioral-charter-map",
+    label: "Behavioral Charter Map",
+    description: "Timeline of activity segments with risk scores",
+  },
+]);
+
+export const analyticsRouteGroup: DashboardRouteGroup = {
+  label: "Analytics",
+  icon: ChartLine,
+  items: analyticsRoutes,
+};
+

--- a/src/features/playground/routes.ts
+++ b/src/features/playground/routes.ts
@@ -1,0 +1,30 @@
+import { FlaskConical } from "lucide-react";
+import { withIcon, type DashboardRouteGroup } from "@/routes/types";
+
+export const playgroundRoutes = withIcon(FlaskConical, [
+  {
+    to: "/dashboard/map",
+    label: "State Visits Map",
+    description: "View visited states on an interactive map",
+    tags: ["map"],
+  },
+  {
+    to: "/dashboard/route-similarity",
+    label: "Route Similarity Analysis",
+    description: "Compare routes based on similarity metrics",
+    tags: ["map"],
+  },
+  {
+    to: "/dashboard/route-novelty",
+    label: "Route Novelty Analysis",
+    description: "Assess how unique a route is compared to known paths",
+    tags: ["map"],
+  },
+]);
+
+export const playgroundRouteGroup: DashboardRouteGroup = {
+  label: "Playground",
+  icon: FlaskConical,
+  items: playgroundRoutes,
+};
+

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,137 +1,60 @@
-import type { LucideIcon } from "lucide-react";
 import {
   ChartArea,
   ChartBar,
-  ChartPie,
   Radar,
+  ChartPie,
   ChartLine,
-  FlaskConical,
   Shield,
   Settings,
 } from "lucide-react";
+import {
+  withIcon,
+  type DashboardRoute,
+  type DashboardRouteGroup,
+} from "./types";
+import {
+  analyticsRoutes,
+  analyticsRouteGroup,
+} from "@/features/analytics/routes";
+import {
+  playgroundRoutes,
+  playgroundRouteGroup,
+} from "@/features/playground/routes";
 
-export interface DashboardRoute {
-  to: string;
-  label: string;
-  icon: LucideIcon;
-  description: string;
-  tooltip?: string;
-  tags?: string[];
-  badge?: string;
-  preview?: 'fragility';
-}
+export const settingsRoutes = withIcon(Settings, [
+  {
+    to: "/dashboard/settings",
+    label: "Intervention Settings",
+    description: "Configure reminder preferences",
+  },
+]);
 
-export interface DashboardRouteGroup {
-  label: string;
-  icon: LucideIcon;
-  items: DashboardRoute[];
-}
+const settingsRouteGroup: DashboardRouteGroup = {
+  label: "Settings",
+  icon: Settings,
+  items: settingsRoutes,
+};
 
-function withIcon(
-  icon: LucideIcon,
-  routes: Omit<DashboardRoute, "icon">[],
-): DashboardRoute[] {
-  return routes.map((route) => ({ ...route, icon }));
-}
+export const privacyRoutes = withIcon(Shield, [
+  {
+    to: "/dashboard/privacy",
+    label: "Privacy Dashboard",
+    description: "Manage data retention and export/delete options",
+  },
+]);
 
+const privacyRouteGroup: DashboardRouteGroup = {
+  label: "Privacy",
+  icon: Shield,
+  items: privacyRoutes,
+};
 
 export const dashboardRoutes: DashboardRouteGroup[] = [
-  {
-    label: "Playground",
-    icon: FlaskConical,
-    items: withIcon(FlaskConical, [
-      {
-        to: "/dashboard/map",
-        label: "State Visits Map",
-        description: "View visited states on an interactive map",
-        tags: ["map"],
-      },
-      {
-        to: "/dashboard/route-similarity",
-        label: "Route Similarity Analysis",
-        description: "Compare routes based on similarity metrics",
-        tags: ["map"],
-      },
-      {
-        to: "/dashboard/route-novelty",
-        label: "Route Novelty Analysis",
-        description: "Assess how unique a route is compared to known paths",
-        tags: ["map"],
-      },
-    ]),
-  },
-  {
-    label: "Analytics",
-    icon: ChartLine,
-    items: withIcon(ChartLine, [
-      {
-        to: "/dashboard/mileage-globe",
-        label: "Global Mileage Map",
-        description: "Visualize mileage across the world using a globe",
-        tags: ["map"],
-      },
-      {
-        to: "/dashboard/fragility",
-        label: "Fragility Analysis",
-        description: "Review training fragility indicators",
-        preview: 'fragility',
-      },
-      {
-        to: "/dashboard/session-similarity",
-        label: "Session Similarity Analysis",
-        description: "Find training sessions that resemble each other",
-      },
-      {
-        to: "/dashboard/good-day",
-        label: "Good Day Analysis",
-        description: "Identify patterns that contribute to positive days",
-      },
-      {
-        to: "/dashboard/habit-consistency",
-        label: "Habit Consistency Trend",
-        description: "Track how consistently habits are maintained over time",
-      },
-      {
-        to: "/dashboard/statistics",
-        label: "Metric Correlation Matrix",
-        description: "Explore correlations between daily metrics",
-      },
-      {
-        to: "/dashboard/focus-history",
-        label: "Focus History",
-        description: "Review past focus detections and interventions",
-      },
-      {
-        to: "/dashboard/behavioral-charter-map",
-        label: "Behavioral Charter Map",
-        description: "Timeline of activity segments with risk scores",
-      },
-    ]),
-  },
-  {
-    label: "Settings",
-    icon: Settings,
-    items: withIcon(Settings, [
-      {
-        to: "/dashboard/settings",
-        label: "Intervention Settings",
-        description: "Configure reminder preferences",
-      },
-    ]),
-  },
-  {
-    label: "Privacy",
-    icon: Shield,
-    items: withIcon(Shield, [
-      {
-        to: "/dashboard/privacy",
-        label: "Privacy Dashboard",
-        description: "Manage data retention and export/delete options",
-      },
-    ]),
-  },
+  playgroundRouteGroup,
+  analyticsRouteGroup,
+  settingsRouteGroup,
+  privacyRouteGroup,
 ];
-
 
 export const chartRouteGroups: DashboardRouteGroup[] = [
   {
@@ -288,12 +211,9 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
 
 const allDashboardRoutes = dashboardRoutes.flatMap((group) => group.items);
 
-export const analyticsRoutes =
-  dashboardRoutes.find((g) => g.label === "Analytics")?.items ?? [];
-
-export const settingsRoutes =
-  dashboardRoutes.find((g) => g.label === "Settings")?.items ?? [];
-
 export const mapRoutes = allDashboardRoutes.filter((route) =>
-  route.tags?.includes("map")
+  route.tags?.includes("map"),
 );
+
+export { analyticsRoutes, playgroundRoutes };
+export type { DashboardRoute, DashboardRouteGroup } from "./types";

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -1,0 +1,26 @@
+import type { LucideIcon } from "lucide-react";
+
+export interface DashboardRoute {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  description: string;
+  tooltip?: string;
+  tags?: string[];
+  badge?: string;
+  preview?: 'fragility';
+}
+
+export interface DashboardRouteGroup {
+  label: string;
+  icon: LucideIcon;
+  items: DashboardRoute[];
+}
+
+export function withIcon(
+  icon: LucideIcon,
+  routes: Omit<DashboardRoute, "icon">[],
+): DashboardRoute[] {
+  return routes.map((route) => ({ ...route, icon }));
+}
+


### PR DESCRIPTION
## Summary
- modularize route definitions into feature-specific files
- aggregate routes in new routes index for central imports
- adjust navigation components to consume new index

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68909f42b4688324b2d12f4502c13c37