### PR TITLE
fix: keep navigation menu open on hover

### DIFF
--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -17,7 +17,7 @@ const NavigationMenu = React.forwardRef<
   <NavigationMenuPrimitive.Root
     ref={ref}
     className={cn(
-      "relative z-10 flex max-w-max items-center justify-center",
+      "relative z-10 flex max-w-max flex-1 items-center justify-center",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- prevent NavigationMenu dropdown from collapsing by letting root expand to full width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890befae4948324954dd10ce217c924