### PR TITLE
Add rolling good-day frequency trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,13 @@ All charts should be wrapped in Shadcn’s `<ChartContainer>` so they inherit CS
 
 Map components (Leaflet, Deck.GL) live under `src/components/map/...` and can reference shared styling from `ui/...`.
 
-`useRunningSessions()` returns t-SNE coordinates for recent runs and is visualised with the `SessionSimilarityMap` scatter chart. A `good` flag marks sessions where pace beat the expected baseline.
+`useRunningSessions()` returns t-SNE coordinates for recent runs along with a rolling good-day frequency trendline. It feeds the `SessionSimilarityMap` scatter chart. A `good` flag marks sessions where pace beat the expected baseline.
 
 ```ts
-{ x: number; y: number; cluster: number; good: boolean }[]
+{
+  sessions: { x: number; y: number; cluster: number; good: boolean }[]
+  trend: { date: string; avg: number; lower: number; upper: number }[]
+}
 ```
 
 `useTrainingConsistency()` powers the `TrainingEntropyHeatmap` chart showing start-time

--- a/src/components/statistics/GoodDayInsights.tsx
+++ b/src/components/statistics/GoodDayInsights.tsx
@@ -3,10 +3,16 @@
 import { Card } from "@/ui/card"
 import { Skeleton } from "@/ui/skeleton"
 import GoodDaySparkline from "./GoodDaySparkline"
-import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions"
+import GoodDayTrendline from "./GoodDayTrendline"
+import {
+  useRunningSessions,
+  type SessionPoint,
+  type GoodDayTrendPoint,
+} from "@/hooks/useRunningSessions"
 
 interface GoodDayInsightsProps {
   sessions?: SessionPoint[] | null
+  trend?: GoodDayTrendPoint[] | null
   onSelect?: (s: SessionPoint) => void
   onRangeChange?: (range: [string, string] | null) => void
   highlightDate?: string | null
@@ -14,12 +20,14 @@ interface GoodDayInsightsProps {
 
 export default function GoodDayInsights({
   sessions: propSessions,
+  trend: propTrend,
   onSelect,
   onRangeChange,
   highlightDate,
 }: GoodDayInsightsProps) {
-  const hookSessions = useRunningSessions()
-  const sessions = propSessions ?? hookSessions
+  const hookData = useRunningSessions()
+  const sessions = propSessions ?? hookData.sessions
+  const trend = propTrend ?? hookData.trend
 
   if (!sessions) return <Skeleton className="h-32" />
   if (!sessions.length) return null
@@ -76,12 +84,13 @@ export default function GoodDayInsights({
             {trendChange.toFixed(2)} vs prev 7 runs)
           </div>
         </div>
-        <div className="sm:w-40 w-full">
+        <div className="sm:w-40 w-full space-y-2">
           <GoodDaySparkline
             data={trendData}
             onRangeChange={onRangeChange}
             highlightDate={highlightDate}
           />
+          {trend && <GoodDayTrendline data={trend.slice(-30)} />}
         </div>
       </div>
       {clusters.length > 0 && (

--- a/src/components/statistics/GoodDayTrendline.tsx
+++ b/src/components/statistics/GoodDayTrendline.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/ui/chart"
+import type { ChartConfig } from "@/ui/chart"
+import { GoodDayTrendPoint } from "@/hooks/useRunningSessions"
+
+interface GoodDayTrendlineProps {
+  data: GoodDayTrendPoint[]
+}
+
+export default function GoodDayTrendline({ data }: GoodDayTrendlineProps) {
+  const config = {
+    avg: { label: "Good-day rate", color: "hsl(var(--chart-2))" },
+  } satisfies ChartConfig
+
+  return (
+    <ChartContainer config={config} className="h-16 w-full">
+      <LineChart data={data} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+        <XAxis dataKey="date" hide />
+        <YAxis domain={[0, 1]} hide />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <Line
+          type="monotone"
+          dataKey="avg"
+          stroke={config.avg.color}
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="lower"
+          stroke={config.avg.color}
+          strokeDasharray="4 4"
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="upper"
+          stroke={config.avg.color}
+          strokeDasharray="4 4"
+          dot={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -3,6 +3,7 @@ export { default as AvgDailyMileageRadar } from "./AvgDailyMileageRadar";
 export { default as GoodDayMap } from "./GoodDayMap";
 export { default as GoodDaySparkline } from "./GoodDaySparkline";
 export { default as GoodDayInsights } from "./GoodDayInsights";
+export { default as GoodDayTrendline } from "./GoodDayTrendline";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";

--- a/src/pages/GoodDay.tsx
+++ b/src/pages/GoodDay.tsx
@@ -30,7 +30,7 @@ const FILTERS_KEY = "goodDayFilters"
 const PRESETS_KEY = "goodDayPresets"
 
 export default function GoodDayPage() {
-  const sessions = useRunningSessions()
+  const { sessions, trend } = useRunningSessions()
   const [condition, setCondition] = useState("all")
   const [hourRange, setHourRange] = useState<[number, number]>([0, 23])
   const [route, setRoute] = useState("all")
@@ -192,6 +192,7 @@ export default function GoodDayPage() {
       </div>
       <GoodDayInsights
         sessions={filteredSessions}
+        trend={trend}
         onSelect={setActive}
         onRangeChange={setDateRange}
         highlightDate={highlightDate}

--- a/src/pages/SessionSimilarity.tsx
+++ b/src/pages/SessionSimilarity.tsx
@@ -3,7 +3,7 @@ import { SessionSimilarityMap } from "@/components/statistics";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
 
 export default function SessionSimilarityPage() {
-  const sessions = useRunningSessions();
+  const { sessions } = useRunningSessions();
 
   return (
     <div className="p-4 space-y-4">


### PR DESCRIPTION
## Summary
- compute 7‑day rolling good-day rate and 95% confidence band in `useRunningSessions`
- render mini trendline with confidence bounds under the good-day sparkline
- expose trend data across pages and docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a8a689c88324ae0f0c19475a16f4