### PR TITLE
Handle missing state visits response

### DIFF
--- a/src/hooks/useStateVisits.ts
+++ b/src/hooks/useStateVisits.ts
@@ -19,9 +19,15 @@ export function useStateVisits(): UseStateVisitsResult {
     setError(null);
     try {
       const result = await getStateVisits();
-      setData(result);
+      if (!result) {
+        setError(new Error("Failed to load state visits"));
+        setData([]);
+      } else {
+        setData(result);
+      }
     } catch (e) {
       setError(e as Error);
+      setData([]);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- ensure `useStateVisits` sets an error and defaults to an empty array if API returns no data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689101edd89c8324a8638c838325002a