### PR TITLE
feat: improve heatmap visualization

### DIFF
--- a/src/components/statistics/HabitConsistencyHeatmap.tsx
+++ b/src/components/statistics/HabitConsistencyHeatmap.tsx
@@ -7,6 +7,10 @@ import { Skeleton } from "@/ui/skeleton"
 import useTrainingConsistency from "@/hooks/useTrainingConsistency"
 import { Link } from "react-router-dom"
 
+function getHourLabel(hour: number) {
+  return `${hour.toString().padStart(2, "0")}:00`
+}
+
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
 export default function HabitConsistencyHeatmap() {
@@ -54,25 +58,45 @@ export default function HabitConsistencyHeatmap() {
       description="Session count by weekday and hour"
     >
       <ChartContainer config={{}} className="h-64 md:h-80 lg:h-96">
-        <div className="grid gap-px text-center text-[10px]">
-          <div className="grid grid-cols-7 text-xs font-medium">
-            {dayLabels.map((d) => (
-              <div key={d}>{d}</div>
-            ))}
-          </div>
-          {grid.map((row, hour) => (
-            <div key={hour} className="grid grid-cols-7">
-              {row.map((cell, idx) => (
-                <div
-                  key={idx}
-                  className="flex items-center justify-center border bg-accent text-accent-foreground h-4"
-                  style={{ opacity: max ? cell.count / max : 0 }}
-                  tabIndex={0}
-                  aria-label={`${dayLabels[idx]} hour ${hour}: ${cell.count} sessions`}
-                />
+        <div className="flex h-full flex-col">
+          <div className="grid flex-1 gap-px text-center text-[10px]">
+            <div className="grid grid-cols-8 text-xs font-medium">
+              <div />
+              {dayLabels.map((d) => (
+                <div key={d}>{d}</div>
               ))}
             </div>
-          ))}
+            {grid.map((row, hour) => (
+              <div key={hour} className="grid grid-cols-8">
+                <div className="pr-1 text-right text-xs text-muted-foreground">
+                  {getHourLabel(hour)}
+                </div>
+                {row.map((cell, idx) => {
+                  const ratio = max ? cell.count / max : 0
+                  const color = `hsl(var(--accent) / ${ratio})`
+                  return (
+                    <div
+                      key={idx}
+                      className="flex items-center justify-center border text-accent-foreground h-4"
+                      style={{ backgroundColor: color }}
+                      tabIndex={0}
+                      aria-label={`${dayLabels[idx]} hour ${hour}: ${cell.count} sessions`}
+                    />
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 flex items-center text-[10px] text-muted-foreground">
+            <span className="mr-2">0</span>
+            <div
+              className="h-2 flex-1 rounded"
+              style={{
+                background: "linear-gradient(to right, hsl(var(--accent) / 0), hsl(var(--accent)))",
+              }}
+            />
+            <span className="ml-2">{max}</span>
+          </div>
         </div>
       </ChartContainer>
     </ChartCard>


### PR DESCRIPTION
## Summary
- use background color scale instead of opacity for heatmap cells
- show hourly labels and gradient legend in HabitConsistencyHeatmap

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6891035efd608324a15de9fac23356ce