### PR TITLE
feat(map): show placeholder when no state visit data

### DIFF
--- a/src/components/map/GeoActivityExplorer.tsx
+++ b/src/components/map/GeoActivityExplorer.tsx
@@ -179,8 +179,15 @@ export default function GeoActivityExplorer() {
     );
   }
 
-  if (!data) {
-    return null;
+  if (!data || data?.length === 0) {
+    return (
+      <div className="flex h-60 w-full flex-col items-center justify-center text-sm">
+        <p>No state visit data available.</p>
+        <button className="underline" onClick={refetch}>
+          Retry
+        </button>
+      </div>
+    );
   }
 
   const toggleState = (abbr: string) => {

--- a/src/components/map/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/map/__tests__/GeoActivityExplorer.test.tsx
@@ -28,34 +28,9 @@ vi.mock("recharts", async () => {
   };
 });
 
+const mockUseStateVisits = vi.fn();
 vi.mock("@/hooks/useStateVisits", () => ({
-  useStateVisits: () => ({
-    data: [
-      {
-        stateCode: "CA",
-        visited: true,
-        totalDays: 10,
-        totalMiles: 100,
-        cities: [{ name: "LA", days: 4, miles: 40 }],
-        log: [
-          { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
-        ],
-      },
-      {
-        stateCode: "TX",
-        visited: true,
-        totalDays: 5,
-        totalMiles: 50,
-        cities: [{ name: "Austin", days: 5, miles: 50 }],
-        log: [
-          { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
-        ],
-      },
-    ],
-    loading: false,
-    error: null,
-    refetch: vi.fn(),
-  }),
+  useStateVisits: (...args: any[]) => mockUseStateVisits(...args),
 }));
 
 vi.mock("@/hooks/useInsights", () => ({
@@ -71,8 +46,56 @@ vi.mock("@/hooks/useInsights", () => ({
   }),
 }));
 
+const defaultVisits = [
+  {
+    stateCode: "CA",
+    visited: true,
+    totalDays: 10,
+    totalMiles: 100,
+    cities: [{ name: "LA", days: 4, miles: 40 }],
+    log: [
+      { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
+    ],
+  },
+  {
+    stateCode: "TX",
+    visited: true,
+    totalDays: 5,
+    totalMiles: 50,
+    cities: [{ name: "Austin", days: 5, miles: 50 }],
+    log: [
+      { date: new Date().toISOString().slice(0, 10), type: "run", miles: 1 },
+    ],
+  },
+];
+
+beforeEach(() => {
+  mockUseStateVisits.mockReturnValue({
+    data: defaultVisits,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+});
+
 
 describe("GeoActivityExplorer", () => {
+  it("shows placeholder when no data", () => {
+    const refetch = vi.fn();
+    mockUseStateVisits.mockReturnValue({
+      data: [],
+      loading: false,
+      error: null,
+      refetch,
+    });
+    render(<GeoActivityExplorer />);
+    expect(
+      screen.getByText("No state visit data available."),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Retry"));
+    expect(refetch).toHaveBeenCalled();
+  });
+
   it("renders filter selects", () => {
     render(<GeoActivityExplorer />);
     expect(screen.getAllByLabelText("Activity").length).toBeGreaterThan(0);

--- a/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/visualizations/__tests__/CorrelationRippleMatrix.test.tsx
@@ -1,5 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import React from 'react'
 import '@testing-library/jest-dom'
@@ -57,7 +56,7 @@ describe('CorrelationRippleMatrix', () => {
 
     const cells = container.querySelectorAll('path.recharts-rectangle')
     expect(cells.length).toBeGreaterThan(1)
-    await userEvent.click(cells[1] as SVGPathElement, { skipHover: true })
+    fireEvent.click(cells[1] as SVGPathElement)
     await waitFor(() =>
       expect(
         document.querySelector('[data-testid="correlation-details"]'),


### PR DESCRIPTION
## Summary
- show message and retry button when state visits data is missing
- test no data behavior and improve state visit mock setup
- stabilize CorrelationRippleMatrix interaction test

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689101eb05488324b8b83b2f19318593