### PR TITLE
feat: show cluster insights cards

### DIFF
--- a/src/components/maps/ClusterCard.tsx
+++ b/src/components/maps/ClusterCard.tsx
@@ -1,0 +1,98 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  ScatterChart,
+  Scatter,
+} from "@/ui/chart";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+} from "@/ui/dialog";
+import * as React from "react";
+
+interface ClusterCardProps {
+  data: any[];
+  color: string;
+}
+
+function getAnnotation(avgTemp: number, avgStart: number) {
+  const timeLabel =
+    avgStart < 6
+      ? "Early runs"
+      : avgStart < 12
+      ? "Morning runs"
+      : avgStart < 18
+      ? "Afternoon runs"
+      : "Evening runs";
+  const tempLabel =
+    avgTemp < 45
+      ? "cold temp"
+      : avgTemp < 65
+      ? "moderate temp"
+      : "warm temp";
+  return `${timeLabel}, ${tempLabel}`;
+}
+
+export default function ClusterCard({ data, color }: ClusterCardProps) {
+  const paceData = React.useMemo(
+    () => data.map((d, i) => ({ index: i, paceDelta: d.paceDelta })),
+    [data],
+  );
+  const avgTemp =
+    data.reduce((sum, d) => sum + d.temperature, 0) / data.length;
+  const avgStart =
+    data.reduce((sum, d) => sum + d.startHour, 0) / data.length;
+  const annotation = getAnnotation(avgTemp, avgStart);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Card className="cursor-pointer">
+          <CardHeader className="p-4 pb-2">
+            <CardTitle className="text-sm">{annotation}</CardTitle>
+            <CardDescription className="text-xs">
+              Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-4 pt-0">
+            <ChartContainer
+              className="h-16 w-full"
+              config={{ pace: { color } }}
+            >
+              <LineChart data={paceData}>
+                <XAxis dataKey="index" hide />
+                <YAxis dataKey="paceDelta" hide domain={["dataMin", "dataMax"]} />
+                <Line type="monotone" dataKey="paceDelta" stroke="var(--color-pace)" dot={false} />
+              </LineChart>
+            </ChartContainer>
+          </CardContent>
+        </Card>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <h3 className="mb-2 text-lg font-semibold">{annotation}</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
+        </p>
+        <ChartContainer className="h-48 w-full" config={{}}>
+          <ScatterChart>
+            <XAxis type="number" dataKey="x" />
+            <YAxis type="number" dataKey="y" />
+            <Scatter data={data} fill={color} />
+          </ScatterChart>
+        </ChartContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/maps/SessionSimilarityMap.tsx
+++ b/src/components/maps/SessionSimilarityMap.tsx
@@ -16,6 +16,7 @@ import { polygonHull, polygonCentroid } from "d3-polygon"
 import { contourDensity } from "d3-contour"
 import { geoPath } from "d3-geo"
 import { Customized, Polygon } from "recharts"
+import ClusterCard from "./ClusterCard"
 
 const colors = [
   "var(--chart-1)",
@@ -113,30 +114,15 @@ export default function SessionSimilarityMap({
           />
         </ScatterChart>
       </ChartContainer>
-      <div className="mt-4 grid grid-cols-3 gap-4">
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {clusters.map((c) => {
           const clusterData = data.filter((d) => d.cluster === c)
-          const avgTemp =
-            clusterData.reduce((sum, d) => sum + d.temperature, 0) /
-            clusterData.length
-          const avgStart =
-            clusterData.reduce((sum, d) => sum + d.startHour, 0) /
-            clusterData.length
-          const descriptor = clusterData[0]?.descriptor ?? ""
           return (
-            <div key={c} className="flex flex-col items-center">
-              <ChartContainer className="h-32 w-full" config={{}}>
-                <ScatterChart>
-                  <XAxis type="number" dataKey="x" hide />
-                  <YAxis type="number" dataKey="y" hide />
-                  <Scatter data={clusterData} fill={clusterConfig[c].color} />
-                </ScatterChart>
-              </ChartContainer>
-              <p className="mt-2 text-xs text-center">{descriptor}</p>
-              <p className="text-xs text-muted-foreground text-center">
-                Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
-              </p>
-            </div>
+            <ClusterCard
+              key={c}
+              data={clusterData}
+              color={clusterConfig[c].color}
+            />
           )
         })}
       </div>


### PR DESCRIPTION
## Summary
- display cluster insights with sparkline and averages
- replace session similarity grid with clickable cluster cards

## Testing
- `npm test` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68911756a1a48324945aa56338c10ceb