### PR TITLE
feat: add sidebar navigation component

### DIFF
--- a/src/components/layout/__tests__/sidebar-navigation.test.tsx
+++ b/src/components/layout/__tests__/sidebar-navigation.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import { SidebarProvider } from "@/ui/sidebar";
+import SidebarNavigation from "../sidebar-navigation";
+
+const renderWithProviders = () =>
+  render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <SidebarProvider>
+        <SidebarNavigation />
+      </SidebarProvider>
+    </MemoryRouter>
+  );
+
+describe("SidebarNavigation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  it("toggles group expansion", () => {
+    renderWithProviders();
+    const trigger = screen.getByText("Maps");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(trigger);
+    return waitFor(() =>
+      expect(trigger).toHaveAttribute("aria-expanded", "false"),
+    );
+  });
+
+  it("highlights route on hover", () => {
+    renderWithProviders();
+    const link = screen.getByText("State Visits Map").closest("a")!;
+    expect(link).not.toHaveClass("bg-accent");
+    fireEvent.mouseEnter(link);
+    expect(link).toHaveClass("bg-accent");
+  });
+
+  it("toggles favorites", async () => {
+    const user = userEvent.setup();
+    renderWithProviders();
+    const link = screen.getByText("State Visits Map").closest("a")!;
+    const star = link.querySelector("svg.lucide-star")!;
+    expect(star).toHaveClass("text-muted-foreground");
+    await user.click(star);
+    expect(star).toHaveClass("fill-yellow-400");
+    expect(screen.getByText("Favorites")).toBeInTheDocument();
+  });
+});
+

--- a/src/components/layout/sidebar-navigation.tsx
+++ b/src/components/layout/sidebar-navigation.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import NavSection from "@/components/nav-section";
+import { SidebarContent } from "@/ui/sidebar";
+import { dashboardRoutes } from "@/routes";
+import useNavigationFavorites from "@/hooks/useNavigationFavorites";
+import useNavigationRecent from "@/hooks/useNavigationRecent";
+
+export default function SidebarNavigation() {
+  const location = useLocation();
+  const allRoutes = React.useMemo(
+    () => dashboardRoutes.flatMap((g) => g.items),
+    []
+  );
+  const { favorites, favoriteRoutes, toggleFavorite } =
+    useNavigationFavorites(allRoutes);
+  const { recentRoutes } = useNavigationRecent(allRoutes);
+  const [highlighted, setHighlighted] = React.useState<string | null>(null);
+
+  return (
+    <SidebarContent>
+      {favoriteRoutes.length > 0 && (
+        <NavSection
+          label="Favorites"
+          routes={favoriteRoutes}
+          pathname={location.pathname}
+          favorites={favorites}
+          toggleFavorite={toggleFavorite}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
+        />
+      )}
+      {recentRoutes.length > 0 && (
+        <NavSection
+          label="Recent"
+          routes={recentRoutes}
+          pathname={location.pathname}
+          favorites={favorites}
+          toggleFavorite={toggleFavorite}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
+        />
+      )}
+      {dashboardRoutes.map((group) => (
+        <NavSection
+          key={group.label}
+          label={group.label}
+          routes={group.items}
+          icon={group.icon}
+          pathname={location.pathname}
+          favorites={favorites}
+          toggleFavorite={toggleFavorite}
+          highlighted={highlighted}
+          setHighlighted={setHighlighted}
+        />
+      ))}
+    </SidebarContent>
+  );
+}
+

