### PR TITLE
Add daily reading stats heatmap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "lucide-react": "^0.534.0",
         "maplibre-gl": "^3.6.0",
         "react": "^18.2.0",
+        "react-calendar-heatmap": "^1.10.0",
         "react-dom": "^18.2.0",
         "react-map-gl": "^8.0.4",
         "react-router-dom": "^6.22.2",
@@ -7570,6 +7571,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -8416,6 +8423,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar-heatmap": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-calendar-heatmap/-/react-calendar-heatmap-1.10.0.tgz",
+      "integrity": "sha512-e5vcrzMWzKIF710egr1FpjWyuDEFeZm39nvV25muc8Wtqqi8iDOfqREELeQ9Wouqf9hhj939gq0i+iAxo7KdSw==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lucide-react": "^0.534.0",
     "maplibre-gl": "^3.6.0",
     "react": "^18.2.0",
+    "react-calendar-heatmap": "^1.10.0",
     "react-dom": "^18.2.0",
     "react-map-gl": "^8.0.4",
     "react-router-dom": "^6.22.2",

--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -3,6 +3,7 @@ const {
   getEvents,
   getPoints,
   getAchievements,
+  getDailyStats,
 } = require('../services/kindleService');
 
 const router = express.Router();
@@ -28,6 +29,14 @@ router.get('/achievements', (req, res) => {
     res.json(getAchievements());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load achievements' });
+  }
+});
+
+router.get('/daily-stats', (req, res) => {
+  try {
+    res.json(getDailyStats());
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load daily stats' });
   }
 });
 

--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -25,4 +25,12 @@ describe('GET /api/kindle', () => {
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0]).toHaveProperty('AchievementName');
   });
+
+  it('returns daily stats data', async () => {
+    const res = await request(app).get('/api/kindle/daily-stats');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('date');
+    expect(res.body[0]).toHaveProperty('minutes');
+  });
 });

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { aggregateDailyReading } = require('../../src/services/readingStats');
 
 function parseCsv(filePath) {
   const content = fs.readFileSync(filePath, 'utf-8').trim();
@@ -63,9 +64,25 @@ function getAchievements() {
   return parseCsv(filePath);
 }
 
+function getDailyStats() {
+  const filePath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'data',
+    'kindle',
+    'Kindle',
+    'Kindle.Devices.ReadingSession',
+    'Kindle.Devices.ReadingSession.csv',
+  );
+  const rows = parseCsv(filePath);
+  return aggregateDailyReading(rows);
+}
+
 module.exports = {
   getEvents,
   getPoints,
   getAchievements,
+  getDailyStats,
 };
 

--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Heatmap from 'react-calendar-heatmap';
+import 'react-calendar-heatmap/dist/styles.css';
+import useDailyReading from '@/hooks/useDailyReading';
+
+export default function CalendarHeatmap() {
+  const { data } = useDailyReading();
+  if (!data || data.length === 0) return null;
+  const dates = data.map((d) => new Date(d.date));
+  const startDate = new Date(Math.min(...dates));
+  const endDate = new Date(Math.max(...dates));
+  const values = data.map((d) => ({ date: d.date, count: d.minutes }));
+  return <Heatmap startDate={startDate} endDate={endDate} values={values} />;
+}

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import CalendarHeatmap from '../CalendarHeatmap';
+
+vi.mock('@/hooks/useDailyReading', () => ({
+  __esModule: true,
+  default: () => ({
+    data: [
+      { date: '2024-01-01', minutes: 5, pages: 2 },
+      { date: '2024-01-02', minutes: 10, pages: 4 },
+    ],
+    error: null,
+    isLoading: false,
+  }),
+}));
+
+describe('CalendarHeatmap', () => {
+  it('renders heatmap cells', () => {
+    const { container } = render(<CalendarHeatmap />);
+    const svg = container.querySelector('svg.react-calendar-heatmap');
+    expect(svg).not.toBeNull();
+  });
+});

--- a/src/hooks/useDailyReading.js
+++ b/src/hooks/useDailyReading.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import { getDailyReadingStats } from '@/lib/api';
+
+export default function useDailyReading() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getDailyReadingStats()
+      .then(setData)
+      .catch(setError);
+  }, []);
+
+  return { data, error, isLoading: !data && !error };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1662,6 +1662,18 @@ export async function getReadingMediumTotals(): Promise<ReadingMediumTotal[]> {
   });
 }
 
+export interface DailyReadingStat {
+  date: string;
+  minutes: number;
+  pages: number;
+}
+
+export async function getDailyReadingStats(): Promise<DailyReadingStat[]> {
+  const res = await fetch('/api/kindle/daily-stats');
+  if (!res.ok) throw new Error('Failed to fetch daily stats');
+  return res.json();
+}
+
 // ----- Focus sessions -----
 
 export type FocusLabel = "Deep Dive" | "Skim" | "Page Turn Panic";

--- a/src/services/__tests__/readingStats.test.js
+++ b/src/services/__tests__/readingStats.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateDailyReading } from '../readingStats';
+
+describe('aggregateDailyReading', () => {
+  it('aggregates minutes and pages per day', () => {
+    const sessions = [
+      { start_timestamp: '2024-01-01T00:00:00Z', total_reading_millis: '600000', number_of_page_flips: '10' },
+      { start_timestamp: '2024-01-01T01:00:00Z', total_reading_millis: '300000', number_of_page_flips: '5' },
+      { start_timestamp: '2024-01-02T00:00:00Z', total_reading_millis: '120000', number_of_page_flips: '2' },
+    ];
+    const result = aggregateDailyReading(sessions);
+    expect(result).toEqual([
+      { date: '2024-01-01', minutes: 15, pages: 15 },
+      { date: '2024-01-02', minutes: 2, pages: 2 },
+    ]);
+  });
+});

--- a/src/services/readingStats.js
+++ b/src/services/readingStats.js
@@ -1,0 +1,20 @@
+function aggregateDailyReading(sessions) {
+  const totals = {};
+  for (const s of sessions) {
+    const ts = s.start_timestamp && s.start_timestamp !== 'Not Available'
+      ? s.start_timestamp
+      : s.end_timestamp;
+    if (!ts || ts === 'Not Available') continue;
+    const date = ts.slice(0, 10);
+    const minutes = Number(s.total_reading_millis || 0) / 60000;
+    const pages = Number(s.number_of_page_flips || 0);
+    if (!totals[date]) {
+      totals[date] = { date, minutes: 0, pages: 0 };
+    }
+    totals[date].minutes += minutes;
+    totals[date].pages += pages;
+  }
+  return Object.values(totals).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+module.exports = { aggregateDailyReading };


### PR DESCRIPTION
## Summary
- aggregate Kindle reading sessions into daily minutes and pages
- expose `/api/kindle/daily-stats` and client hook for fetching aggregates
- render daily totals with a calendar heatmap

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68913375521083249c470c59783aefb1