### PR TITLE
feat: add dashboard, sidebar, and mobile tab layouts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Layout from "@/components/layout/Layout";
+import DashboardLayout from "@/layouts/DashboardLayout";
 import Dashboard from "@/pages/Dashboard";
 import DashboardLanding from "@/pages/DashboardLanding";
 import MapPlaygroundPage from "@/pages/MapPlayground";
@@ -60,7 +60,7 @@ function App() {
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <DashboardFiltersProvider>
         <SelectionProvider>
-        <Layout>
+        <DashboardLayout>
           <Routes>
             <Route path="/" element={<VisualizationsList />} />
             <Route path="/visualizations" element={<VisualizationsList />} />
@@ -119,7 +119,7 @@ function App() {
               <Route path="behavioral-charter-map" element={<BehavioralCharterMapPage />} />
             </Route>
           </Routes>
-        </Layout>
+        </DashboardLayout>
         </SelectionProvider>
       </DashboardFiltersProvider>
     </BrowserRouter>

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -4,11 +4,11 @@ import CommandPalette from "@/ui/CommandPalette";
 import { ChartActionsProvider } from "@/hooks/useChartActions";
 import useRecentViews from "@/hooks/useRecentViews";
 
-interface LayoutProps {
+interface DashboardLayoutProps {
   children: React.ReactNode;
 }
 
-export default function Layout({ children }: LayoutProps) {
+export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const location = useLocation();
   const { addRecentView } = useRecentViews();
 

--- a/src/layouts/MobileTabLayout.tsx
+++ b/src/layouts/MobileTabLayout.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+import { cn } from "@/lib/utils";
+
+interface MobileTabLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function MobileTabLayout({ children }: MobileTabLayoutProps) {
+  const tabs = React.useMemo(
+    () =>
+      dashboardRoutes.map((group) => ({
+        to: group.items[0]?.to ?? "/dashboard",
+        label: group.label,
+        icon: group.icon,
+      })),
+    []
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-auto">{children}</div>
+      <nav className="flex border-t bg-background md:hidden">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          return (
+            <NavLink
+              key={tab.to}
+              to={tab.to}
+              className={({ isActive }) =>
+                cn(
+                  "flex flex-1 flex-col items-center justify-center gap-1 p-2 text-xs",
+                  isActive
+                    ? "text-foreground"
+                    : "text-muted-foreground"
+                )
+              }
+            >
+              <Icon className="h-5 w-5" />
+              <span>{tab.label}</span>
+            </NavLink>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
+

--- a/src/layouts/SidebarLayout.tsx
+++ b/src/layouts/SidebarLayout.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarContent,
+  SidebarTrigger,
+  SidebarInset,
+} from "@/ui/sidebar";
+import NavSection from "@/components/nav-section";
+import { dashboardRoutes } from "@/routes";
+import useNavigationFavorites from "@/hooks/useNavigationFavorites";
+import useNavigationRecent from "@/hooks/useNavigationRecent";
+
+interface SidebarLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function SidebarLayout({ children }: SidebarLayoutProps) {
+  const location = useLocation();
+  const allRoutes = React.useMemo(
+    () => dashboardRoutes.flatMap((g) => g.items),
+    []
+  );
+  const { favorites, favoriteRoutes, toggleFavorite } =
+    useNavigationFavorites(allRoutes);
+  const { recentRoutes } = useNavigationRecent(allRoutes);
+  const [highlighted, setHighlighted] = React.useState<string | null>(null);
+
+  return (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader>
+          <SidebarTrigger />
+        </SidebarHeader>
+        <SidebarContent>
+          {favoriteRoutes.length > 0 && (
+            <NavSection
+              label="Favorites"
+              routes={favoriteRoutes}
+              pathname={location.pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+              highlighted={highlighted}
+              setHighlighted={setHighlighted}
+            />
+          )}
+          {recentRoutes.length > 0 && (
+            <NavSection
+              label="Recent"
+              routes={recentRoutes}
+              pathname={location.pathname}
+              favorites={favorites}
+              toggleFavorite={toggleFavorite}
+              highlighted={highlighted}
+              setHighlighted={setHighlighted}
+            />
+          )}
+          <NavSection
+            label="All"
+            groups={dashboardRoutes}
+            pathname={location.pathname}
+            favorites={favorites}
+            toggleFavorite={toggleFavorite}
+            highlighted={highlighted}
+            setHighlighted={setHighlighted}
+          />
+        </SidebarContent>
+        <SidebarFooter />
+      </Sidebar>
+      <SidebarInset>{children}</SidebarInset>
+    </SidebarProvider>
+  );
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,21 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
+import SidebarLayout from "@/layouts/SidebarLayout";
+import MobileTabLayout from "@/layouts/MobileTabLayout";
 
 export default function Dashboard() {
-  return <Outlet />;
+  return (
+    <>
+      <div className="hidden h-full md:block">
+        <SidebarLayout>
+          <Outlet />
+        </SidebarLayout>
+      </div>
+      <div className="h-full md:hidden">
+        <MobileTabLayout>
+          <Outlet />
+        </MobileTabLayout>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- add dedicated DashboardLayout with chart actions and command palette providers
- implement SidebarLayout for desktop navigation and MobileTabLayout for mobile tabs
- wire new layouts into Dashboard routes and cleanup old layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689111385b4c83248346b748f2e8c915