--- a/src/hooks/usePersistedGroups.ts
+++ b/src/hooks/usePersistedGroups.ts
@@ -17,21 +17,21 @@ export function usePersistedGroups(storageKey: string) {
   });
 
   const handleOpenChange = useCallback(
-    (groupLabel: string) => (open: boolean) => {
-      setOpenGroups(() => {
-        const next = open ? { [groupLabel]: true } : {};
-        try {
-          if (typeof window !== "undefined") {
-            localStorage.setItem(storageKey, JSON.stringify(next));
+      (groupLabel: string) => (open: boolean) => {
+        setOpenGroups(() => {
+          const next = { [groupLabel]: open };
+          try {
+            if (typeof window !== "undefined") {
+              localStorage.setItem(storageKey, JSON.stringify(next));
+            }
+          } catch {
+            // ignore
           }
-        } catch {
-          // ignore
-        }
-        return next;
-      });
-    },
-    [storageKey]
-  );
+          return next;
+        });
+      },
+      [storageKey]
+    );
 
   return { openGroups, handleOpenChange } as const;
 }

--- a/src/layouts/SidebarLayout.tsx
+++ b/src/layouts/SidebarLayout.tsx
@@ -1,73 +1,26 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
 import {
   SidebarProvider,
   Sidebar,
   SidebarHeader,
   SidebarFooter,
-  SidebarContent,
   SidebarTrigger,
   SidebarInset,
 } from "@/ui/sidebar";
-import NavSection from "@/components/nav-section";
-import { dashboardRoutes } from "@/routes";
-import useNavigationFavorites from "@/hooks/useNavigationFavorites";
-import useNavigationRecent from "@/hooks/useNavigationRecent";
+import SidebarNavigation from "@/components/layout/sidebar-navigation";
 
 interface SidebarLayoutProps {
   children: React.ReactNode;
 }
 
 export default function SidebarLayout({ children }: SidebarLayoutProps) {
-  const location = useLocation();
-  const allRoutes = React.useMemo(
-    () => dashboardRoutes.flatMap((g) => g.items),
-    []
-  );
-  const { favorites, favoriteRoutes, toggleFavorite } =
-    useNavigationFavorites(allRoutes);
-  const { recentRoutes } = useNavigationRecent(allRoutes);
-  const [highlighted, setHighlighted] = React.useState<string | null>(null);
-
   return (
     <SidebarProvider>
       <Sidebar>
         <SidebarHeader>
           <SidebarTrigger />
         </SidebarHeader>
-        <SidebarContent>
-          {favoriteRoutes.length > 0 && (
-            <NavSection
-              label="Favorites"
-              routes={favoriteRoutes}
-              pathname={location.pathname}
-              favorites={favorites}
-              toggleFavorite={toggleFavorite}
-              highlighted={highlighted}
-              setHighlighted={setHighlighted}
-            />
-          )}
-          {recentRoutes.length > 0 && (
-            <NavSection
-              label="Recent"
-              routes={recentRoutes}
-              pathname={location.pathname}
-              favorites={favorites}
-              toggleFavorite={toggleFavorite}
-              highlighted={highlighted}
-              setHighlighted={setHighlighted}
-            />
-          )}
-          <NavSection
-            label="All"
-            groups={dashboardRoutes}
-            pathname={location.pathname}
-            favorites={favorites}
-            toggleFavorite={toggleFavorite}
-            highlighted={highlighted}
-            setHighlighted={setHighlighted}
-          />
-        </SidebarContent>
+        <SidebarNavigation />
         <SidebarFooter />
       </Sidebar>
       <SidebarInset>{children}</SidebarInset>

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,3 +13,15 @@ if (typeof globalThis.URL.createObjectURL === 'undefined') {
 if (typeof Element.prototype.scrollIntoView !== 'function') {
   Element.prototype.scrollIntoView = () => {}
 }
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  // Simple matchMedia polyfill for tests
+  window.matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }) as any
+}


### PR DESCRIPTION
## Summary
- add `SidebarNavigation` component to render route groups with favorites
- embed `SidebarNavigation` in `SidebarLayout`
- persist sidebar group state and add unit tests

## Testing
- `npx vitest run src/components/layout/__tests__/sidebar-navigation.test.tsx`
- `npm test` *(fails: Dashboard renders nested routes; TrainingEntropyHeatmap tests)*

------
https://chatgpt.com/codex/tasks/task_e_6891173e9d248324b5be0936cadd60da