### PR TITLE
Fix correlation detail test to use fireEvent

### DIFF
--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -1,5 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import React from 'react'
 import '@testing-library/jest-dom'
@@ -57,7 +56,7 @@ describe('CorrelationRippleMatrix', () => {
 
     const cells = container.querySelectorAll('path.recharts-rectangle')
     expect(cells.length).toBeGreaterThan(1)
-    await userEvent.click(cells[1] as SVGPathElement, { skipHover: true })
+    fireEvent.click(cells[1] as SVGPathElement)
     await waitFor(() =>
       expect(
         document.querySelector('[data-testid="correlation-details"]'),


### PR DESCRIPTION
## Summary
- ensure CorrelationRippleMatrix test clicks SVG cells using fireEvent
- verify correlation detail sheet appears after clicking a cell

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689100fb0c0083248baf460b2d4319b5