### PR TITLE
feat: add visualizations list route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,8 +48,9 @@ import InterventionSettingsPage from "@/pages/InterventionSettings";
 import PrivacyDashboardPage from "@/pages/PrivacyDashboard";
 import BehavioralCharterMapPage from "@/pages/BehavioralCharterMap";
 import SidebarDemoPage from "@/pages/SidebarDemo";
+import VisualizationsList from "@/pages/VisualizationsList";
 
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 import { SelectionProvider } from "@/hooks/useSelection";
 
@@ -60,9 +61,10 @@ function App() {
         <SelectionProvider>
         <Layout>
           <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/" element={<VisualizationsList />} />
+            <Route path="/visualizations" element={<VisualizationsList />} />
             <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
-            <Route path="/dashboard" element={<Dashboard />}> 
+            <Route path="/dashboard" element={<Dashboard />}>
               <Route index element={<DashboardLanding />} />
               <Route path="map" element={<MapPlaygroundPage />} />
               <Route path="route-similarity" element={<RouteSimilarityPage />} />


### PR DESCRIPTION
## Summary
- expose visualizations list page
- default to visualizations list at root

## Testing
- `npm test` *(fails: CorrelationRippleMatrix shows detail panel on cell click)*

------
https://chatgpt.com/codex/tasks/task_e_6890d58177dc832485bf6b4d1556886f