### PR TITLE
fix: correct PaceDeltaHistogram import path

### DIFF
--- a/src/components/maps/GoodDayMap.tsx
+++ b/src/components/maps/GoodDayMap.tsx
@@ -24,7 +24,7 @@ import { useEffect, useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import { symbol, symbolStar } from "d3-shape"
 import SessionDetailDrawer from "@/components/analytical/SessionDetailDrawer"
-import PaceDeltaHistogram from "./PaceDeltaHistogram"
+import PaceDeltaHistogram from "@/components/analytical/PaceDeltaHistogram"
 
 interface GoodDayMapProps {
   data: SessionPoint[] | null


### PR DESCRIPTION
## Summary
- fix incorrect relative import for `PaceDeltaHistogram`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68913a723fa483248ea909a88ea054fa