### PR TITLE
docs: document architecture and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dashboard
 
+See [Architecture](docs/architecture.md) for an overview of frameworks, routes, and design conventions.
+
 ## Project structure & imports
 Use the `src/components/ui` folder for all shared, “primitive” UI bits—buttons, cards, tabs, tooltips, charts, etc. This is where the Shadcn-CLI lives, and any one-off or feature-specific code goes elsewhere (e.g. `src/components/dashboard/StepsChart.tsx`).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture
+
+## Framework and Build Tools
+- **React 18 + TypeScript** for the application framework.
+- **Vite** handles development server and production builds.
+- **Tailwind CSS** supplies utility-first styling driven by design tokens in `src/styles/globals.css`.
+- **Vitest** with Testing Library provides unit testing support.
+
+## Folder Structure and Naming Conventions
+```
+/                    # repository root
+├─ docs/             # project documentation
+├─ public/           # static assets served as-is
+├─ src/              # application source
+│  ├─ components/    # UI pieces (primitives in `ui/`, feature-specific elsewhere)
+│  ├─ features/      # grouped feature modules
+│  ├─ hooks/         # reusable data and state hooks
+│  ├─ lib/           # utilities and helpers
+│  ├─ pages/         # route targets
+│  ├─ routes/        # route definitions and groups
+│  ├─ styles/        # global styles and tokens
+│  └─ types/         # shared TypeScript types
+```
+- React components and pages use **PascalCase** file names (e.g. `Dashboard.tsx`).
+- Hooks begin with `use` (e.g. `useGarminData.ts`).
+- Tests live beside code in `__tests__` directories.
+
+## Navigation and Routes
+- Navigation is powered by **react-router-dom**.
+- Route configuration lives in `src/routes`, where `DashboardRouteGroup` objects organize related paths and icons.
+- Actual page components reside in `src/pages` and are referenced by the route definitions.
+
+## Design System and Alias Guidelines
+- Shared UI primitives live under `src/components/ui` and follow the Shadcn style.
+- Styling relies on Tailwind CSS with tokens extended in `tailwind.config.ts` and consumed via CSS variables.
+- Import paths use the `@` alias mapped to `src` (configured in `vite.config.ts` and `tsconfig.json`).
+- Reuse existing primitives and the `cn()` helper for class merging when building new components.
+
+Keep this document updated as architecture and conventions evolve.


### PR DESCRIPTION
## Summary
- add an Architecture guide covering framework, folder structure, navigation, and design system
- reference the guide in the README

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6890ab862fbc8324839fda47aa918515