### PR TITLE
feat: allow tagging and false positive flag on sessions

### DIFF
--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -58,6 +58,7 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23], onSel
   if (!goodSessions.length) {
     const sampleSessions: SessionPoint[] = [
       {
+        id: 1,
         x: 1,
         y: 2,
         cluster: 0,
@@ -74,8 +75,12 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23], onSel
         lat: 0,
         lon: 0,
         condition: "Sunny",
+        start: new Date().toISOString(),
+        tags: [],
+        isFalsePositive: false,
       },
       {
+        id: 2,
         x: 2,
         y: 1.5,
         cluster: 1,
@@ -92,6 +97,9 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23], onSel
         lat: 0,
         lon: 0,
         condition: "Cloudy",
+        start: new Date().toISOString(),
+        tags: [],
+        isFalsePositive: false,
       },
     ]
     return (

--- a/src/lib/sessionMeta.ts
+++ b/src/lib/sessionMeta.ts
@@ -1,0 +1,40 @@
+/** Utilities for persisting per-session metadata like tags and false positive flag. */
+export interface SessionMeta {
+  tags: string[]
+  isFalsePositive: boolean
+}
+
+const STORAGE_KEY = 'session_meta'
+
+function readAll(): Record<number, SessionMeta> {
+  if (typeof localStorage === 'undefined') return {}
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function writeAll(data: Record<number, SessionMeta>) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+}
+
+export function getSessionMeta(id: number): SessionMeta {
+  const all = readAll()
+  return all[id] || { tags: [], isFalsePositive: false }
+}
+
+export function setSessionMeta(id: number, meta: SessionMeta) {
+  const all = readAll()
+  all[id] = meta
+  writeAll(all)
+}
+
+export function updateSessionMeta(id: number, meta: Partial<SessionMeta>): SessionMeta {
+  const current = getSessionMeta(id)
+  const next = { ...current, ...meta }
+  setSessionMeta(id, next)
+  return next
+}
+


### PR DESCRIPTION
## Summary
- extend SessionPoint with tags and false positive flag
- add UI to tag sessions or mark false positives
- persist session metadata in local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68909f97c1dc8324bb226b13fcfc2315