### PR TITLE
Rename chart navigation labels

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -63,32 +63,32 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
     items: withIcon(ChartArea, [
       {
         to: "/dashboard/charts/area-chart-interactive",
-        label: "Interactive Trend",
+        label: "Customizable Time-Series Trend",
         description: "Play with dynamic area chart interactions",
       },
       {
         to: "/dashboard/charts/steps-trend-with-goal",
-        label: "Step Goal Trend",
+        label: "Daily Step-Goal Achievement Trend",
         description: "Track steps against a target over time",
       },
       {
         to: "/dashboard/charts/area-chart-load-ratio",
-        label: "Load Ratio Trend",
+        label: "Training Load Ratio Over Time",
         description: "Monitor training load ratio changes",
       },
       {
         to: "/dashboard/charts/peer-benchmark-bands",
-        label: "Peer Benchmark Trend",
+        label: "Performance Compared with Peers",
         description: "Compare performance against peers",
       },
       {
         to: "/dashboard/charts/reading-probability-timeline",
-        label: "Reading Probability Trend",
+        label: "Reading Habit Likelihood Trend",
         description: "View reading likelihood over time",
       },
       {
         to: "/dashboard/charts/time-in-bed-chart",
-        label: "Time in Bed Trend",
+        label: "Sleep Duration Trend",
         description: "Examine time spent in bed",
       },
     ]),
@@ -99,42 +99,42 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
     items: withIcon(ChartBar, [
       {
         to: "/dashboard/charts/bar-chart-interactive",
-        label: "Interactive Comparison",
+        label: "Customizable Metric Comparison",
         description: "Experiment with interactive bar comparisons",
       },
       {
         to: "/dashboard/charts/bar-chart-default",
-        label: "Default Bar Comparison",
+        label: "Standard Metric Comparison",
         description: "Basic bar chart for category comparison",
       },
       {
         to: "/dashboard/charts/bar-chart-horizontal",
-        label: "Horizontal Bar Comparison",
+        label: "Horizontal Metric Comparison",
         description: "Compare categories using horizontal bars",
       },
       {
         to: "/dashboard/charts/bar-chart-mixed",
-        label: "Mixed Bar Comparison",
+        label: "Mixed Category Comparison",
         description: "View bars with mixed data series",
       },
       {
         to: "/dashboard/charts/bar-chart-label-custom",
-        label: "Custom Label Comparison",
+        label: "Comparison with Custom Category Labels",
         description: "Bar chart demonstrating custom labels",
       },
       {
         to: "/dashboard/charts/shoe-usage-chart",
-        label: "Shoe Usage Comparison",
+        label: "Running Shoe Mileage Comparison",
         description: "Compare mileage by shoe",
       },
       {
         to: "/dashboard/charts/treadmill-vs-outdoor",
-        label: "Treadmill vs Outdoor Comparison",
+        label: "Treadmill vs. Outdoor Running Comparison",
         description: "Compare treadmill and outdoor training",
       },
       {
         to: "/dashboard/charts/weekly-volume-history-chart",
-        label: "Weekly Volume Trend",
+        label: "Weekly Training Volume Trend",
         description: "Historical view of weekly training volume",
       },
     ]),
@@ -145,27 +145,27 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
     items: withIcon(Radar, [
       {
         to: "/dashboard/charts/radar-chart-default",
-        label: "Default Radar Profile",
+        label: "Standard Multi-Metric Radar Profile",
         description: "Basic radar chart profile",
       },
       {
         to: "/dashboard/charts/radar-chart-workout-by-time",
-        label: "Workout Time Radar",
+        label: "Workout Time Distribution Radar",
         description: "Radar view of workout distribution by time",
       },
       {
         to: "/dashboard/charts/monthly-mileage-pattern",
-        label: "Monthly Mileage Pattern",
+        label: "Monthly Mileage Distribution Radar",
         description: "Radar chart with highlighted data points",
       },
       {
         to: "/dashboard/charts/avg-daily-mileage-radar",
-        label: "Average Daily Mileage Radar",
+        label: "Average Daily Mileage Profile",
         description: "Compare average daily mileage",
       },
       {
         to: "/dashboard/charts/activity-by-time",
-        label: "Activity Time Radar",
+        label: "Activity Time Allocation Radar",
         description: "Visualize activity levels across time",
       },
     ]),
@@ -176,22 +176,22 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
     items: withIcon(ChartPie, [
       {
         to: "/dashboard/charts/radial-chart-label",
-        label: "Labeled Radial Progress",
+        label: "Radial Progress Indicator with Segment Labels",
         description: "Radial progress chart with labels",
       },
       {
         to: "/dashboard/charts/radial-chart-text",
-        label: "Text Radial Progress",
+        label: "Radial Progress Indicator with Center Text",
         description: "Radial progress chart with text",
       },
       {
         to: "/dashboard/charts/radial-chart-grid",
-        label: "Grid Radial Progress",
+        label: "Grid-Based Radial Progress Indicator",
         description: "Radial progress chart with grid",
       },
       {
         to: "/dashboard/charts/reading-stack-split",
-        label: "Reading Stack Split",
+        label: "Stacked Radial Chart of Reading Time Split",
         description: "Segment reading activity across categories",
       },
     ]),
@@ -202,7 +202,7 @@ export const chartRouteGroups: DashboardRouteGroup[] = [
     items: withIcon(ChartLine, [
       {
         to: "/dashboard/statistics",
-        label: "Metric Correlation Matrix",
+        label: "Correlation Heatmap of Metrics",
         description: "Explore correlations between daily metrics",
       },
     ]),


### PR DESCRIPTION
## Summary
- rename chart navigation items to more descriptive titles

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6890bf5959c08324a61d28f812cb8824