### PR TITLE
feat: add timeframe filter for training consistency

### DIFF
--- a/src/components/trends/HabitConsistencyHeatmap.tsx
+++ b/src/components/trends/HabitConsistencyHeatmap.tsx
@@ -13,8 +13,12 @@ function getHourLabel(hour: number) {
 
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
-export default function HabitConsistencyHeatmap() {
-  const { data, error } = useTrainingConsistency()
+export default function HabitConsistencyHeatmap({
+  timeframe,
+}: {
+  timeframe?: string
+}) {
+  const { data, error } = useTrainingConsistency(timeframe)
 
   if (error)
     return (

--- a/src/hooks/__tests__/useTrainingConsistency.test.ts
+++ b/src/hooks/__tests__/useTrainingConsistency.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import useTrainingConsistency from "../useTrainingConsistency"
+import * as api from "@/lib/api"
+import type { RunningSession } from "@/lib/api"
+
+describe("useTrainingConsistency", () => {
+  it("filters sessions by timeframe", async () => {
+    const baseSession = {
+      pace: 6,
+      duration: 30,
+      heartRate: 130,
+      lat: 0,
+      lon: 0,
+      weather: { temperature: 50, humidity: 40, wind: 0, condition: "Clear" },
+    }
+    const now = Date.now()
+    const recent = new Date(now - 2 * 7 * 24 * 60 * 60 * 1000)
+    const older = new Date(now - 10 * 7 * 24 * 60 * 60 * 1000)
+    const sessions: RunningSession[] = [
+      { id: 1, date: recent.toISOString().slice(0, 10), start: recent.toISOString(), ...baseSession },
+      { id: 2, date: older.toISOString().slice(0, 10), start: older.toISOString(), ...baseSession },
+    ]
+
+    const spy = vi.spyOn(api, "getRunningSessions").mockResolvedValue(sessions)
+
+    const { result } = renderHook(() => useTrainingConsistency("4w"))
+    await waitFor(() => expect(result.current.data).not.toBeNull())
+    expect(result.current.data?.sessions).toHaveLength(1)
+    expect(result.current.data?.sessions[0].id).toBe(1)
+
+    spy.mockRestore()
+  })
+
+  it("includes older sessions for longer timeframe", async () => {
+    const baseSession = {
+      pace: 6,
+      duration: 30,
+      heartRate: 130,
+      lat: 0,
+      lon: 0,
+      weather: { temperature: 50, humidity: 40, wind: 0, condition: "Clear" },
+    }
+    const now = Date.now()
+    const recent = new Date(now - 2 * 7 * 24 * 60 * 60 * 1000)
+    const older = new Date(now - 10 * 7 * 24 * 60 * 60 * 1000)
+    const sessions: RunningSession[] = [
+      { id: 1, date: recent.toISOString().slice(0, 10), start: recent.toISOString(), ...baseSession },
+      { id: 2, date: older.toISOString().slice(0, 10), start: older.toISOString(), ...baseSession },
+    ]
+
+    const spy = vi.spyOn(api, "getRunningSessions").mockResolvedValue(sessions)
+
+    const { result } = renderHook(() => useTrainingConsistency("12w"))
+    await waitFor(() => expect(result.current.data).not.toBeNull())
+    expect(result.current.data?.sessions).toHaveLength(2)
+
+    spy.mockRestore()
+  })
+})
+

--- a/src/pages/HabitConsistency.tsx
+++ b/src/pages/HabitConsistency.tsx
@@ -1,14 +1,26 @@
-import React from "react";
+import React, { useState } from "react";
 import { HabitConsistencyHeatmap } from "@/components/trends";
+import { SimpleSelect } from "@/ui/select";
 
 export default function HabitConsistencyPage() {
+  const [timeframe, setTimeframe] = useState("12w");
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Habit Consistency</h1>
       <p className="text-sm text-muted-foreground">
         Session counts by weekday and hour illustrate your training habits.
       </p>
-      <HabitConsistencyHeatmap />
+      <SimpleSelect
+        label="Timeframe"
+        value={timeframe}
+        onValueChange={setTimeframe}
+        options={[
+          { value: "4w", label: "4 weeks" },
+          { value: "12w", label: "12 weeks" },
+          { value: "all", label: "All time" },
+        ]}
+      />
+      <HabitConsistencyHeatmap timeframe={timeframe} />
     </div>
   );
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,3 +13,14 @@ if (typeof globalThis.URL.createObjectURL === 'undefined') {
 if (typeof Element.prototype.scrollIntoView !== 'function') {
   Element.prototype.scrollIntoView = () => {}
 }
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })
+}


### PR DESCRIPTION
## Summary
- add timeframe support to training consistency hook and heatmap component
- allow selecting timeframe on Habit Consistency page
- test timeframe filtering logic

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689117928f3483248ca094d5dde79d1c