### PR TITLE
Add accessibility label to command palette search input

### DIFF
--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -46,6 +46,7 @@ export default function CommandPalette({
         <div className="p-2">
           <input
             autoFocus
+            aria-label="Command search"
             className="mb-2 w-full border-b bg-transparent px-2 py-1 outline-none"
             placeholder="Type a command or search..."
             value={query}


### PR DESCRIPTION
## Summary
- add `aria-label="Command search"` to CommandPalette search input

## Testing
- `NODE_PATH=$(npm root -g) eslint src/components/ui/CommandPalette.tsx --resolve-plugins-relative-to $(npm root -g) --plugin jsx-a11y --rule 'jsx-a11y/control-has-associated-label: 2' --parser @typescript-eslint/parser`
- `npm test` *(fails: CorrelationRippleMatrix > shows detail panel on cell click)*

------
https://chatgpt.com/codex/tasks/task_e_6890f653c0a8832490f1bde668969782