### PR TITLE
feat(nav): add route search bar

### DIFF
--- a/src/components/__tests__/nav-section.test.tsx
+++ b/src/components/__tests__/nav-section.test.tsx
@@ -14,6 +14,7 @@ describe("NavSection contentId", () => {
     toggleFavorite: () => {},
     highlighted: null as string | null,
     setHighlighted: () => {},
+    searchMatches: [] as string[],
   };
 
   const groups = [

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import { dashboardRoutes } from "@/routes";
 import { cn } from "@/lib/utils";
+import SearchBar from "@/components/nav/SearchBar";
 
 interface MobileTabBarProps {
   className?: string;
@@ -14,38 +15,47 @@ export default function MobileTabBar({ className }: MobileTabBarProps) {
         to: group.items[0]?.to ?? "/dashboard",
         label: group.label,
         icon: group.icon,
+        items: group.items,
       })),
     []
   );
+  const allRoutes = React.useMemo(
+    () => dashboardRoutes.flatMap((g) => g.items),
+    []
+  );
+  const [matches, setMatches] = React.useState<string[]>([]);
 
   return (
-    <nav
-      className={cn("flex border-t bg-background", className)}
-      role="tablist"
-      aria-label="Dashboard navigation"
-    >
-      {tabs.map((tab) => {
-        const Icon = tab.icon;
-        return (
-          <NavLink
-            key={tab.to}
-            to={tab.to}
-            role="tab"
-            aria-label={tab.label}
-            className={({ isActive }) =>
-              cn(
-                "flex flex-1 flex-col items-center justify-center gap-1 p-2 text-xs",
-                isActive
-                  ? "text-foreground"
-                  : "text-muted-foreground"
-              )
-            }
-          >
-            <Icon className="h-5 w-5" aria-hidden="true" />
-            <span>{tab.label}</span>
-          </NavLink>
-        );
-      })}
-    </nav>
+    <div className={cn("border-t bg-background", className)}>
+      <SearchBar routes={allRoutes} onResults={setMatches} />
+      <nav role="tablist" aria-label="Dashboard navigation" className="flex">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          const groupMatch = matches.some((m) =>
+            tab.items.some((r) => r.to === m)
+          );
+          return (
+            <NavLink
+              key={tab.to}
+              to={tab.to}
+              role="tab"
+              aria-label={tab.label}
+              className={({ isActive }) =>
+                cn(
+                  "flex flex-1 flex-col items-center justify-center gap-1 p-2 text-xs",
+                  isActive
+                    ? "text-foreground"
+                    : "text-muted-foreground",
+                  groupMatch && "bg-accent text-accent-foreground"
+                )
+              }
+            >
+              <Icon className="h-5 w-5" aria-hidden="true" />
+              <span>{tab.label}</span>
+            </NavLink>
+          );
+        })}
+      </nav>
+    </div>
   );
 }

--- a/src/components/layout/__tests__/mobile-tab-bar.test.tsx
+++ b/src/components/layout/__tests__/mobile-tab-bar.test.tsx
@@ -45,4 +45,22 @@ describe("MobileTabBar", () => {
       screen.getByRole("tab", { name: secondLabel })
     ).toHaveAttribute("aria-current", "page");
   });
+
+  it("highlights tabs from search results", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={[firstPath]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <MobileTabBar />
+      </MemoryRouter>
+    );
+    const input = screen.getByRole("searchbox", { name: /search routes/i });
+    await user.type(input, "fragility");
+    const analyticalTab = screen.getByRole("tab", { name: /Analytical/ });
+    expect(analyticalTab).toHaveClass("bg-accent");
+    await user.clear(input);
+    expect(analyticalTab).not.toHaveClass("bg-accent");
+  });
 });

--- a/src/components/layout/__tests__/sidebar-navigation.test.tsx
+++ b/src/components/layout/__tests__/sidebar-navigation.test.tsx
@@ -61,5 +61,16 @@ describe("SidebarNavigation", () => {
     expect(star).toHaveClass("fill-yellow-400");
     expect(screen.getByText("Favorites")).toBeInTheDocument();
   });
+
+  it("updates highlights based on search", async () => {
+    const user = userEvent.setup();
+    renderWithProviders();
+    const input = screen.getByRole("searchbox", { name: /search routes/i });
+    await user.type(input, "interactive");
+    const link = screen.getByText("State Visits Map").closest("a")!;
+    expect(link).toHaveClass("bg-accent");
+    await user.clear(input);
+    expect(link).not.toHaveClass("bg-accent");
+  });
 });
 

