### PR TITLE
feat: enhance correlation tooltip

### DIFF
--- a/src/components/visualizations/CorrelationDetails.tsx
+++ b/src/components/visualizations/CorrelationDetails.tsx
@@ -15,6 +15,7 @@ export interface CorrelationDrilldown {
   seriesY: TimeseriesPoint[];
   rolling: TimeseriesPoint[];
   breakdown: { weekday: number; weekend: number };
+  insight?: string;
 }
 
 interface CorrelationDetailsProps {


### PR DESCRIPTION
## Summary
- show metric pair names, correlation/p-value, mini chart, and insight in correlation matrix tooltip
- add optional insight in drilldown data model
- make tooltips and cells keyboard-accessible with ARIA labels

## Testing
- `npm test` *(fails: CorrelationRippleMatrix detail panel test)*

------
https://chatgpt.com/codex/tasks/task_e_6890c7ad80d88324aa09af377a2c84e3