### PR TITLE
feat: add fragility tooltips and docs

### DIFF
--- a/docs/fragility-index.md
+++ b/docs/fragility-index.md
@@ -1,0 +1,17 @@
+# Fragility Index
+
+The fragility index measures how many outcome flips are needed to change a statistically significant result to non-significant.
+
+## Glossary
+
+### 2×2 Table
+A contingency table summarizing events and non-events across two groups.
+
+### P-value
+Probability of observing results at least as extreme as those measured, assuming the null hypothesis is true.
+
+### Fisher's exact test
+A statistical test used for small-sample contingency tables to compute an exact p-value.
+
+### Fragility Index
+The number of individual outcome flips required to render a significant result non-significant.

--- a/src/components/fragility/OutcomeFlipSimulator.tsx
+++ b/src/components/fragility/OutcomeFlipSimulator.tsx
@@ -4,6 +4,14 @@ import React, { useState, useMemo } from 'react'
 import { Button } from '@/ui/button'
 import { Input } from '@/ui/input'
 import { computeFragilityIndex, computePValue } from '@/lib/clinicalFragility'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { ChevronRight } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/ui/tooltip'
 
 interface CellProps {
   label: string
@@ -35,6 +43,35 @@ function Cell({ label, value, onChange, onInc, onDec }: CellProps) {
   )
 }
 
+interface TermProps {
+  term: string
+  definition: string
+  href?: string
+}
+
+function Term({ term, definition, href }: TermProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="underline decoration-dotted cursor-help">{term}</span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {definition}
+        {href && (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="ml-1 underline"
+          >
+            Docs
+          </a>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 export default function OutcomeFlipSimulator() {
   const [a, setA] = useState(5)
   const [b, setB] = useState(0)
@@ -59,42 +96,115 @@ export default function OutcomeFlipSimulator() {
     setter: React.Dispatch<React.SetStateAction<number>>,
   ) => () => setter((v) => Math.max(0, v - 1))
 
+  const [open, setOpen] = useState(false)
+
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-2 gap-4">
-        <Cell
-          label="Group 1 Event"
-          value={a}
-          onChange={handleChange(setA)}
-          onInc={increment(setA)}
-          onDec={decrement(setA)}
-        />
-        <Cell
-          label="Group 1 No Event"
-          value={b}
-          onChange={handleChange(setB)}
-          onInc={increment(setB)}
-          onDec={decrement(setB)}
-        />
-        <Cell
-          label="Group 2 Event"
-          value={c}
-          onChange={handleChange(setC)}
-          onInc={increment(setC)}
-          onDec={decrement(setC)}
-        />
-        <Cell
-          label="Group 2 No Event"
-          value={d}
-          onChange={handleChange(setD)}
-          onInc={increment(setD)}
-          onDec={decrement(setD)}
-        />
+    <TooltipProvider>
+      <div className="space-y-6">
+        <div className="grid grid-cols-2 gap-4">
+          <Cell
+            label="Group 1 Event"
+            value={a}
+            onChange={handleChange(setA)}
+            onInc={increment(setA)}
+            onDec={decrement(setA)}
+          />
+          <Cell
+            label="Group 1 No Event"
+            value={b}
+            onChange={handleChange(setB)}
+            onInc={increment(setB)}
+            onDec={decrement(setB)}
+          />
+          <Cell
+            label="Group 2 Event"
+            value={c}
+            onChange={handleChange(setC)}
+            onInc={increment(setC)}
+            onDec={decrement(setC)}
+          />
+          <Cell
+            label="Group 2 No Event"
+            value={d}
+            onChange={handleChange(setD)}
+            onInc={increment(setD)}
+            onDec={decrement(setD)}
+          />
+        </div>
+        <div className="space-y-1 text-sm">
+          <div>
+            <Term
+              term="P-value"
+              definition="Probability of observing these results if the null hypothesis is true."
+              href="https://en.wikipedia.org/wiki/P-value"
+            />
+            : {p.toPrecision(3)}
+          </div>
+          <div>
+            <Term
+              term="Fragility Index"
+              definition="Number of outcome flips needed to lose statistical significance."
+              href="https://en.wikipedia.org/wiki/Fragility_index"
+            />
+            : {fi}
+          </div>
+        </div>
+        <Collapsible.Root
+          open={open}
+          onOpenChange={setOpen}
+          className="space-y-2"
+        >
+          <Collapsible.Trigger asChild>
+            <Button
+              variant="outline"
+              aria-expanded={open}
+              aria-controls="how-it-works"
+            >
+              How it works
+              <ChevronRight className="ml-2 h-4 w-4 transition-transform data-[state=open]:rotate-90" />
+            </Button>
+          </Collapsible.Trigger>
+          <Collapsible.Content
+            id="how-it-works"
+            className="space-y-2 rounded-md border p-4 text-sm"
+          >
+            <p>
+              1. Enter counts into a 2×2 table for events and non-events in
+              each group.
+            </p>
+            <p>
+              2. Calculate the{' '}
+              <Term
+                term="p-value"
+                definition="Measure of how compatible the data are with the null hypothesis."
+                href="https://en.wikipedia.org/wiki/P-value"
+              />{' '}
+              using{' '}
+              <Term
+                term="Fisher's exact test"
+                definition="Statistical test for small-sample 2×2 tables."
+                href="https://en.wikipedia.org/wiki/Fisher%27s_exact_test"
+              />
+              .
+            </p>
+            <p>
+              3. Flip outcomes between groups until the{' '}
+              <Term
+                term="p-value"
+                definition="Measure of how compatible the data are with the null hypothesis."
+                href="https://en.wikipedia.org/wiki/P-value"
+              />
+              {' '}reaches 0.05 or higher; the number of flips is the{' '}
+              <Term
+                term="fragility index"
+                definition="Count of flips required for non-significance."
+                href="https://en.wikipedia.org/wiki/Fragility_index"
+              />
+              .
+            </p>
+          </Collapsible.Content>
+        </Collapsible.Root>
       </div>
-      <div className="space-y-1 text-sm">
-        <div>P-value: {p.toPrecision(3)}</div>
-        <div>Fragility Index: {fi}</div>
-      </div>
-    </div>
+    </TooltipProvider>
   )
 }


### PR DESCRIPTION
## Summary
- add reusable tooltip term helper
- explain fragility calculation in new collapsible section
- document glossary of fragility index concepts

## Testing
- `npm test` *(fails: window.matchMedia is not a function; element type is invalid in TrainingEntropyHeatmap tests)*

------
https://chatgpt.com/codex/tasks/task_e_689117888c7083248f5c61332e1d6edc