### PR TITLE
Add fragility index docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ frequency and a weekly entropy trendline.
 ### Analytics fun page
 `src/pages/Examples.tsx` shows sample charts. It now renders an interactive area chart with a time-range select next to the bar chart demos.
 
+### Fragility Index
+The Fragility Index (FI) counts how many outcome flips are needed in a 2×2 trial to turn a statistically significant result non-significant.
+
+- **Low FI** – results hinge on one or two participants and may not be reliable.
+- **High FI** – findings remain significant after several flips, suggesting more robust evidence.
+
+FI grows with sample size and should complement, not replace, reported effect sizes or confidence intervals.
+
 ## Charts & Apps Overview
 
 ### Dashboard

--- a/docs/fragility-examples.md
+++ b/docs/fragility-examples.md
@@ -1,0 +1,21 @@
+# Fragility Index Examples
+
+## Case Study 1: Low FI
+| Outcome | Treatment | Control |
+|---------|-----------|---------|
+| Event   | 10        | 3       |
+| No Event| 10        | 17      |
+
+Fragility Index: **1**
+
+A single outcome flip in the control group (from non-event to event) would make the result non-significant, indicating a fragile finding.
+
+## Case Study 2: Higher FI
+| Outcome | Treatment | Control |
+|---------|-----------|---------|
+| Event   | 13        | 1       |
+| No Event| 7         | 19      |
+
+Fragility Index: **5**
+
+It would take five outcome reversals in the control group to overturn significance, making this result more robust though still dependent on sample size.

--- a/src/pages/ClinicalFragilityDemo.tsx
+++ b/src/pages/ClinicalFragilityDemo.tsx
@@ -5,6 +5,10 @@ export default function ClinicalFragilityDemoPage() {
   return (
     <div className="space-y-4 p-4">
       <h1 className="text-2xl font-bold">Clinical Fragility Demo</h1>
+      <p className="text-sm">
+        Read more in the <a href="/docs/fragility-index.md" className="underline">Fragility Index guide</a> and
+        <a href="/docs/fragility-examples.md" className="underline ml-1">examples</a>.
+      </p>
       <OutcomeFlipSimulator />
     </div>
   )


### PR DESCRIPTION
## Summary
- document fragility index basics in README
- add case study examples for fragility index
- link fragility index docs from demo page

## Testing
- `npm test` *(fails: 2 test files, 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_689119de213c8324a86245c480797a9f