### PR TITLE
feat: add mobile tab bar component

### DIFF
--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+import { cn } from "@/lib/utils";
+
+interface MobileTabBarProps {
+  className?: string;
+}
+
+export default function MobileTabBar({ className }: MobileTabBarProps) {
+  const tabs = React.useMemo(
+    () =>
+      dashboardRoutes.map((group) => ({
+        to: group.items[0]?.to ?? "/dashboard",
+        label: group.label,
+        icon: group.icon,
+      })),
+    []
+  );
+
+  return (
+    <nav
+      className={cn("flex border-t bg-background", className)}
+      role="tablist"
+      aria-label="Dashboard navigation"
+    >
+      {tabs.map((tab) => {
+        const Icon = tab.icon;
+        return (
+          <NavLink
+            key={tab.to}
+            to={tab.to}
+            role="tab"
+            aria-label={tab.label}
+            className={({ isActive }) =>
+              cn(
+                "flex flex-1 flex-col items-center justify-center gap-1 p-2 text-xs",
+                isActive
+                  ? "text-foreground"
+                  : "text-muted-foreground"
+              )
+            }
+          >
+            <Icon className="h-5 w-5" aria-hidden="true" />
+            <span>{tab.label}</span>
+          </NavLink>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/layout/__tests__/mobile-tab-bar.test.tsx
+++ b/src/components/layout/__tests__/mobile-tab-bar.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import MobileTabBar from "../MobileTabBar";
+import { dashboardRoutes } from "@/routes";
+
+describe("MobileTabBar", () => {
+  const firstPath = dashboardRoutes[0].items[0].to;
+  const firstLabel = dashboardRoutes[0].label;
+  const secondPath = dashboardRoutes[1].items[0].to;
+  const secondLabel = dashboardRoutes[1].label;
+
+  it("highlights active tab", () => {
+    render(
+      <MemoryRouter
+        initialEntries={[firstPath]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <MobileTabBar />
+      </MemoryRouter>
+    );
+    const firstTab = screen.getByRole("tab", { name: firstLabel });
+    expect(firstTab).toHaveAttribute("aria-current", "page");
+  });
+
+  it("switches routes on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={[firstPath]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <MobileTabBar />
+        <Routes>
+          <Route path={firstPath} element={<div>First Page</div>} />
+          <Route path={secondPath} element={<div>Second Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole("tab", { name: secondLabel }));
+    expect(screen.getByText("Second Page")).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: secondLabel })
+    ).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/src/layouts/MobileTabLayout.tsx
+++ b/src/layouts/MobileTabLayout.tsx
@@ -1,48 +1,15 @@
 import React from "react";
-import { NavLink } from "react-router-dom";
-import { dashboardRoutes } from "@/routes";
-import { cn } from "@/lib/utils";
+import MobileTabBar from "@/components/layout/MobileTabBar";
 
 interface MobileTabLayoutProps {
   children: React.ReactNode;
 }
 
 export default function MobileTabLayout({ children }: MobileTabLayoutProps) {
-  const tabs = React.useMemo(
-    () =>
-      dashboardRoutes.map((group) => ({
-        to: group.items[0]?.to ?? "/dashboard",
-        label: group.label,
-        icon: group.icon,
-      })),
-    []
-  );
-
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 overflow-auto">{children}</div>
-      <nav className="flex border-t bg-background md:hidden">
-        {tabs.map((tab) => {
-          const Icon = tab.icon;
-          return (
-            <NavLink
-              key={tab.to}
-              to={tab.to}
-              className={({ isActive }) =>
-                cn(
-                  "flex flex-1 flex-col items-center justify-center gap-1 p-2 text-xs",
-                  isActive
-                    ? "text-foreground"
-                    : "text-muted-foreground"
-                )
-              }
-            >
-              <Icon className="h-5 w-5" />
-              <span>{tab.label}</span>
-            </NavLink>
-          );
-        })}
-      </nav>
+      <MobileTabBar className="md:hidden" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extract bottom navigation into new `MobileTabBar`
- use `MobileTabBar` in `MobileTabLayout`
- test mobile tabs highlight and switch routes

## Testing
- `npm test` *(fails: 2 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689119d4ce088324a4144d93d469d109