### PR TITLE
Compute session robustness confidence

### DIFF
--- a/src/components/statistics/SessionDetailDrawer.tsx
+++ b/src/components/statistics/SessionDetailDrawer.tsx
@@ -201,6 +201,12 @@ export default function SessionDetailDrawer({ session, onClose }: SessionDetailD
       diff: 1,
     },
     {
+      label: "Confidence",
+      accessor: (s) => s.confidence,
+      format: (n) => `${(n * 100).toFixed(0)}%`,
+      diff: 0.05,
+    },
+    {
       label: "Start Hour",
       accessor: (s) => s.startHour,
       format: (n) => n.toString(),


### PR DESCRIPTION
## Summary
- derive session confidence as average of data completeness and weather info quality
- show confidence percentage in SessionDetailDrawer
- use confidence for GoodDayMap star halos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890b75b4d2883249c7d3a146eaf227c