### PR TITLE
Add reading sessions timeline and API

### DIFF
--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -4,6 +4,7 @@ const {
   getPoints,
   getAchievements,
   getDailyStats,
+  getSessions,
 } = require('../services/kindleService');
 
 const router = express.Router();
@@ -37,6 +38,14 @@ router.get('/daily-stats', (req, res) => {
     res.json(getDailyStats());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load daily stats' });
+  }
+});
+
+router.get('/sessions', (req, res) => {
+  try {
+    res.json(getSessions());
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load sessions' });
   }
 });
 

--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -33,4 +33,12 @@ describe('GET /api/kindle', () => {
     expect(res.body[0]).toHaveProperty('date');
     expect(res.body[0]).toHaveProperty('minutes');
   });
+
+  it('returns sessions data', async () => {
+    const res = await request(app).get('/api/kindle/sessions');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('start');
+    expect(res.body[0]).toHaveProperty('title');
+  });
 });

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { aggregateDailyReading } = require('../../src/services/readingStats');
+const { aggregateReadingSessions } = require('../../src/services/readingSessions');
 
 function parseCsv(filePath) {
   const content = fs.readFileSync(filePath, 'utf-8').trim();
@@ -79,10 +80,50 @@ function getDailyStats() {
   return aggregateDailyReading(rows);
 }
 
+function getSessions() {
+  const sessionsPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'data',
+    'kindle',
+    'Kindle',
+    'Kindle.Devices.ReadingSession',
+    'Kindle.Devices.ReadingSession.csv',
+  );
+  const highlightsPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'data',
+    'kindle',
+    'Kindle',
+    'Kindle.Devices.kindleHighlightActions',
+    'Kindle.Devices.kindleHighlightActions.csv',
+  );
+  const ordersPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'data',
+    'kindle',
+    'Kindle',
+    'Kindle.UnifiedLibraryIndex',
+    'datasets',
+    'Kindle.UnifiedLibraryIndex.CustomerOrders',
+    'Kindle.UnifiedLibraryIndex.CustomerOrders.csv',
+  );
+  const sessions = parseCsv(sessionsPath);
+  const highlights = parseCsv(highlightsPath);
+  const orders = parseCsv(ordersPath);
+  return aggregateReadingSessions(sessions, highlights, orders);
+}
+
 module.exports = {
   getEvents,
   getPoints,
   getAchievements,
   getDailyStats,
+  getSessions,
 };
 

