### PR TITLE
feat: add date range brushing for good day stats

### DIFF
--- a/src/components/statistics/GoodDayInsights.tsx
+++ b/src/components/statistics/GoodDayInsights.tsx
@@ -8,9 +8,16 @@ import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSession
 interface GoodDayInsightsProps {
   sessions?: SessionPoint[] | null
   onSelect?: (s: SessionPoint) => void
+  onRangeChange?: (range: [string, string] | null) => void
+  highlightDate?: string | null
 }
 
-export default function GoodDayInsights({ sessions: propSessions, onSelect }: GoodDayInsightsProps) {
+export default function GoodDayInsights({
+  sessions: propSessions,
+  onSelect,
+  onRangeChange,
+  highlightDate,
+}: GoodDayInsightsProps) {
   const hookSessions = useRunningSessions()
   const sessions = propSessions ?? hookSessions
 
@@ -70,7 +77,11 @@ export default function GoodDayInsights({ sessions: propSessions, onSelect }: Go
           </div>
         </div>
         <div className="sm:w-40 w-full">
-          <GoodDaySparkline data={trendData} />
+          <GoodDaySparkline
+            data={trendData}
+            onRangeChange={onRangeChange}
+            highlightDate={highlightDate}
+          />
         </div>
       </div>
       {clusters.length > 0 && (

--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -31,9 +31,15 @@ interface GoodDayMapProps {
   condition?: string | null
   hourRange?: [number, number]
   onSelect?: (s: SessionPoint) => void
+  dateRange?: [string, string] | null
 }
-
-export default function GoodDayMap({ data, condition, hourRange = [0, 23], onSelect }: GoodDayMapProps) {
+export default function GoodDayMap({
+  data,
+  condition,
+  hourRange = [0, 23],
+  onSelect,
+  dateRange,
+}: GoodDayMapProps) {
   const [sampleData, setSampleData] = useState<SessionPoint[] | null>(null)
   const [hoverRange, setHoverRange] = useState<[number, number] | null>(null)
   const [active, setActive] = useState<SessionPoint | null>(null)
@@ -41,18 +47,25 @@ export default function GoodDayMap({ data, condition, hourRange = [0, 23], onSel
 
   useEffect(() => {
     setAnimKey((k) => k + 1)
-  }, [condition, hourRange, sampleData])
+  }, [condition, hourRange, sampleData, dateRange])
 
   if (!data && !sampleData) return <Skeleton className="h-64" />
 
   const sessions = sampleData ?? data ?? []
+
+  const inDateRange = (s: SessionPoint) => {
+    if (!dateRange) return true
+    const d = s.start.slice(0, 10)
+    return d >= dateRange[0] && d <= dateRange[1]
+  }
 
   const goodSessions = sessions.filter(
     (d) =>
       d.good &&
       (!condition || d.condition === condition) &&
       d.startHour >= hourRange[0] &&
-      d.startHour <= hourRange[1],
+      d.startHour <= hourRange[1] &&
+      inDateRange(d),
   )
 
   if (!goodSessions.length) {

--- a/src/components/statistics/GoodDaySparkline.tsx
+++ b/src/components/statistics/GoodDaySparkline.tsx
@@ -8,6 +8,8 @@ import {
   YAxis,
   ChartTooltip,
   ChartTooltipContent,
+  Brush,
+  ReferenceLine,
 } from "@/ui/chart"
 import type { ChartConfig } from "@/ui/chart"
 
@@ -18,9 +20,15 @@ interface TrendPoint {
 
 interface GoodDaySparklineProps {
   data: TrendPoint[]
+  onRangeChange?: (range: [string, string] | null) => void
+  highlightDate?: string | null
 }
 
-export default function GoodDaySparkline({ data }: GoodDaySparklineProps) {
+export default function GoodDaySparkline({
+  data,
+  onRangeChange,
+  highlightDate,
+}: GoodDaySparklineProps) {
   const config = {
     count: { label: "Good sessions", color: "hsl(var(--chart-1))" },
   } satisfies ChartConfig
@@ -30,6 +38,9 @@ export default function GoodDaySparkline({ data }: GoodDaySparklineProps) {
       <LineChart data={data} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
         <XAxis dataKey="date" hide />
         <YAxis allowDecimals={false} hide />
+        {highlightDate && (
+          <ReferenceLine x={highlightDate} strokeWidth={2} stroke="hsl(var(--chart-4))" />
+        )}
         <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
         <Line
           type="monotone"
@@ -37,6 +48,25 @@ export default function GoodDaySparkline({ data }: GoodDaySparklineProps) {
           stroke={config.count.color}
           strokeWidth={2}
           dot={false}
+        />
+        <Brush
+          dataKey="date"
+          height={8}
+          travellerWidth={8}
+          onChange={(range) => {
+            if (
+              typeof range?.startIndex === "number" &&
+              typeof range?.endIndex === "number"
+            ) {
+              const start = data[range.startIndex].date
+              const end = data[range.endIndex].date
+              if (range.startIndex === 0 && range.endIndex === data.length - 1) {
+                onRangeChange?.(null)
+              } else {
+                onRangeChange?.([start, end])
+              }
+            }
+          }}
         />
       </LineChart>
     </ChartContainer>

--- a/src/pages/GoodDay.tsx
+++ b/src/pages/GoodDay.tsx
@@ -1,20 +1,22 @@
-import React, { useMemo, useState } from "react";
-import { GoodDayMap, GoodDayInsights } from "@/components/statistics";
-import SessionDetailDrawer from "@/components/statistics/SessionDetailDrawer";
-import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions";
-import { SimpleSelect } from "@/ui/select";
-import Slider from "@/ui/slider";
+import React, { useMemo, useState } from "react"
+import { GoodDayMap, GoodDayInsights } from "@/components/statistics"
+import SessionDetailDrawer from "@/components/statistics/SessionDetailDrawer"
+import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions"
+import { SimpleSelect } from "@/ui/select"
+import Slider from "@/ui/slider"
 
 export default function GoodDayPage() {
-  const sessions = useRunningSessions();
-  const [condition, setCondition] = useState("all");
-  const [hourRange, setHourRange] = useState<[number, number]>([0, 23]);
-  const [active, setActive] = useState<SessionPoint | null>(null);
+  const sessions = useRunningSessions()
+  const [condition, setCondition] = useState("all")
+  const [hourRange, setHourRange] = useState<[number, number]>([0, 23])
+  const [active, setActive] = useState<SessionPoint | null>(null)
+  const [dateRange, setDateRange] = useState<[string, string] | null>(null)
+  const [highlightDate, setHighlightDate] = useState<string | null>(null)
 
   const conditions = useMemo(
     () => (sessions ? Array.from(new Set(sessions.map((s) => s.condition))) : []),
     [sessions],
-  );
+  )
 
 
   return (
@@ -23,7 +25,12 @@ export default function GoodDayPage() {
       <p className="text-sm text-muted-foreground">
         Sessions that exceeded expectations are highlighted below.
       </p>
-      <GoodDayInsights sessions={sessions} onSelect={setActive} />
+      <GoodDayInsights
+        sessions={sessions}
+        onSelect={setActive}
+        onRangeChange={setDateRange}
+        highlightDate={highlightDate}
+      />
       {sessions && (
         <div className="flex gap-4 flex-wrap items-center">
           <SimpleSelect
@@ -67,9 +74,13 @@ export default function GoodDayPage() {
         data={sessions}
         condition={condition === "all" ? null : condition}
         hourRange={hourRange}
-        onSelect={setActive}
+        onSelect={(s) => {
+          setActive(s)
+          setHighlightDate(s.start.slice(0, 10))
+        }}
+        dateRange={dateRange}
       />
       <SessionDetailDrawer session={active} onClose={() => setActive(null)} />
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- add brushable date range output and map selection highlight to GoodDaySparkline
- wire GoodDayInsights and GoodDayPage to synchronize range filtering and map selection highlighting
- filter GoodDayMap sessions by brushed date range

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6890a3c593f08324b1089e6c459b9489