### PR TITLE
Add navigational breadcrumbs component

### DIFF
--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+
+const routeLabelMap: Record<string, string> = {};
+for (const group of dashboardRoutes) {
+  for (const item of group.items) {
+    routeLabelMap[item.to] = item.label;
+  }
+}
+
+interface BreadcrumbsProps {
+  /**
+   * Optional custom labels for dynamic route parameters.
+   * Provide an object where keys are parameter names and values are labels.
+   */
+  labels?: Record<string, string>;
+}
+
+function startCase(str: string): string {
+  return str
+    .split("-")
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ");
+}
+
+export default function Breadcrumbs({ labels = {} }: BreadcrumbsProps) {
+  const location = useLocation();
+  const params = useParams();
+  const segments = location.pathname.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const crumbs = segments.map((segment, index) => {
+    const to = "/" + segments.slice(0, index + 1).join("/");
+    let label: string | undefined;
+
+    const paramEntry = Object.entries(params).find(([, value]) => value === segment);
+    if (paramEntry) {
+      const [paramName] = paramEntry;
+      label = labels[paramName];
+    }
+
+    if (!label) {
+      label = routeLabelMap[to];
+    }
+
+    if (!label) {
+      label = startCase(segment);
+    }
+
+    return { to, label };
+  });
+
+  return (
+    <nav aria-label="breadcrumb" className="mb-4">
+      <ol className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground">
+        {crumbs.map((crumb, index) => {
+          const isLast = index === crumbs.length - 1;
+          return (
+            <li key={crumb.to} className="flex items-center gap-1">
+              {index > 0 && <span>/</span>}
+              {isLast ? (
+                <span className="text-foreground">{crumb.label}</span>
+              ) : (
+                <Link to={crumb.to} className="hover:underline">
+                  {crumb.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+

--- a/src/components/layout/__tests__/breadcrumbs.test.tsx
+++ b/src/components/layout/__tests__/breadcrumbs.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import Breadcrumbs from "../Breadcrumbs";
+
+describe("Breadcrumbs", () => {
+  it("shows hierarchy for nested routes", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/dashboard/charts/bar-chart-interactive"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route
+            path="/dashboard/charts/bar-chart-interactive"
+            element={<Breadcrumbs />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveTextContent("Dashboard");
+    expect(links[0]).toHaveAttribute("href", "/dashboard");
+    expect(links[1]).toHaveTextContent("Charts");
+    expect(links[1]).toHaveAttribute("href", "/dashboard/charts");
+    expect(
+      screen.getByText("Customizable Metric Comparison")
+    ).toBeInTheDocument();
+  });
+
+  it("allows custom labels for params", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/dashboard/user/123"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route
+            path="/dashboard/user/:userId"
+            element={<Breadcrumbs labels={{ userId: "John Doe" }} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("User")).toBeInTheDocument();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+  });
+});
+

--- a/src/layouts/MobileTabLayout.tsx
+++ b/src/layouts/MobileTabLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import MobileTabBar from "@/components/layout/MobileTabBar";
+import Breadcrumbs from "@/components/layout/Breadcrumbs";
 
 interface MobileTabLayoutProps {
   children: React.ReactNode;
@@ -8,7 +9,10 @@ interface MobileTabLayoutProps {
 export default function MobileTabLayout({ children }: MobileTabLayoutProps) {
   return (
     <div className="flex h-full flex-col">
-      <div className="flex-1 overflow-auto">{children}</div>
+      <div className="flex-1 overflow-auto p-4">
+        <Breadcrumbs />
+        {children}
+      </div>
       <MobileTabBar className="md:hidden" />
     </div>
   );

--- a/src/layouts/SidebarLayout.tsx
+++ b/src/layouts/SidebarLayout.tsx
@@ -8,6 +8,7 @@ import {
   SidebarInset,
 } from "@/ui/sidebar";
 import SidebarNavigation from "@/components/layout/sidebar-navigation";
+import Breadcrumbs from "@/components/layout/Breadcrumbs";
 
 interface SidebarLayoutProps {
   children: React.ReactNode;
@@ -23,7 +24,10 @@ export default function SidebarLayout({ children }: SidebarLayoutProps) {
         <SidebarNavigation />
         <SidebarFooter />
       </Sidebar>
-      <SidebarInset>{children}</SidebarInset>
+      <SidebarInset className="p-4">
+        <Breadcrumbs />
+        {children}
+      </SidebarInset>
     </SidebarProvider>
   );
 }


### PR DESCRIPTION
## Summary
- implement reusable breadcrumb component with route metadata and custom param labels
- show breadcrumbs in mobile and sidebar layouts
- cover breadcrumb hierarchy and param label overrides in tests

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891335dd38c8324af6fee294d13cd60