### PR TITLE
fix: include range deps in WeeklyVolumeChart effect

### DIFF
--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -54,7 +54,7 @@ export default function WeeklyVolumeChart() {
     if (data && range.start === null && range.end === null && data.length) {
       setRange({ start: data[0].week, end: data[data.length - 1].week });
     }
-  }, [data]);
+  }, [data, range.start, range.end, setRange]);
 
   if (!data) return <Skeleton className="h-64" />;
 


### PR DESCRIPTION
## Summary
- include `range.start`, `range.end`, and `setRange` in `WeeklyVolumeChart` initialization effect

## Testing
- `npm test -- --run` *(fails: CorrelationRippleMatrix shows detail panel on cell click)*

------
https://chatgpt.com/codex/tasks/task_e_6890f64ca8208324b805deaa639b43ec