### PR TITLE
Add session timeline playback and cluster stability

### DIFF
--- a/src/components/maps/ClusterCard.tsx
+++ b/src/components/maps/ClusterCard.tsx
@@ -22,11 +22,12 @@ import {
 import * as React from "react";
 
 interface ClusterCardProps {
-  data: any[];
-  color: string;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  onSelect?: () => void;
+  data: any[]
+  color: string
+  stability: number
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  onSelect?: () => void
 }
 
 function getAnnotation(avgTemp: number, avgStart: number) {
@@ -50,6 +51,7 @@ function getAnnotation(avgTemp: number, avgStart: number) {
 export default function ClusterCard({
   data,
   color,
+  stability,
   open,
   onOpenChange,
   onSelect,
@@ -71,7 +73,8 @@ export default function ClusterCard({
           <CardHeader className="p-4 pb-2">
             <CardTitle className="text-sm">{annotation}</CardTitle>
             <CardDescription className="text-xs">
-              Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
+              Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h ·
+              Stability {(stability * 100).toFixed(0)}%
             </CardDescription>
           </CardHeader>
           <CardContent className="p-4 pt-0">
@@ -91,7 +94,8 @@ export default function ClusterCard({
       <DialogContent className="sm:max-w-md">
         <h3 className="mb-2 text-lg font-semibold">{annotation}</h3>
         <p className="text-sm text-muted-foreground mb-4">
-          Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h
+          Avg temp {avgTemp.toFixed(1)}°F · Start {avgStart.toFixed(0)}h ·
+          Stability {(stability * 100).toFixed(0)}%
         </p>
         <ChartContainer className="h-48 w-full" config={{}}>
           <ScatterChart>

--- a/src/lib/__tests__/clusterStability.test.ts
+++ b/src/lib/__tests__/clusterStability.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { computeClusterStability } from "../clusterStability";
+
+describe("computeClusterStability", () => {
+  it("gives higher score to clusters with stable centroids", () => {
+    const stable: any[] = [
+      { cluster: 0, x: 0, y: 0, start: "2024-01-01" },
+      { cluster: 0, x: 0.1, y: -0.1, start: "2024-01-02" },
+      { cluster: 0, x: -0.1, y: 0.1, start: "2024-01-03" },
+      { cluster: 0, x: 0.05, y: -0.05, start: "2024-01-04" },
+      { cluster: 0, x: -0.05, y: 0.05, start: "2024-01-05" },
+    ];
+    const unstable: any[] = [
+      { cluster: 1, x: 0, y: 0, start: "2024-01-01" },
+      { cluster: 1, x: 5, y: 5, start: "2024-01-02" },
+      { cluster: 1, x: -5, y: -5, start: "2024-01-03" },
+      { cluster: 1, x: 5, y: -5, start: "2024-01-04" },
+      { cluster: 1, x: -5, y: 5, start: "2024-01-05" },
+    ];
+    const res = computeClusterStability([...stable, ...unstable], 3);
+    expect(res[0]).toBeGreaterThan(res[1]);
+  });
+});

--- a/src/lib/clusterStability.ts
+++ b/src/lib/clusterStability.ts
@@ -1,0 +1,42 @@
+import { SessionPoint } from "@/hooks/useRunningSessions";
+
+/**
+ * Compute a stability score for each cluster based on rolling variance of its centroid.
+ * Lower variance -> higher stability. Score is 1 / (1 + variance).
+ */
+export function computeClusterStability(
+  points: SessionPoint[],
+  window = 5,
+): Record<number, number> {
+  const byCluster: Record<number, SessionPoint[]> = {};
+  for (const p of points) {
+    if (!byCluster[p.cluster]) byCluster[p.cluster] = [];
+    byCluster[p.cluster].push(p);
+  }
+
+  const result: Record<number, number> = {};
+  for (const key in byCluster) {
+    const pts = byCluster[key].slice().sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
+    const centroids: [number, number][] = [];
+    for (let i = 0; i < pts.length; i++) {
+      const startIdx = Math.max(0, i - window + 1);
+      const subset = pts.slice(startIdx, i + 1);
+      const cx = subset.reduce((s, p) => s + p.x, 0) / subset.length;
+      const cy = subset.reduce((s, p) => s + p.y, 0) / subset.length;
+      centroids.push([cx, cy]);
+    }
+    const meanCx = centroids.reduce((s, c) => s + c[0], 0) / centroids.length;
+    const meanCy = centroids.reduce((s, c) => s + c[1], 0) / centroids.length;
+    const variance =
+      centroids.reduce(
+        (s, [cx, cy]) => s + (cx - meanCx) ** 2 + (cy - meanCy) ** 2,
+        0,
+      ) / centroids.length;
+    result[Number(key)] = 1 / (1 + variance);
+  }
+  return result;
+}
+
+export default computeClusterStability;


### PR DESCRIPTION
## Summary
- add timeline scrubber with playback controls to session similarity map
- calculate rolling centroid variance to score cluster stability
- surface stability metric in cluster detail cards

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6891308d06cc8324b8f1fe7c2215b704