### PR TITLE
refactor: alias recharts tooltip

### DIFF
--- a/src/components/analytical/AvgDailyMileageRadar.tsx
+++ b/src/components/analytical/AvgDailyMileageRadar.tsx
@@ -7,7 +7,7 @@ import {
   PolarAngleAxis,
   PolarRadiusAxis,
   Radar,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartLegend,
   ChartLegendContent,
 } from "@/ui/chart"

--- a/src/components/analytical/CorrelationDetails.tsx
+++ b/src/components/analytical/CorrelationDetails.tsx
@@ -2,7 +2,7 @@
 
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/ui/sheet";
 import { Button } from "@/ui/button";
-import { ChartContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, BarChart, Bar, ResponsiveContainer } from "@/ui/chart";
+import { ChartContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, ChartTooltip as Tooltip, BarChart, Bar, ResponsiveContainer } from "@/ui/chart";
 import { Pin, PinOff } from "lucide-react";
 
 interface TimeseriesPoint {

--- a/src/components/analytical/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/analytical/PerfVsEnvironmentMatrix.tsx
@@ -7,7 +7,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
 } from "@/ui/chart";
 import ChartCard from "@/components/dashboard/ChartCard";
 import { useRunningStats } from "@/hooks/useRunningStats";

--- a/src/components/analytical/SessionDetailDrawer.tsx
+++ b/src/components/analytical/SessionDetailDrawer.tsx
@@ -19,7 +19,7 @@ import {
   YAxis,
   Area,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   type ChartConfig,
 } from "@/ui/chart"
 

--- a/src/components/analytical/TreadmillVsOutdoor.tsx
+++ b/src/components/analytical/TreadmillVsOutdoor.tsx
@@ -4,7 +4,7 @@ import {
   ChartContainer,
   PieChart,
   Pie,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartLegend,
   ResponsiveContainer,
 } from "@/ui/chart"

--- a/src/components/dashboard/ReadingProbabilityTimeline.tsx
+++ b/src/components/dashboard/ReadingProbabilityTimeline.tsx
@@ -9,7 +9,7 @@ import {
   YAxis,
   CartesianGrid,
   ReferenceArea,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart";
 import ChartCard from "./ChartCard";

--- a/src/components/dashboard/RouteNoveltyMap.tsx
+++ b/src/components/dashboard/RouteNoveltyMap.tsx
@@ -16,7 +16,7 @@ import {
   Line,
   XAxis,
   YAxis,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   Area,
   ReferenceLine,
   ReferenceArea,

--- a/src/components/dashboard/TimeInBedChart.tsx
+++ b/src/components/dashboard/TimeInBedChart.tsx
@@ -8,7 +8,7 @@ import {
   CartesianGrid,
   YAxis,
   ReferenceLine,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from '@/ui/chart'
 import ChartCard from './ChartCard'

--- a/src/components/dashboard/TrainingEntropyHeatmap.tsx
+++ b/src/components/dashboard/TrainingEntropyHeatmap.tsx
@@ -1,6 +1,6 @@
 "use client";
 import ChartCard from "./ChartCard";
-import { ChartContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip as ChartTooltip } from "@/ui/chart";
+import { ChartContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, ChartTooltip } from "@/ui/chart";
 import { Skeleton } from "@/ui/skeleton";
 import useTrainingConsistency from "@/hooks/useTrainingConsistency";
 import {

--- a/src/components/dashboard/WeeklyVolumeChart.tsx
+++ b/src/components/dashboard/WeeklyVolumeChart.tsx
@@ -6,7 +6,7 @@ import {
   XAxis,
   CartesianGrid,
   Brush,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
 } from "@/ui/chart";
 import ChartCard from "./ChartCard";
 import type { ChartConfig } from "@/ui/chart";

--- a/src/components/examples/AreaChartLoadRatio.tsx
+++ b/src/components/examples/AreaChartLoadRatio.tsx
@@ -9,7 +9,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
   ReferenceArea,
   ReferenceLine,

--- a/src/components/examples/BarChartExamples.tsx
+++ b/src/components/examples/BarChartExamples.tsx
@@ -5,7 +5,7 @@ import {
   Bar,
   XAxis,
   YAxis,
-  Tooltip,
+  ChartTooltip as Tooltip,
   CartesianGrid,
   ChartLegend,
   ChartLegendContent,

--- a/src/components/examples/PerfVsEnvironmentMatrix.tsx
+++ b/src/components/examples/PerfVsEnvironmentMatrix.tsx
@@ -9,7 +9,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart";
 import ChartCard from "@/components/dashboard/ChartCard";

--- a/src/components/examples/ScatterChartPaceHeartRate.tsx
+++ b/src/components/examples/ScatterChartPaceHeartRate.tsx
@@ -9,7 +9,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart";
 import {

--- a/src/components/examples/TreadmillVsOutdoor.tsx
+++ b/src/components/examples/TreadmillVsOutdoor.tsx
@@ -10,7 +10,7 @@ import {
   CartesianGrid,
   ChartLegend,
   ChartLegendContent,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from '@/ui/chart'
 import {

--- a/src/components/examples/WeeklyVolumeHistoryChart.tsx
+++ b/src/components/examples/WeeklyVolumeHistoryChart.tsx
@@ -6,7 +6,7 @@ import {
   Bar,
   XAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from '@/ui/chart'
 import Slider from '@/ui/slider'

--- a/src/components/maps/GoodDayMap.tsx
+++ b/src/components/maps/GoodDayMap.tsx
@@ -7,7 +7,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,

--- a/src/components/maps/SessionSimilarityMap.tsx
+++ b/src/components/maps/SessionSimilarityMap.tsx
@@ -7,7 +7,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartLegend,
   ChartLegendContent,
 } from "@/ui/chart"

--- a/src/components/trends/ActivityByTime.tsx
+++ b/src/components/trends/ActivityByTime.tsx
@@ -7,7 +7,7 @@ import {
   PolarAngleAxis,
   PolarRadiusAxis,
   Radar,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
   ChartTooltipContent,
 } from "@/ui/chart"
 import ChartCard from "@/components/dashboard/ChartCard"

--- a/src/components/trends/FocusTimeline.tsx
+++ b/src/components/trends/FocusTimeline.tsx
@@ -6,7 +6,7 @@ import {
   YAxis,
   ReferenceArea,
   ReferenceDot,
-  Tooltip,
+  ChartTooltip as Tooltip,
   ChartContainer,
 } from "@/ui/chart";
 import useLowEndDevice from "@/hooks/useLowEndDevice";

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -20,7 +20,7 @@ export {
   PolarRadiusAxis,
   CartesianGrid,
   Brush,
-  Tooltip,
+  Tooltip as RechartsTooltip,
   ReferenceLine,
   ReferenceArea,
   ReferenceDot,

--- a/src/pages/HabitConsistency.tsx
+++ b/src/pages/HabitConsistency.tsx
@@ -9,7 +9,7 @@ import {
   CartesianGrid,
   XAxis,
   YAxis,
-  Tooltip as ChartTooltip,
+  ChartTooltip,
 } from "@/ui/chart";
 
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];


### PR DESCRIPTION
## Summary
- avoid UI tooltip collisions by aliasing Recharts `Tooltip` as `RechartsTooltip`
- update chart imports to use `ChartTooltip` or alias it explicitly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689122359a608324a1bcde2a9477bd1c