### PR TITLE
Add timeframe filter for habit consistency heatmap

### DIFF
--- a/src/components/trends/HabitConsistencyHeatmap.tsx
+++ b/src/components/trends/HabitConsistencyHeatmap.tsx
@@ -14,8 +14,10 @@ const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
 export default function HabitConsistencyHeatmap({
   heatmap,
+  timeframe,
 }: {
   heatmap: TrainingHeatmapCell[]
+  timeframe: string
 }) {
 
   const grid = Array.from({ length: 24 }, () =>
@@ -31,7 +33,9 @@ export default function HabitConsistencyHeatmap({
     return (
       <ChartCard
         title="Habit Consistency"
-        description="Session count by weekday and hour"
+        description={`Session count by weekday and hour${
+          timeframe !== 'all' ? ` (last ${timeframe})` : ''
+        }`}
       >
         <div className="flex flex-col items-center justify-center gap-4 h-64 md:h-80 lg:h-96 text-sm text-muted-foreground text-center">
           <p>No session data yet.</p>
@@ -46,7 +50,9 @@ export default function HabitConsistencyHeatmap({
   return (
     <ChartCard
       title="Habit Consistency"
-      description="Session count by weekday and hour"
+      description={`Session count by weekday and hour${
+        timeframe !== 'all' ? ` (last ${timeframe})` : ''
+      }`}
     >
       <ChartContainer config={{}} className="h-64 md:h-80 lg:h-96">
         <div className="flex h-full flex-col">

--- a/src/hooks/__tests__/useTrainingConsistency.test.ts
+++ b/src/hooks/__tests__/useTrainingConsistency.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect } from 'vitest'
-import {
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import useTrainingConsistency, {
   computeConsistencyScore,
   computeMostConsistentDay,
   computePreferredTrainingHour,
 } from '../useTrainingConsistency'
 import type { RunningSession } from '@/lib/api'
+import { getRunningSessions } from '@/lib/api'
+
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  getRunningSessions: vi.fn(),
+}))
 
 describe('training consistency metrics', () => {
   const sessions: RunningSession[] = [
@@ -60,5 +67,46 @@ describe('training consistency metrics', () => {
 
   it('finds preferred training hour', () => {
     expect(computePreferredTrainingHour(sessions)).toBe(6)
+  })
+})
+
+describe('useTrainingConsistency timeframe filtering', () => {
+  it('filters sessions based on timeframe', async () => {
+    const now = new Date()
+    const createSession = (offset: number): RunningSession => {
+      const d = new Date(now)
+      d.setDate(d.getDate() - offset)
+      return {
+        id: offset,
+        pace: 6,
+        duration: 30,
+        heartRate: 130,
+        date: d.toISOString().slice(0, 10),
+        start: d.toISOString(),
+        lat: 0,
+        lon: 0,
+        weather: { temperature: 0, humidity: 0, wind: 0, condition: '' },
+      }
+    }
+    const mockSessions: RunningSession[] = [
+      createSession(4),
+      createSession(17),
+      createSession(40),
+    ]
+    ;(getRunningSessions as any).mockResolvedValue(mockSessions)
+
+    const { result, rerender } = renderHook(({ tf }) => useTrainingConsistency(tf), {
+      initialProps: { tf: '30d' },
+    })
+
+    await waitFor(() => expect(result.current.data).not.toBeNull())
+    expect(result.current.data?.sessions.length).toBe(2)
+
+    rerender({ tf: '7d' })
+    await waitFor(() =>
+      result.current.data?.sessions.length !== undefined &&
+      result.current.data.sessions.length < 2,
+    )
+    expect(result.current.data?.sessions.length).toBe(1)
   })
 })

--- a/src/pages/HabitConsistency.tsx
+++ b/src/pages/HabitConsistency.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { HabitConsistencyHeatmap } from "@/components/trends";
 import useTrainingConsistency from "@/hooks/useTrainingConsistency";
 import { Skeleton } from "@/ui/skeleton";
+import { SimpleSelect } from "@/ui/select";
 import {
   ChartContainer,
   LineChart,
@@ -15,7 +16,8 @@ import {
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export default function HabitConsistencyPage() {
-  const { data, error } = useTrainingConsistency();
+  const [timeframe, setTimeframe] = React.useState("30d");
+  const { data, error } = useTrainingConsistency(timeframe);
 
   if (error) {
     return (
@@ -53,6 +55,17 @@ export default function HabitConsistencyPage() {
       <p className="text-sm text-muted-foreground">
         Session counts by weekday and hour illustrate your training habits.
       </p>
+      <SimpleSelect
+        value={timeframe}
+        onValueChange={(v) => setTimeframe(v)}
+        options={[
+          { value: "7d", label: "Last 7 days" },
+          { value: "30d", label: "Last 30 days" },
+          { value: "90d", label: "Last 90 days" },
+          { value: "all", label: "All time" },
+        ]}
+        label="Timeframe"
+      />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>Consistency Score: {data.consistencyScore.toFixed(2)}</div>
         <div>Most Consistent Day: {dayLabels[data.mostConsistentDay]}</div>
@@ -61,7 +74,7 @@ export default function HabitConsistencyPage() {
           {data.preferredTrainingHour.toString().padStart(2, "0")}:00
         </div>
       </div>
-      <HabitConsistencyHeatmap heatmap={data.heatmap} />
+      <HabitConsistencyHeatmap heatmap={data.heatmap} timeframe={timeframe} />
       <ChartContainer config={{}} className="h-32">
         <LineChart
           data={consistencySeries}


### PR DESCRIPTION
## Summary
- add timeframe filtering to `useTrainingConsistency`
- allow selecting timeframe on HabitConsistency page
- update HabitConsistencyHeatmap to display timeframe
- test filtering for different timeframes

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891200acb5c8324ab5dae0c66fc4b85