### PR TITLE
fix: guard GoodDayMap getComputedStyle

### DIFF
--- a/src/components/statistics/GoodDayMap.tsx
+++ b/src/components/statistics/GoodDayMap.tsx
@@ -20,7 +20,7 @@ import { Skeleton } from "@/ui/skeleton"
 import { Slider } from "@/ui/slider"
 import { scaleLinear } from "d3-scale"
 import type { ChartConfig } from "@/ui/chart"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import { symbol, symbolStar } from "d3-shape"
 import SessionDetailDrawer from "./SessionDetailDrawer"
@@ -132,9 +132,22 @@ export default function GoodDayMap({
   const benchmarkCount = Math.max(1, Math.floor(sortedByDelta.length * benchmarkPercent))
   const benchmarkSet = new Set(sortedByDelta.slice(0, benchmarkCount).map((s) => s.id))
 
-  const style = getComputedStyle(document.documentElement)
-  const start = `hsl(${style.getPropertyValue("--chart-4")})`
-  const end = `hsl(${style.getPropertyValue("--chart-6")})`
+  const [colors, setColors] = useState({
+    start: "hsl(222 70% 60%)",
+    end: "hsl(230 70% 50%)",
+  })
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      const style = getComputedStyle(document.documentElement)
+      setColors({
+        start: `hsl(${style.getPropertyValue("--chart-4")})`,
+        end: `hsl(${style.getPropertyValue("--chart-6")})`,
+      })
+    }
+  }, [])
+
+  const { start, end } = colors
   const config = {} satisfies ChartConfig
 
   const minDelta = Math.min(...goodSessions.map((d) => d.paceDelta))


### PR DESCRIPTION
## Summary
- avoid referencing document in SSR by moving getComputedStyle into useEffect
- provide fallback chart colors when document isn't available

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6890dfc0b5a483249ed9ff09c5e45c0a