### PR TITLE
refactor: type brush handle props

### DIFF
--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -16,7 +16,15 @@ import { useEffect, useState } from "react";
 import { Skeleton } from "@/ui/skeleton";
 import usePrefersReducedMotion from "@/hooks/usePrefersReducedMotion";
 
-function BrushHandle({ x, y, width, height, stroke }: any) {
+interface BrushHandleProps {
+  x: number
+  y: number
+  width: number
+  height: number
+  stroke: string
+}
+
+function BrushHandle({ x, y, width, height, stroke }: BrushHandleProps) {
   const line1 = x + width / 2 - 3;
   const line2 = x + width / 2 + 3;
   return (


### PR DESCRIPTION
## Summary
- add BrushHandleProps interface to clarify Recharts brush custom handle expectations
- use strongly typed props for BrushHandle in WeeklyVolumeChart

## Testing
- `npm test` *(fails: CorrelationRippleMatrix shows detail panel on cell click)*

------
https://chatgpt.com/codex/tasks/task_e_6890f64b0bc88324b6f853f943d980fe