### PR TITLE
feat: add clinical fragility index

### DIFF
--- a/src/lib/__tests__/clinicalFragility.test.ts
+++ b/src/lib/__tests__/clinicalFragility.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { computeFragilityIndex } from '../clinicalFragility'
+
+describe('computeFragilityIndex', () => {
+  it('returns 0 for already non-significant tables', () => {
+    expect(computeFragilityIndex(10, 90, 15, 85)).toBe(0)
+  })
+
+  it('returns 1 when a single flip removes significance', () => {
+    expect(computeFragilityIndex(10, 90, 20, 80)).toBe(1)
+  })
+
+  it('handles cases requiring multiple flips', () => {
+    expect(computeFragilityIndex(1, 99, 10, 90)).toBe(2)
+  })
+
+  it('flips the control group when it has fewer events', () => {
+    expect(computeFragilityIndex(20, 80, 10, 90)).toBe(1)
+  })
+})

--- a/src/lib/clinicalFragility.ts
+++ b/src/lib/clinicalFragility.ts
@@ -1,0 +1,91 @@
+export function computeFragilityIndex(a: number, b: number, c: number, d: number): number {
+  let flips = 0
+  let p = pValue(a, b, c, d)
+  if (p >= 0.05) return 0
+  while (p < 0.05) {
+    if (a <= c) {
+      if (b <= 0) break
+      a += 1
+      b -= 1
+    } else {
+      if (d <= 0) break
+      c += 1
+      d -= 1
+    }
+    flips += 1
+    p = pValue(a, b, c, d)
+  }
+  return flips
+}
+
+function pValue(a: number, b: number, c: number, d: number): number {
+  if (Math.min(a, b, c, d) < 5) {
+    return fisherExactPValue(a, b, c, d)
+  }
+  return chiSquarePValue(a, b, c, d)
+}
+
+function fisherExactPValue(a: number, b: number, c: number, d: number): number {
+  const row1 = a + b
+  const row2 = c + d
+  const col1 = a + c
+  const n = row1 + row2
+  const obs = hypergeomProb(a, row1, row2, col1)
+  let p = 0
+  const min = Math.max(0, col1 - row2)
+  const max = Math.min(row1, col1)
+  for (let i = min; i <= max; i++) {
+    const prob = hypergeomProb(i, row1, row2, col1)
+    if (prob <= obs + 1e-12) p += prob
+  }
+  return p
+}
+
+function hypergeomProb(x: number, row1: number, row2: number, col1: number): number {
+  const n = row1 + row2
+  const logP =
+    logCombination(row1, x) +
+    logCombination(row2, col1 - x) -
+    logCombination(n, col1)
+  return Math.exp(logP)
+}
+
+const logFactorialCache: number[] = [0]
+function logFactorial(n: number): number {
+  if (logFactorialCache[n] !== undefined) return logFactorialCache[n]
+  let last = logFactorialCache.length
+  let log = logFactorialCache[last - 1]
+  for (let i = last; i <= n; i++) {
+    log += Math.log(i)
+    logFactorialCache[i] = log
+  }
+  return logFactorialCache[n]
+}
+
+function logCombination(n: number, k: number): number {
+  if (k < 0 || k > n) return -Infinity
+  return logFactorial(n) - logFactorial(k) - logFactorial(n - k)
+}
+
+function chiSquarePValue(a: number, b: number, c: number, d: number): number {
+  const n = a + b + c + d
+  const numerator = n * (a * d - b * c) ** 2
+  const denominator = (a + b) * (c + d) * (a + c) * (b + d)
+  const chi2 = numerator / denominator
+  return 1 - erf(Math.sqrt(chi2 / 2))
+}
+
+function erf(x: number): number {
+  // Abramowitz and Stegun formula 7.1.26
+  const sign = x >= 0 ? 1 : -1
+  const absX = Math.abs(x)
+  const a1 = 0.254829592
+  const a2 = -0.284496736
+  const a3 = 1.421413741
+  const a4 = -1.453152027
+  const a5 = 1.061405429
+  const p = 0.3275911
+  const t = 1 / (1 + p * absX)
+  const y = 1 - (((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX))
+  return sign * y
+}


### PR DESCRIPTION
## Summary
- add computeFragilityIndex helper to simulate outcome flips until a trial becomes non‑significant
- support Fisher's exact or chi-square tests based on cell counts
- cover non-significant, single flip, and multi-flip scenarios in unit tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6891075c856883248ac09dd7ae6bb740