--- a/src/components/layout/sidebar-navigation.tsx
+++ b/src/components/layout/sidebar-navigation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 import NavSection from "@/components/nav-section";
+import SearchBar from "@/components/nav/SearchBar";
 import { SidebarContent } from "@/ui/sidebar";
 import { dashboardRoutes } from "@/routes";
 import useNavigationFavorites from "@/hooks/useNavigationFavorites";
@@ -16,9 +17,11 @@ export default function SidebarNavigation() {
     useNavigationFavorites(allRoutes);
   const { recentRoutes } = useNavigationRecent(allRoutes);
   const [highlighted, setHighlighted] = React.useState<string | null>(null);
+  const [searchMatches, setSearchMatches] = React.useState<string[]>([]);
 
   return (
     <SidebarContent>
+      <SearchBar routes={allRoutes} onResults={setSearchMatches} />
       {favoriteRoutes.length > 0 && (
         <NavSection
           label="Favorites"
@@ -28,6 +31,7 @@ export default function SidebarNavigation() {
           toggleFavorite={toggleFavorite}
           highlighted={highlighted}
           setHighlighted={setHighlighted}
+          searchMatches={searchMatches}
         />
       )}
       {recentRoutes.length > 0 && (
@@ -39,6 +43,7 @@ export default function SidebarNavigation() {
           toggleFavorite={toggleFavorite}
           highlighted={highlighted}
           setHighlighted={setHighlighted}
+          searchMatches={searchMatches}
         />
       )}
       {dashboardRoutes.map((group) => (
@@ -52,6 +57,7 @@ export default function SidebarNavigation() {
           toggleFavorite={toggleFavorite}
           highlighted={highlighted}
           setHighlighted={setHighlighted}
+          searchMatches={searchMatches}
         />
       ))}
     </SidebarContent>

--- a/src/components/nav-section.tsx
+++ b/src/components/nav-section.tsx
@@ -34,6 +34,7 @@ interface NavSectionProps {
   toggleFavorite: (to: string) => void;
   highlighted: string | null;
   setHighlighted: (to: string) => void;
+  searchMatches?: string[];
 }
 
 export default function NavSection({
@@ -46,6 +47,7 @@ export default function NavSection({
   toggleFavorite,
   highlighted,
   setHighlighted,
+  searchMatches = [],
 }: NavSectionProps) {
   const storageKey = `nav_section_state_${label}`;
   const { openGroups, handleOpenChange } = usePersistedGroups(storageKey);
@@ -81,7 +83,8 @@ export default function NavSection({
                           isActive={pathname === route.to}
                           className={cn(
                             "justify-start",
-                            highlighted === route.to &&
+                            (highlighted === route.to ||
+                              searchMatches.includes(route.to)) &&
                               "bg-accent text-accent-foreground"
                           )}
                           onMouseEnter={() => setHighlighted(route.to)}
@@ -170,7 +173,8 @@ export default function NavSection({
                                   isActive={pathname === route.to}
                                   className={cn(
                                     "justify-start",
-                                    highlighted === route.to &&
+                                    (highlighted === route.to ||
+                                      searchMatches.includes(route.to)) &&
                                       "bg-accent text-accent-foreground"
                                   )}
                                   onMouseEnter={() => setHighlighted(route.to)}

--- a/src/components/nav/SearchBar.tsx
+++ b/src/components/nav/SearchBar.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import type { DashboardRoute } from "@/routes";
+
+function fuzzyMatch(query: string, target: string) {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      qi++;
+    }
+  }
+  return qi === q.length;
+}
+
+interface SearchBarProps {
+  routes: DashboardRoute[];
+  onResults: (matches: string[]) => void;
+}
+
+export default function SearchBar({ routes, onResults }: SearchBarProps) {
+  const [query, setQuery] = React.useState("");
+
+  React.useEffect(() => {
+    if (!query) {
+      onResults([]);
+      return;
+    }
+    const matches = routes
+      .filter(
+        (r) =>
+          fuzzyMatch(query, r.label) ||
+          (r.description && fuzzyMatch(query, r.description)) ||
+          r.tags?.some((tag) => fuzzyMatch(query, tag))
+      )
+      .map((r) => r.to);
+    onResults(matches);
+  }, [query, routes, onResults]);
+
+  return (
+    <input
+      type="search"
+      placeholder="Search..."
+      aria-label="Search routes"
+      value={query}
+      onChange={(e) => setQuery(e.target.value)}
+      className="mb-2 w-full rounded-md border bg-background px-2 py-1 text-sm"
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- add fuzzy SearchBar to query route metadata
- highlight search matches in sidebar and mobile tab navigation
- test search result highlighting

## Testing
- `npm test` *(fails: Element type is invalid: expected a string (for built-in components) or a class/function)*

------
https://chatgpt.com/codex/tasks/task_e_68911bfc169083249178931eaa3c5e30