### PR TITLE
feat: add session share button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "date-fns": "^4.1.0",
         "events": "^3.3.0",
         "framer-motion": "^12.23.12",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^0.534.0",
         "maplibre-gl": "^3.6.0",
         "react": "^18.2.0",
@@ -6428,6 +6429,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "date-fns": "^4.1.0",
     "events": "^3.3.0",
     "framer-motion": "^12.23.12",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.534.0",
     "maplibre-gl": "^3.6.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add share capability to session detail drawer
- export session delta, weather, route data to image and JSON
- include html-to-image dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890b4ba13a883249bcd69948aa07a3c