### PR TITLE
feat: add session timeline and stability

### DIFF
--- a/src/components/analytical/__tests__/SessionDetailDrawer.test.tsx
+++ b/src/components/analytical/__tests__/SessionDetailDrawer.test.tsx
@@ -41,6 +41,7 @@ const baseSession: SessionPoint = {
   lon: 0,
   condition: 'Clear',
   start: '2024-01-01T08:00:00Z',
+  startTs: new Date('2024-01-01T08:00:00Z').getTime(),
   tags: [],
   isFalsePositive: false,
   factors: [

--- a/src/components/maps/ClusterCard.tsx
+++ b/src/components/maps/ClusterCard.tsx
@@ -24,6 +24,7 @@ import * as React from "react";
 interface ClusterCardProps {
   data: any[];
   color: string;
+  stability?: number;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   onSelect?: () => void;
@@ -50,6 +51,7 @@ function getAnnotation(avgTemp: number, avgStart: number) {
 export default function ClusterCard({
   data,
   color,
+  stability,
   open,
   onOpenChange,
   onSelect,
@@ -72,6 +74,7 @@ export default function ClusterCard({
             <CardTitle className="text-sm">{annotation}</CardTitle>
             <CardDescription className="text-xs">
               Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
+              {stability !== undefined && ` · Stability ${stability.toFixed(2)}`}
             </CardDescription>
           </CardHeader>
           <CardContent className="p-4 pt-0">

--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -33,6 +33,8 @@ export interface SessionPoint {
   condition: string
   /** ISO timestamp when the session started */
   start: string
+  /** Numeric timestamp for efficient comparisons */
+  startTs: number
   tags: string[]
   isFalsePositive: boolean
   factors: SessionFactor[]
@@ -222,6 +224,7 @@ export function useRunningSessions(): {
             lon: session.lon,
             condition: session.weather.condition,
             start: session.start ?? session.date,
+            startTs: new Date(session.start ?? session.date).getTime(),
             tags: meta.tags,
             isFalsePositive: meta.isFalsePositive,
             factors,


### PR DESCRIPTION
## Summary
- track session start timestamps with numeric form
- add timeline playback to session similarity map
- show cluster stability from rolling centroid variance

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68912997f0f88324aa839f51749e4628