### PR TITLE
feat: add tooltips and session dialog to training heatmap

### DIFF
--- a/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/TrainingEntropyHeatmap.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import React from 'react'
 import '@testing-library/jest-dom'
@@ -23,7 +24,19 @@ const mockUseTrainingConsistency = useTrainingConsistency as unknown as vi.Mock
 beforeEach(() => {
   mockUseTrainingConsistency.mockReturnValue({
     data: {
-      sessions: [],
+      sessions: [
+        {
+          id: 1,
+          pace: 5,
+          duration: 30,
+          heartRate: 120,
+          date: '2023-01-01',
+          start: '2023-01-01T00:00:00',
+          lat: 0,
+          lon: 0,
+          weather: { temperature: 0, humidity: 0, wind: 0, condition: '' },
+        },
+      ],
       heatmap: [{ day: 0, hour: 0, count: 1 }],
       weeklyEntropy: [0.2],
     },
@@ -46,5 +59,23 @@ describe('TrainingEntropyHeatmap', () => {
     expect(
       screen.getByText(/Failed to load training data/),
     ).toBeInTheDocument()
+  })
+
+  it('shows tooltip on hover', async () => {
+    const user = userEvent.setup()
+    render(<TrainingEntropyHeatmap />)
+    const cell = screen.getByLabelText('Sun hour 0: 1 sessions')
+    await user.hover(cell)
+    expect(
+      await screen.findByText('1 sessions on Sun at 00:00'),
+    ).toBeInTheDocument()
+  })
+
+  it('opens dialog with sessions on click', async () => {
+    const user = userEvent.setup()
+    render(<TrainingEntropyHeatmap />)
+    const cell = screen.getByLabelText('Sun hour 0: 1 sessions')
+    await user.click(cell)
+    expect(screen.getByText('Session 1')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- show session counts and timeframes via tooltip in training heatmap
- open session details dialog when clicking heatmap cells
- add tests for tooltip display and dialog invocation

## Testing
- `npm test` *(fails: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6891076b395c8324ab008c7ccd84c2cc