### PR TITLE
feat: add display mode to correlation matrix

### DIFF
--- a/src/components/visualizations/CorrelationRippleMatrix.tsx
+++ b/src/components/visualizations/CorrelationRippleMatrix.tsx
@@ -30,7 +30,7 @@ interface CorrelationRippleMatrixProps {
   showValues?: boolean; // display correlation values in cells (default: true)
   cellSize?: number; // explicit cell size override
   maxCellSize?: number; // maximum computed cell size
-  upperOnly?: boolean; // only render x >= y cells
+  displayMode?: "upper" | "lower" | "full"; // which part of the matrix to display
   palette?: PaletteOption; // color scheme for visualization
   cellGap?: number; // gap or border width between cells
 }
@@ -164,7 +164,7 @@ export default function CorrelationRippleMatrix({
   showValues = true,
   cellSize: cellSizeProp,
   maxCellSize,
-  upperOnly = false,
+  displayMode = "upper",
   palette = "default",
   cellGap = 1,
 
@@ -210,7 +210,11 @@ export default function CorrelationRippleMatrix({
 
   const heatData: CellData[] = matrix
     .flatMap((row, y) => row.map((value, x) => ({ x, y, value })))
-    .filter(({ x, y }) => !upperOnly || x >= y);
+    .filter(({ x, y }) => {
+      if (displayMode === "upper") return x >= y
+      if (displayMode === "lower") return x <= y
+      return true
+    });
 
   const colorScale = createColorScale(minValue, maxValue, palette);
 

--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -90,5 +90,29 @@ describe('CorrelationRippleMatrix', () => {
     expect(bg).toContain('#440154')
     expect(bg).toContain('#fde725')
   })
+
+  it('respects displayMode for lower triangle', () => {
+    const matrix = [
+      [1, 0.5],
+      [0.5, 1],
+    ]
+    const labels = ['A', 'B']
+    const { container } = render(
+      <CorrelationRippleMatrix
+        matrix={matrix}
+        labels={labels}
+        displayMode="lower"
+        cellSize={50}
+      />,
+    )
+
+    // B vs A cell should not be rendered in lower mode
+    const cells = container.querySelectorAll('path.recharts-rectangle')
+    expect(cells.length).toBe(3)
+    const upperCell = Array.from(cells).find((c) =>
+      c.getAttribute('aria-label')?.includes('B vs A'),
+    )
+    expect(upperCell).toBeUndefined()
+  })
 })
 

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import CorrelationRippleMatrix from "@/components/visualizations/CorrelationRippleMatrix";
 import { Button } from "@/ui/button";
+import { SimpleSelect } from "@/ui/select";
 import {
   getDailySteps,
   getDailySleep,
@@ -54,7 +55,7 @@ const METRIC_GROUPS: MetricGroup[] = [
 
 export default function StatisticsPage() {
   const [points, setPoints] = useState<Metrics[]>([]);
-  const [upperOnly, setUpperOnly] = useState(true);
+  const [displayMode, setDisplayMode] = useState<"upper" | "lower" | "full">("upper");
   const [showValues, setShowValues] = useState(false);
 
   useEffect(() => {
@@ -145,13 +146,18 @@ export default function StatisticsPage() {
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setUpperOnly((p) => !p)}
-          >
-            {upperOnly ? "Show Full Matrix" : "Show Upper Triangle"}
-          </Button>
+          <SimpleSelect
+            value={displayMode}
+            onValueChange={(v) =>
+              setDisplayMode(v as "upper" | "lower" | "full")
+            }
+            options={[
+              { value: "upper", label: "Upper Triangle" },
+              { value: "lower", label: "Lower Triangle" },
+              { value: "full", label: "Full Matrix" },
+            ]}
+            label="Display"
+          />
           <Button
             variant="outline"
             size="sm"
@@ -181,7 +187,7 @@ export default function StatisticsPage() {
           matrix={matrix}
           labels={labels}
           groups={groups}
-          upperOnly={upperOnly}
+          displayMode={displayMode}
           showValues={showValues}
           maxCellSize={80}
         />


### PR DESCRIPTION
## Summary
- extend `CorrelationRippleMatrix` with a `displayMode` prop to choose upper, lower, or full matrix views
- expose selection UI on statistics page and pass chosen mode to the matrix
- test that lower-triangle mode excludes upper cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a5cb123083249be7a083d7b7094a