### PR TITLE
feat: add correlation details panel

### DIFF
--- a/src/components/visualizations/CorrelationDetails.tsx
+++ b/src/components/visualizations/CorrelationDetails.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/ui/sheet";
+import { Button } from "@/ui/button";
+import { ChartContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, BarChart, Bar, ResponsiveContainer } from "@/ui/chart";
+import { Pin, PinOff } from "lucide-react";
+
+interface TimeseriesPoint {
+  time: number;
+  value: number;
+}
+
+export interface CorrelationDrilldown {
+  seriesX: TimeseriesPoint[];
+  seriesY: TimeseriesPoint[];
+  rolling: TimeseriesPoint[];
+  breakdown: { weekday: number; weekend: number };
+}
+
+interface CorrelationDetailsProps {
+  open: boolean;
+  xLabel: string;
+  yLabel: string;
+  data?: CorrelationDrilldown;
+  pinned: boolean;
+  onPinnedChange: (pinned: boolean) => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function CorrelationDetails({
+  open,
+  xLabel,
+  yLabel,
+  data,
+  pinned,
+  onPinnedChange,
+  onOpenChange,
+}: CorrelationDetailsProps) {
+  const timeSeries = (data
+    ? data.seriesX.map((p, i) => ({
+        time: p.time,
+        x: p.value,
+        y: data.seriesY[i]?.value ?? null,
+      }))
+    : []) as { time: number; x: number; y: number | null }[];
+  const breakdownData = data
+    ? [
+        { label: "Weekday", value: data.breakdown.weekday },
+        { label: "Weekend", value: data.breakdown.weekend },
+      ]
+    : [];
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => (!pinned ? onOpenChange(o) : null)}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-md overflow-y-auto"
+        data-testid="correlation-details"
+      >
+        <SheetHeader>
+          <SheetTitle>
+            {xLabel} vs {yLabel}
+          </SheetTitle>
+        </SheetHeader>
+        <div className="mt-2 flex justify-end">
+          <Button
+            size="sm"
+            variant={pinned ? "default" : "outline"}
+            onClick={() => onPinnedChange(!pinned)}
+            aria-label={pinned ? "Unpin details" : "Pin details"}
+          >
+            {pinned ? <PinOff className="mr-2 h-4 w-4" /> : <Pin className="mr-2 h-4 w-4" />}
+            {pinned ? "Unpin" : "Pin"}
+          </Button>
+        </div>
+        {data ? (
+          <div className="mt-4 space-y-6">
+            <ChartContainer
+              config={{ x: { label: xLabel }, y: { label: yLabel } }}
+              className="h-40"
+            >
+              <LineChart data={timeSeries} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="time" type="number" hide />
+                <YAxis />
+                <Tooltip />
+                <Line type="monotone" dataKey="x" stroke="hsl(var(--chart-1))" dot={false} />
+                <Line type="monotone" dataKey="y" stroke="hsl(var(--chart-2))" dot={false} />
+              </LineChart>
+            </ChartContainer>
+            <ChartContainer
+              config={{ r: { label: "Rolling r" } }}
+              className="h-40"
+            >
+              <LineChart data={data.rolling} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="time" type="number" hide />
+                <YAxis domain={[-1, 1]} />
+                <Tooltip />
+                <Line type="monotone" dataKey="value" stroke="hsl(var(--chart-1))" dot={false} />
+              </LineChart>
+            </ChartContainer>
+            <ChartContainer
+              config={{ value: { label: "Correlation" } }}
+              className="h-40"
+              disableResponsive
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={breakdownData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="label" />
+                  <YAxis domain={[ -1, 1 ]} />
+                  <Tooltip />
+                  <Bar dataKey="value" fill="hsl(var(--chart-1))" />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartContainer>
+          </div>
+        ) : (
+          <div className="mt-4 text-sm text-muted-foreground">No data</div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+

--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -18,7 +18,7 @@ vi.mock('recharts', async () => {
 })
 
 describe('CorrelationRippleMatrix', () => {
-  it('shows detail chart on cell click', async () => {
+  it('shows detail panel on cell click', async () => {
     const cell = (v: number) => ({ value: v, n: 10, p: 0.01 })
     const matrix = [
       [cell(1), cell(0.5)],
@@ -26,10 +26,21 @@ describe('CorrelationRippleMatrix', () => {
     ]
     const labels = ['A', 'B']
     const drilldown = {
-      '0-1': [
-        { x: 0, y: 1 },
-        { x: 1, y: 2 },
-      ],
+      '0-1': {
+        seriesX: [
+          { time: 0, value: 1 },
+          { time: 1, value: 2 },
+        ],
+        seriesY: [
+          { time: 0, value: 2 },
+          { time: 1, value: 3 },
+        ],
+        rolling: [
+          { time: 0, value: 0.5 },
+          { time: 1, value: 0.6 },
+        ],
+        breakdown: { weekday: 0.5, weekend: 0.3 },
+      },
     }
     const { container } = render(
       <CorrelationRippleMatrix
@@ -40,13 +51,17 @@ describe('CorrelationRippleMatrix', () => {
       />,
     )
 
-    expect(container.querySelector('[data-testid="detail-chart"]')).not.toBeInTheDocument()
+    expect(
+      document.querySelector('[data-testid="correlation-details"]'),
+    ).not.toBeInTheDocument()
 
     const cells = container.querySelectorAll('path.recharts-rectangle')
     expect(cells.length).toBeGreaterThan(1)
     await userEvent.click(cells[1] as SVGPathElement, { skipHover: true })
     await waitFor(() =>
-      expect(container.querySelector('[data-testid="detail-chart"]')).toBeInTheDocument(),
+      expect(
+        document.querySelector('[data-testid="correlation-details"]'),
+      ).toBeInTheDocument(),
     )
   })
 

--- a/src/components/visualizations/index.ts
+++ b/src/components/visualizations/index.ts
@@ -2,4 +2,5 @@ export { default as BehavioralCharterMap } from "./BehavioralCharterMap";
 export type { Segment } from "./BehavioralCharterMap";
 export { default as TransitionMatrix } from "./TransitionMatrix";
 export { default as CorrelationRippleMatrix } from "./CorrelationRippleMatrix";
+export { default as CorrelationDetails } from "./CorrelationDetails";
 export { default as FocusTimeline } from "./FocusTimeline";


### PR DESCRIPTION
## Summary
- replace ripple popover with a CorrelationDetails side panel
- show time series, rolling correlation and weekday/weekend breakdown for metric pairs
- allow pinning the panel open while exploring other cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c0f77ef083249e5d83d3a75ec4fb