--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -1,0 +1,43 @@
+import React, { useRef, useEffect } from 'react';
+import { select } from 'd3-selection';
+import { scaleTime } from 'd3-scale';
+
+const WIDTH = 600;
+const HEIGHT = 40;
+
+export default function ReadingTimeline({ sessions = [] }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const svg = select(ref.current);
+    svg.selectAll('*').remove();
+    if (!sessions.length) return;
+
+    const parsed = sessions.map((s) => ({
+      ...s,
+      startDate: new Date(s.start),
+      endDate: new Date(s.end),
+    }));
+    const min = Math.min(...parsed.map((d) => d.startDate.getTime()));
+    const max = Math.max(...parsed.map((d) => d.endDate.getTime()));
+    const x = scaleTime().domain([min, max]).range([0, WIDTH]);
+    svg.attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`);
+    svg
+      .selectAll('rect')
+      .data(parsed)
+      .enter()
+      .append('rect')
+      .attr('x', (d) => x(d.startDate))
+      .attr('y', 5)
+      .attr('width', (d) => Math.max(1, x(d.endDate) - x(d.startDate)))
+      .attr('height', 30)
+      .attr('fill', 'steelblue')
+      .append('title')
+      .text(
+        (d) =>
+          `${d.title}\n${d.duration.toFixed(1)} min, ${d.highlights} highlights`,
+      );
+  }, [sessions]);
+
+  return <svg ref={ref} style={{ width: '100%', height: HEIGHT }} />;
+}

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReadingTimeline from '../ReadingTimeline.jsx';
+
+describe('ReadingTimeline', () => {
+  it('renders an svg element', () => {
+    const sessions = [
+      {
+        start: '2025-01-01T00:00:00Z',
+        end: '2025-01-01T00:30:00Z',
+        asin: 'B001',
+        title: 'Test Book',
+        duration: 30,
+        highlights: 2,
+      },
+    ];
+    const { container } = render(<ReadingTimeline sessions={sessions} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useReadingSessions.js
+++ b/src/hooks/useReadingSessions.js
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import { getKindleSessions } from '@/lib/api';
+
+export default function useReadingSessions() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getKindleSessions().then(setData).catch(setError);
+  }, []);
+
+  return { data, error, isLoading: !data && !error };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1674,6 +1674,21 @@ export async function getDailyReadingStats(): Promise<DailyReadingStat[]> {
   return res.json();
 }
 
+export interface KindleSession {
+  start: string;
+  end: string;
+  asin: string;
+  title: string;
+  duration: number;
+  highlights: number;
+}
+
+export async function getKindleSessions(): Promise<KindleSession[]> {
+  const res = await fetch('/api/kindle/sessions');
+  if (!res.ok) throw new Error('Failed to fetch sessions');
+  return res.json();
+}
+
 // ----- Focus sessions -----
 
 export type FocusLabel = "Deep Dive" | "Skim" | "Page Turn Panic";

--- a/src/pages/TimelinePage.jsx
+++ b/src/pages/TimelinePage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import useReadingSessions from '@/hooks/useReadingSessions';
+import ReadingTimeline from '@/components/timeline/ReadingTimeline.jsx';
+
+export default function TimelinePage() {
+  const { data, error, isLoading } = useReadingSessions();
+  if (error) return <div>Failed to load sessions</div>;
+  if (isLoading) return <div>Loading...</div>;
+  return <ReadingTimeline sessions={data || []} />;
+}

--- a/src/pages/__tests__/TimelinePage.test.jsx
+++ b/src/pages/__tests__/TimelinePage.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import TimelinePage from '../TimelinePage.jsx';
+import useReadingSessions from '@/hooks/useReadingSessions';
+
+vi.mock('@/hooks/useReadingSessions');
+
+describe('TimelinePage', () => {
+  it('renders timeline when data is loaded', () => {
+    useReadingSessions.mockReturnValue({
+      data: [
+        {
+          start: '2025-01-01T00:00:00Z',
+          end: '2025-01-01T00:30:00Z',
+          asin: 'A',
+          title: 'Book',
+          duration: 30,
+          highlights: 0,
+        },
+      ],
+      error: null,
+      isLoading: false,
+    });
+    const { container } = render(<TimelinePage />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/services/readingSessions.js
+++ b/src/services/readingSessions.js
@@ -1,0 +1,51 @@
+function aggregateReadingSessions(sessions, highlights = [], orders = []) {
+  const titleByAsin = {};
+  for (const o of orders) {
+    const asin = o.ASIN;
+    const title = o['Product Name'];
+    if (asin && title && !titleByAsin[asin]) {
+      titleByAsin[asin] = title;
+    }
+  }
+
+  const highlightsByAsin = {};
+  for (const h of highlights) {
+    const asin = h.ASIN;
+    const ts = h.created_timestamp;
+    if (!asin || !ts) continue;
+    if (!highlightsByAsin[asin]) highlightsByAsin[asin] = [];
+    highlightsByAsin[asin].push(ts);
+  }
+
+  return sessions
+    .filter((s) => {
+      const ts = s.start_timestamp || s.end_timestamp;
+      return ts && ts !== 'Not Available';
+    })
+    .map((s) => {
+      const start =
+        s.start_timestamp && s.start_timestamp !== 'Not Available'
+          ? s.start_timestamp
+          : s.end_timestamp;
+      const end =
+        s.end_timestamp && s.end_timestamp !== 'Not Available'
+          ? s.end_timestamp
+          : s.start_timestamp;
+      const asin = s.ASIN;
+      const title = titleByAsin[asin] || asin;
+      const duration = Number(s.total_reading_millis || 0) / 60000;
+      const list = highlightsByAsin[asin] || [];
+      const highlightsCount = list.filter((ts) => ts >= start && ts <= end).length;
+      return {
+        start,
+        end,
+        asin,
+        title,
+        duration,
+        highlights: highlightsCount,
+      };
+    })
+    .sort((a, b) => a.start.localeCompare(b.start));
+}
+
+module.exports = { aggregateReadingSessions };


### PR DESCRIPTION
## Summary
- aggregate Kindle reading sessions with book titles and highlight counts
- expose `/api/kindle/sessions` and client hook to fetch session data
- display sessions in new `ReadingTimeline` component and `TimelinePage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689139eb104c8324afb20aacdd8fbe9e