### PR TITLE
feat: enhance mileage globe visuals

### DIFF
--- a/src/components/GlobeRenderer.tsx
+++ b/src/components/GlobeRenderer.tsx
@@ -10,6 +10,8 @@ interface PathData {
   coordinates: [number, number][];
   date?: string;
   miles?: number;
+  /** Optional stroke color for rendering */
+  color?: string;
 }
 
 interface GlobeRendererProps {
@@ -134,10 +136,11 @@ export default function GlobeRenderer({
           className="activity-path"
           d={pathGenerator({ type: "LineString", coordinates: p.coordinates }) || undefined}
           fill="none"
-          stroke="var(--primary-foreground)"
+          stroke={p.color || "var(--primary-foreground)"}
           strokeWidth={strokeWidth}
           strokeLinecap="round"
           opacity={0.8}
+          style={{ transition: "stroke 0.3s ease" }}
           onMouseEnter={() => onPathMouseEnter?.(p)}
           onMouseLeave={() => onPathMouseLeave?.()}
         />

--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -50,10 +50,18 @@ export default function MileageGlobe({ weekRange, autoRotate = false }: MileageG
   const totalMiles = data.reduce((sum, p) => sum + p.miles, 0)
   const strokeWidth = Math.max(2, Math.min(10, 1 + totalMiles / 50))
 
+  const getPathColor = (miles: number) => {
+    if (miles < 4) return 'var(--color-walk)'
+    if (miles < 8) return 'var(--color-run)'
+    return 'var(--color-bike)'
+  }
+
+  const coloredPaths = data.map((p) => ({ ...p, color: getPathColor(p.miles) }))
+
   return (
     <div className='relative aspect-square w-full'>
       <GlobeRenderer
-        paths={data}
+        paths={coloredPaths}
         worldFeatures={worldFeatures}
         autoRotate={autoRotate}
         strokeWidth={strokeWidth}
@@ -64,6 +72,7 @@ export default function MileageGlobe({ weekRange, autoRotate = false }: MileageG
         <div className='absolute top-2 right-2 bg-background text-foreground text-xs px-2 py-1 rounded shadow'>
           <div>{tooltip.date}</div>
           <div>{tooltip.miles} miles</div>
+          <div>Cumulative: {tooltip.cumulativeMiles} miles</div>
         </div>
       )}
       <div className='absolute bottom-2 left-2 text-xs text-foreground'>

--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -57,7 +57,7 @@ describe("MileageGlobe", () => {
       const land = container.querySelectorAll("path[fill='var(--muted)']");
       expect(land.length).toBeGreaterThan(0);
       const paths = container.querySelectorAll(
-        "path[stroke='var(--primary-foreground)']",
+        "path[stroke='var(--color-run)']",
       );
       expect(paths.length).toBe(1);
       const path = paths[0] as SVGPathElement | undefined;
@@ -95,10 +95,14 @@ describe("MileageGlobe", () => {
     const { container } = render(<MileageGlobe />);
 
     await waitFor(() => {
-      const paths = container.querySelectorAll(
-        "path[stroke='var(--primary-foreground)']",
+      const runPath = container.querySelectorAll(
+        "path[stroke='var(--color-run)']",
       );
-      expect(paths.length).toBe(2);
+      const walkPath = container.querySelectorAll(
+        "path[stroke='var(--color-walk)']",
+      );
+      expect(runPath.length).toBe(1);
+      expect(walkPath.length).toBe(1);
     });
   });
 
@@ -169,12 +173,13 @@ describe("MileageGlobe", () => {
 
     await waitFor(() => {
       const path = container.querySelector(
-        "path[stroke='var(--primary-foreground)']",
+        "path[stroke='var(--color-run)']",
       ) as SVGPathElement | null;
       expect(path).not.toBeNull();
       fireEvent.mouseEnter(path!);
       expect(screen.getByText("2024-01-01")).toBeInTheDocument();
       expect(screen.getByText("5 miles")).toBeInTheDocument();
+      expect(screen.getByText("Cumulative: 5 miles")).toBeInTheDocument();
       fireEvent.mouseLeave(path!);
       expect(screen.queryByText("2024-01-01")).not.toBeInTheDocument();
     });

--- a/src/pages/MileageGlobe.tsx
+++ b/src/pages/MileageGlobe.tsx
@@ -71,6 +71,20 @@ export default function MileageGlobePage() {
             onValueChange={handleScrub}
             className="w-64"
           />
+          <div className="relative w-64 h-2">
+            {weekly.slice(startWeek).map((w, i) => {
+              if (w.miles === 0) return null
+              const total = weekly.length - 1 - startWeek
+              const pos = (i / (total || 1)) * 100
+              return (
+                <span
+                  key={i}
+                  className="absolute top-0 w-0.5 h-2 bg-primary"
+                  style={{ left: `${pos}%`, transform: 'translateX(-50%)' }}
+                />
+              )
+            })}
+          </div>
           <div className="flex items-center gap-2">
             <Button
               size="sm"


### PR DESCRIPTION
## Summary
- color mileage paths by distance and pass stroke color to globe renderer
- show cumulative miles in path tooltip
- mark active weeks on playback slider

## Testing
- `npm test src/components/examples/__tests__/MileageGlobe.test.tsx`
- `npm test` *(fails: expect(received).toBeInTheDocument() in CorrelationRippleMatrix.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6890dfa2f8e08324bbd825ad97ac905c