### PR TITLE
feat: add error handling to activity minutes hook

### DIFF
--- a/src/hooks/useActivityMinutes.ts
+++ b/src/hooks/useActivityMinutes.ts
@@ -1,10 +1,33 @@
 import { useState, useEffect } from 'react'
 import { ActivityMinutes, getActivityMinutes } from '@/lib/api'
 
-export default function useActivityMinutes(): ActivityMinutes[] | null {
+/**
+ * Hook for retrieving activity minutes from the API.
+ *
+ * The API call is wrapped in a try/catch so that any failure can be surfaced to
+ * the consumer. The hook returns an object containing the `data` retrieved and
+ * an `error` if one occurred.
+ */
+export default function useActivityMinutes(): {
+  data: ActivityMinutes[] | null
+  error: Error | null
+} {
   const [data, setData] = useState<ActivityMinutes[] | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+
   useEffect(() => {
-    getActivityMinutes().then(setData)
+    const fetchActivityMinutes = async () => {
+      try {
+        const result = await getActivityMinutes()
+        setData(result)
+      } catch (err: unknown) {
+        console.error(err)
+        setError(err instanceof Error ? err : new Error('Failed to fetch activity minutes'))
+      }
+    }
+
+    fetchActivityMinutes()
   }, [])
-  return data
+
+  return { data, error }
 }


### PR DESCRIPTION
## Summary
- handle errors for activity minutes fetch
- return data and error from `useActivityMinutes`

## Testing
- `npm test` (fails: CorrelationRippleMatrix detail panel missing)


------
https://chatgpt.com/codex/tasks/task_e_6890f64e3fe48324af05a4998bacca0b