### PR TITLE
test: add kindle service tests

### DIFF
--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -1,0 +1,28 @@
+/* @vitest-environment node */
+import request from 'supertest';
+import app from '../app';
+import { describe, it, expect } from 'vitest';
+
+describe('GET /api/kindle', () => {
+  it('returns events data', async () => {
+    const res = await request(app).get('/api/kindle/events');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('Timestamp');
+    expect(res.body[0]).toHaveProperty('Activity');
+  });
+
+  it('returns points data', async () => {
+    const res = await request(app).get('/api/kindle/points');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('Available Balance (Points)');
+    expect(res.body).toHaveProperty('Marketplace');
+  });
+
+  it('returns achievements data', async () => {
+    const res = await request(app).get('/api/kindle/achievements');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('AchievementName');
+  });
+});

--- a/server/services/kindleService.test.js
+++ b/server/services/kindleService.test.js
@@ -1,0 +1,45 @@
+/* @vitest-environment node */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import { getEvents, getPoints, getAchievements } from './kindleService';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('kindleService', () => {
+  it('getEvents parses CSV into array of records', () => {
+    const csv = 'Timestamp,Activity\n2025-01-01T00:00:00Z,OPENED';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(csv);
+    const result = getEvents();
+    expect(result).toEqual([
+      { Timestamp: '2025-01-01T00:00:00Z', Activity: 'OPENED' },
+    ]);
+  });
+
+  it('getPoints returns first row as object', () => {
+    const csv = 'Available Balance (Points),Marketplace,Pending Balance (Points)\n10,www.amazon.com,0';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(csv);
+    const result = getPoints();
+    expect(result).toEqual({
+      'Available Balance (Points)': '10',
+      Marketplace: 'www.amazon.com',
+      'Pending Balance (Points)': '0',
+    });
+  });
+
+  it('getAchievements parses CSV into array', () => {
+    const csv = 'AchievementGroupName,AchievementName,EarnDate,Marketplace,Quantity\nGroup,Gold,2024-01-01Z,www.amazon.com,1';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(csv);
+    const result = getAchievements();
+    expect(result).toEqual([
+      {
+        AchievementGroupName: 'Group',
+        AchievementName: 'Gold',
+        EarnDate: '2024-01-01Z',
+        Marketplace: 'www.amazon.com',
+        Quantity: '1',
+      },
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,8 @@
     ]
   },
   "include": [
-    "src"
+    "src",
+    "server"
   ],
   "references": [
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './vitest.setup.ts',
+    include: [
+      'src/**/*.{test,spec}.{js,ts,jsx,tsx}',
+      'server/**/*.{test,spec}.js',
+    ],
   },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -10,8 +10,11 @@ if (typeof globalThis.URL.createObjectURL === 'undefined') {
   globalThis.URL.createObjectURL = () => ''
 }
 
-if (typeof Element.prototype.scrollIntoView !== 'function') {
-  Element.prototype.scrollIntoView = () => {}
+if (
+  typeof globalThis.Element !== 'undefined' &&
+  typeof globalThis.Element.prototype.scrollIntoView !== 'function'
+) {
+  globalThis.Element.prototype.scrollIntoView = () => {}
 }
 
 if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {


### PR DESCRIPTION
## Summary
- add unit tests for Kindle service functions with mocked CSV data
- integration tests for Kindle API routes using supertest
- configure Vitest to include server tests and support Node environment

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68912ef321ec83248b5597b2eaebf69c