### PR TITLE
feat: add clinical fragility demo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import RouteSimilarityPage from "@/pages/RouteSimilarity";
 import RouteNoveltyPage from "@/pages/RouteNovelty";
 import MileageGlobePage from "@/pages/MileageGlobe";
 import FragilityPage from "@/pages/Fragility";
+import ClinicalFragilityDemoPage from "@/pages/ClinicalFragilityDemo";
 import SessionSimilarityPage from "@/pages/SessionSimilarity";
 import GoodDayPage from "@/pages/GoodDay";
 import HabitConsistencyPage from "@/pages/HabitConsistency";
@@ -71,6 +72,10 @@ function App() {
               <Route path="route-novelty" element={<RouteNoveltyPage />} />
               <Route path="mileage-globe" element={<MileageGlobePage />} />
               <Route path="fragility" element={<FragilityPage />} />
+              <Route
+                path="clinical-fragility-demo"
+                element={<ClinicalFragilityDemoPage />}
+              />
               <Route path="session-similarity" element={<SessionSimilarityPage />} />
               <Route path="good-day" element={<GoodDayPage />} />
               <Route path="habit-consistency" element={<HabitConsistencyPage />} />

--- a/src/components/fragility/OutcomeFlipSimulator.tsx
+++ b/src/components/fragility/OutcomeFlipSimulator.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import React, { useState, useMemo } from 'react'
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { computeFragilityIndex, computePValue } from '@/lib/clinicalFragility'
+
+interface CellProps {
+  label: string
+  value: number
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onInc: () => void
+  onDec: () => void
+}
+
+function Cell({ label, value, onChange, onInc, onDec }: CellProps) {
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-medium">{label}</label>
+      <div className="flex items-center space-x-2">
+        <Button size="sm" onClick={onDec}>
+          -
+        </Button>
+        <Input
+          type="number"
+          value={value}
+          onChange={onChange}
+          className="w-20 text-center"
+        />
+        <Button size="sm" onClick={onInc}>
+          +
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default function OutcomeFlipSimulator() {
+  const [a, setA] = useState(5)
+  const [b, setB] = useState(0)
+  const [c, setC] = useState(0)
+  const [d, setD] = useState(5)
+
+  const p = useMemo(() => computePValue(a, b, c, d), [a, b, c, d])
+  const fi = useMemo(() => computeFragilityIndex(a, b, c, d), [a, b, c, d])
+
+  const handleChange = (
+    setter: React.Dispatch<React.SetStateAction<number>>,
+  ) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10)
+    setter(Number.isNaN(value) ? 0 : Math.max(0, value))
+  }
+
+  const increment = (
+    setter: React.Dispatch<React.SetStateAction<number>>,
+  ) => () => setter((v) => v + 1)
+
+  const decrement = (
+    setter: React.Dispatch<React.SetStateAction<number>>,
+  ) => () => setter((v) => Math.max(0, v - 1))
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4">
+        <Cell
+          label="Group 1 Event"
+          value={a}
+          onChange={handleChange(setA)}
+          onInc={increment(setA)}
+          onDec={decrement(setA)}
+        />
+        <Cell
+          label="Group 1 No Event"
+          value={b}
+          onChange={handleChange(setB)}
+          onInc={increment(setB)}
+          onDec={decrement(setB)}
+        />
+        <Cell
+          label="Group 2 Event"
+          value={c}
+          onChange={handleChange(setC)}
+          onInc={increment(setC)}
+          onDec={decrement(setC)}
+        />
+        <Cell
+          label="Group 2 No Event"
+          value={d}
+          onChange={handleChange(setD)}
+          onInc={increment(setD)}
+          onDec={decrement(setD)}
+        />
+      </div>
+      <div className="space-y-1 text-sm">
+        <div>P-value: {p.toPrecision(3)}</div>
+        <div>Fragility Index: {fi}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/clinicalFragility.ts
+++ b/src/lib/clinicalFragility.ts
@@ -1,3 +1,7 @@
+export function computePValue(a: number, b: number, c: number, d: number): number {
+  return pValue(a, b, c, d)
+}
+
 export function computeFragilityIndex(a: number, b: number, c: number, d: number): number {
   let flips = 0
   let p = pValue(a, b, c, d)

--- a/src/pages/ClinicalFragilityDemo.tsx
+++ b/src/pages/ClinicalFragilityDemo.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import OutcomeFlipSimulator from "@/components/fragility/OutcomeFlipSimulator"
+
+export default function ClinicalFragilityDemoPage() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold">Clinical Fragility Demo</h1>
+      <OutcomeFlipSimulator />
+    </div>
+  )
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -102,6 +102,11 @@ export const analyticalRoutes = withIcon(BarChart3, [
     preview: "fragility",
   },
   {
+    to: "/dashboard/clinical-fragility-demo",
+    label: "Clinical Fragility Demo",
+    description: "Simulate outcome flips and fragility index",
+  },
+  {
     to: "/dashboard/session-similarity",
     label: "Session Similarity Analysis",
     description: "Find training sessions that resemble each other",


### PR DESCRIPTION
## Summary
- add OutcomeFlipSimulator component to adjust 2x2 counts and compute p-value and fragility index in real time
- expose the simulator via ClinicalFragilityDemo page and dashboard route
- export computePValue from clinicalFragility utils

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910c345e848324a90ac2493174bb97