### PR TITLE
feat: track good day streaks and badges

### DIFF
--- a/src/components/statistics/GoodDayBadges.tsx
+++ b/src/components/statistics/GoodDayBadges.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react"
+import { Badge } from "@/ui/badge"
+import type { SessionPoint } from "@/hooks/useRunningSessions"
+import {
+  updateGoodDayStats,
+  type GoodDayStats,
+} from "@/lib/goodDayStats"
+
+interface GoodDayBadgesProps {
+  sessions: SessionPoint[] | null
+}
+
+export default function GoodDayBadges({ sessions }: GoodDayBadgesProps) {
+  const [stats, setStats] = useState<GoodDayStats | null>(null)
+
+  useEffect(() => {
+    if (!sessions) return
+    const updated = updateGoodDayStats(sessions)
+    setStats(updated)
+  }, [sessions])
+
+  if (!stats) return null
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+      <Badge className="flex items-center gap-1">
+        {stats.currentStreak}d streak
+      </Badge>
+      {stats.bestStreak > 0 && (
+        <Badge className="flex items-center gap-1" variant="secondary">
+          Best {stats.bestStreak}d
+        </Badge>
+      )}
+      {stats.personalBest > 0 && (
+        <Badge className="flex items-center gap-1" variant="outline">
+          PB Δ{stats.personalBest.toFixed(2)}
+        </Badge>
+      )}
+    </div>
+  )
+}

--- a/src/components/statistics/index.ts
+++ b/src/components/statistics/index.ts
@@ -4,6 +4,7 @@ export { default as GoodDayMap } from "./GoodDayMap";
 export { default as GoodDaySparkline } from "./GoodDaySparkline";
 export { default as GoodDayInsights } from "./GoodDayInsights";
 export { default as GoodDayTrendline } from "./GoodDayTrendline";
+export { default as GoodDayBadges } from "./GoodDayBadges";
 export { default as HabitConsistencyHeatmap } from "./HabitConsistencyHeatmap";
 export { default as PeerBenchmarkBands } from "./PeerBenchmarkBands";
 export { default as PerfVsEnvironmentMatrix } from "./PerfVsEnvironmentMatrix";

--- a/src/lib/__tests__/goodDayStats.test.ts
+++ b/src/lib/__tests__/goodDayStats.test.ts
@@ -1,0 +1,17 @@
+import { updateGoodDayStats, resetGoodDayStats } from "@/lib/goodDayStats"
+
+describe("goodDayStats", () => {
+  beforeEach(() => resetGoodDayStats())
+
+  it("tracks streaks and personal best", () => {
+    const sessions = [
+      { start: "2024-01-01T10:00:00Z", good: true, paceDelta: 0.5 },
+      { start: "2024-01-02T10:00:00Z", good: true, paceDelta: 0.8 },
+      { start: "2024-01-04T10:00:00Z", good: true, paceDelta: 0.4 },
+    ] as any
+    const stats = updateGoodDayStats(sessions)
+    expect(stats.currentStreak).toBe(1)
+    expect(stats.bestStreak).toBe(2)
+    expect(stats.personalBest).toBeCloseTo(0.8)
+  })
+})

--- a/src/lib/goodDayStats.ts
+++ b/src/lib/goodDayStats.ts
@@ -1,0 +1,81 @@
+import type { SessionPoint } from "@/hooks/useRunningSessions"
+
+export interface GoodDayStats {
+  lastDate: string | null
+  currentStreak: number
+  bestStreak: number
+  personalBest: number
+}
+
+const KEY = "goodDayStats"
+
+function getStorage(): Storage {
+  if (typeof localStorage !== "undefined") return localStorage
+  // simple in-memory fallback for non-browser environments
+  const store: Record<string, string> = {}
+  return {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = v
+    },
+    removeItem: (k: string) => {
+      delete store[k]
+    },
+    clear: () => {
+      for (const k in store) delete store[k]
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    length: 0,
+  } as Storage
+}
+
+function load(): GoodDayStats {
+  try {
+    const raw = getStorage().getItem(KEY)
+    if (raw) return JSON.parse(raw) as GoodDayStats
+  } catch {}
+  return { lastDate: null, currentStreak: 0, bestStreak: 0, personalBest: 0 }
+}
+
+function save(stats: GoodDayStats): void {
+  try {
+    getStorage().setItem(KEY, JSON.stringify(stats))
+  } catch {}
+}
+
+export function resetGoodDayStats(): void {
+  save({ lastDate: null, currentStreak: 0, bestStreak: 0, personalBest: 0 })
+}
+
+export function getGoodDayStats(): GoodDayStats {
+  return load()
+}
+
+export function updateGoodDayStats(
+  sessions: Array<Pick<SessionPoint, "start" | "good" | "paceDelta">>,
+): GoodDayStats {
+  let stats = load()
+  const sorted = sessions
+    .filter((s) => s.good)
+    .sort((a, b) => a.start.localeCompare(b.start))
+  for (const s of sorted) {
+    const day = s.start.slice(0, 10)
+    if (stats.lastDate && day <= stats.lastDate) {
+      if (s.paceDelta > stats.personalBest) stats.personalBest = s.paceDelta
+      continue
+    }
+    if (stats.lastDate) {
+      const prev = new Date(stats.lastDate)
+      prev.setDate(prev.getDate() + 1)
+      const expected = prev.toISOString().slice(0, 10)
+      stats.currentStreak = day === expected ? stats.currentStreak + 1 : 1
+    } else {
+      stats.currentStreak = 1
+    }
+    stats.lastDate = day
+    if (stats.currentStreak > stats.bestStreak) stats.bestStreak = stats.currentStreak
+    if (s.paceDelta > stats.personalBest) stats.personalBest = s.paceDelta
+  }
+  save(stats)
+  return stats
+}

--- a/src/pages/GoodDay.tsx
+++ b/src/pages/GoodDay.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react"
-import { GoodDayMap, GoodDayInsights } from "@/components/statistics"
+import { GoodDayMap, GoodDayInsights, GoodDayBadges } from "@/components/statistics"
 import SessionDetailDrawer from "@/components/statistics/SessionDetailDrawer"
 import { useRunningSessions, type SessionPoint } from "@/hooks/useRunningSessions"
 import { SimpleSelect } from "@/ui/select"
@@ -174,6 +174,7 @@ export default function GoodDayPage() {
       <p className="text-sm text-muted-foreground">
         Sessions that exceeded expectations are highlighted below.
       </p>
+      {sessions && <GoodDayBadges sessions={sessions} />}
       <div className="flex gap-2 flex-wrap">
         {allPresets.map((p) => (
           <Button


### PR DESCRIPTION
## Summary
- track and persist good-day streaks and personal best pace delta
- show streak and personal best badges on Good Day page
- add tests for good day stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890ae0208a08324aa2f0fc51ef19608