### PR TITLE
feat: add dashboard favorites quick links

### DIFF
--- a/src/components/dashboard/FavoriteVisualizations.tsx
+++ b/src/components/dashboard/FavoriteVisualizations.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Card } from "@/ui/card";
+import { dashboardRoutes } from "@/routes";
+import useNavigationFavorites from "@/hooks/useNavigationFavorites";
+
+/**
+ * Displays quick links to pinned dashboard visualizations.
+ *
+ * Uses the `useNavigationFavorites` hook to read the user's list of
+ * favorite routes and renders them as a simple list of links. When there
+ * are no favorites the component renders nothing.
+ */
+export default function FavoriteVisualizations() {
+  const allRoutes = React.useMemo(
+    () => dashboardRoutes.flatMap((group) => group.items),
+    [],
+  );
+  const { favoriteRoutes } = useNavigationFavorites(allRoutes);
+
+  if (favoriteRoutes.length === 0) return null;
+
+  return (
+    <Card className="p-4 space-y-2">
+      <h2 className="text-lg font-semibold">Pinned Visualizations</h2>
+      <ul className="space-y-1">
+        {favoriteRoutes.map((route) => (
+          <li key={route.to}>
+            <Link
+              to={route.to}
+              className="flex items-center gap-2 text-sm text-blue-600 hover:underline"
+            >
+              <route.icon className="h-4 w-4" />
+              {route.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+

--- a/src/components/dashboard/__tests__/FavoriteVisualizations.test.tsx
+++ b/src/components/dashboard/__tests__/FavoriteVisualizations.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { vi } from "vitest";
+import "@testing-library/jest-dom";
+import { Star } from "lucide-react";
+import FavoriteVisualizations from "../FavoriteVisualizations";
+
+vi.mock("@/hooks/useNavigationFavorites", () => ({
+  __esModule: true,
+  default: () => ({
+    favoriteRoutes: [
+      { to: "/foo", label: "Foo", description: "", icon: Star },
+    ],
+  }),
+}));
+
+describe("FavoriteVisualizations", () => {
+  it("renders favorite links", () => {
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <FavoriteVisualizations />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole("link", { name: "Foo" });
+    expect(link).toHaveAttribute("href", "/foo");
+  });
+});
+

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -42,4 +42,6 @@ export { default as RouteNoveltyMap } from "./RouteNoveltyMap";
 export { default as SocialEngagementCard } from "./SocialEngagementCard";
 export { default as MapView } from "./MapView";
 
+export { default as FavoriteVisualizations } from "./FavoriteVisualizations";
+
 

--- a/src/pages/DashboardLanding.tsx
+++ b/src/pages/DashboardLanding.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { BehavioralWeatherWidget, DeltaSpotlightTiles } from "@/components/dashboard";
+import {
+  BehavioralWeatherWidget,
+  DeltaSpotlightTiles,
+  FavoriteVisualizations,
+} from "@/components/dashboard";
 import useTopMetricChanges from "@/hooks/useTopMetricChanges";
 
 export default function DashboardLanding() {
   const topChanges = useTopMetricChanges();
   return (
     <div className="space-y-6 p-6">
+      <FavoriteVisualizations />
       <BehavioralWeatherWidget />
       <DeltaSpotlightTiles metrics={topChanges} />
     </div>


### PR DESCRIPTION
## Summary
- add FavoriteVisualizations component to show pinned routes
- surface favorites on dashboard landing
- test favorites rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911fccfcd88324b71d7603612e6ec1