### PR TITLE
feat: add genre hierarchy sunburst

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "d3-contour": "^4.0.2",
         "d3-drag": "^3.0.0",
         "d3-geo": "^3.1.1",
+        "d3-hierarchy": "^3.1.2",
         "d3-polygon": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
@@ -5799,6 +5800,15 @@
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "d3-contour": "^4.0.2",
     "d3-drag": "^3.0.0",
     "d3-geo": "^3.1.1",
+    "d3-hierarchy": "^3.1.2",
     "d3-polygon": "^3.0.1",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",

--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -5,6 +5,7 @@ const {
   getAchievements,
   getDailyStats,
   getSessions,
+  getGenreHierarchy,
 } = require('../services/kindleService');
 
 const router = express.Router();
@@ -46,6 +47,14 @@ router.get('/sessions', (req, res) => {
     res.json(getSessions());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load sessions' });
+  }
+});
+
+router.get('/genre-hierarchy', (req, res) => {
+  try {
+    res.json(getGenreHierarchy());
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load genre hierarchy' });
   }
 });
 

--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -41,4 +41,11 @@ describe('GET /api/kindle', () => {
     expect(res.body[0]).toHaveProperty('start');
     expect(res.body[0]).toHaveProperty('title');
   });
+
+  it('returns genre hierarchy data', async () => {
+    const res = await request(app).get('/api/kindle/genre-hierarchy');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('name', 'root');
+    expect(res.body).toHaveProperty('children');
+  });
 });

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { aggregateDailyReading } = require('../../src/services/readingStats');
 const { aggregateReadingSessions } = require('../../src/services/readingSessions');
+const { buildGenreHierarchy } = require('../../src/services/genreHierarchy');
 
 function parseCsv(filePath) {
   const content = fs.readFileSync(filePath, 'utf-8').trim();
@@ -119,11 +120,59 @@ function getSessions() {
   return aggregateReadingSessions(sessions, highlights, orders);
 }
 
+function getGenreHierarchy() {
+  const base = path.join(__dirname, '..', '..', 'data', 'kindle', 'Kindle');
+
+  const sessionsPath = path.join(
+    base,
+    'Kindle.Devices.ReadingSession',
+    'Kindle.Devices.ReadingSession.csv'
+  );
+  const ordersPath = path.join(
+    base,
+    'Kindle.UnifiedLibraryIndex',
+    'datasets',
+    'Kindle.UnifiedLibraryIndex.CustomerOrders',
+    'Kindle.UnifiedLibraryIndex.CustomerOrders.csv'
+  );
+  const authorsPath = path.join(
+    base,
+    'Kindle.UnifiedLibraryIndex',
+    'datasets',
+    'Kindle.UnifiedLibraryIndex.CustomerAuthorNameRelationship',
+    'Kindle.UnifiedLibraryIndex.CustomerAuthorNameRelationship.csv'
+  );
+  const genresPath = path.join(
+    base,
+    'Kindle.UnifiedLibraryIndex',
+    'datasets',
+    'Kindle.UnifiedLibraryIndex.CustomerGenres',
+    'Kindle.UnifiedLibraryIndex.CustomerGenres.csv'
+  );
+  const tagsPath = path.join(
+    base,
+    'Kindle.UnifiedLibraryIndex',
+    'datasets',
+    'Kindle.UnifiedLibraryIndex.CustomerTags',
+    'Kindle.UnifiedLibraryIndex.CustomerTags.csv'
+  );
+
+  const sessions = parseCsv(sessionsPath);
+  const orders = parseCsv(ordersPath);
+  const authors = parseCsv(authorsPath);
+  const genres = parseCsv(genresPath);
+  const tags = parseCsv(tagsPath);
+
+  const aggregated = aggregateReadingSessions(sessions, [], orders);
+  return buildGenreHierarchy(aggregated, genres, authors, tags);
+}
+
 module.exports = {
   getEvents,
   getPoints,
   getAchievements,
   getDailyStats,
   getSessions,
+  getGenreHierarchy,
 };
 

--- a/src/components/genre/GenreSunburst.jsx
+++ b/src/components/genre/GenreSunburst.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { select } from 'd3-selection';
+import { hierarchy, partition } from 'd3-hierarchy';
+import { arc } from 'd3-shape';
+import { scaleOrdinal } from 'd3-scale';
+import { schemeCategory10 } from 'd3-scale-chromatic';
+
+const SIZE = 400;
+const RADIUS = SIZE / 2;
+
+export default function GenreSunburst({ data }) {
+  const ref = useRef(null);
+  const [titles, setTitles] = useState([]);
+
+  useEffect(() => {
+    const svg = select(ref.current);
+    svg.selectAll('*').remove();
+    if (!data) return;
+
+    const root = hierarchy(data).sum((d) => d.value || 0);
+    partition().size([2 * Math.PI, RADIUS])(root);
+
+    const color = scaleOrdinal(schemeCategory10);
+    const arcGen = arc()
+      .startAngle((d) => d.x0)
+      .endAngle((d) => d.x1)
+      .innerRadius((d) => d.y0)
+      .outerRadius((d) => d.y1);
+
+    const g = svg
+      .attr('viewBox', `${-RADIUS} ${-RADIUS} ${SIZE} ${SIZE}`)
+      .append('g');
+
+    g.selectAll('path')
+      .data(root.descendants().filter((d) => d.depth))
+      .join('path')
+      .attr('d', arcGen)
+      .attr('fill', (d) => color(d.ancestors().map((d) => d.data.name).join('-')))
+      .on('click', (_event, d) => {
+        const leaves = d
+          .descendants()
+          .filter((n) => !n.children)
+          .map((n) => n.data.name);
+        setTitles(leaves);
+      })
+      .append('title')
+      .text((d) => d.data.name);
+  }, [data]);
+
+  return (
+    <div>
+      <svg ref={ref} style={{ width: '100%', height: SIZE }} />
+      {titles.length > 0 && (
+        <ul>
+          {titles.map((t) => (
+            <li key={t}>{t}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/services/__tests__/genreHierarchy.test.js
+++ b/src/services/__tests__/genreHierarchy.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { buildGenreHierarchy } from '../genreHierarchy';
+
+describe('buildGenreHierarchy', () => {
+  it('builds nested tree from flat records', () => {
+    const sessions = [
+      { asin: 'A1', title: 'Book One', duration: 30 },
+      { asin: 'A2', title: 'Book Two', duration: 15 },
+    ];
+    const genres = [
+      { ASIN: 'A1', Genre: 'Fiction' },
+      { ASIN: 'A2', Genre: 'Fiction' },
+    ];
+    const authors = [
+      { ASIN: 'A1', 'Author Name': 'Author A' },
+      { ASIN: 'A2', 'Author Name': 'Author B' },
+    ];
+    const tags = [
+      { ASIN: 'A1', 'Tag Source Group': 'genre', 'Tag Name': 'Mystery' },
+      { ASIN: 'A2', 'Tag Source Group': 'genre', 'Tag Name': 'Fantasy' },
+    ];
+    const root = buildGenreHierarchy(sessions, genres, authors, tags);
+    expect(root.name).toBe('root');
+    const fiction = root.children.find((c) => c.name === 'Fiction');
+    expect(fiction.children).toHaveLength(2);
+    const mystery = fiction.children.find((c) => c.name === 'Mystery');
+    expect(mystery.children[0].name).toBe('Author A');
+    const book = mystery.children[0].children[0];
+    expect(book).toEqual({ name: 'Book One', value: 30 });
+  });
+});

--- a/src/services/genreHierarchy.js
+++ b/src/services/genreHierarchy.js
@@ -1,0 +1,61 @@
+function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
+  const genreByAsin = {};
+  for (const g of genres) {
+    const asin = g.ASIN;
+    const genre = g.Genre;
+    if (asin && genre && !genreByAsin[asin]) genreByAsin[asin] = genre;
+  }
+  const subgenreByAsin = {};
+  for (const t of tags) {
+    if (t['Tag Source Group'] !== 'genre') continue;
+    const asin = t.ASIN;
+    const name = t['Tag Name'];
+    if (asin && name && !subgenreByAsin[asin]) subgenreByAsin[asin] = name;
+  }
+  const authorByAsin = {};
+  for (const a of authors) {
+    const asin = a.ASIN;
+    const name = a['Author Name'];
+    if (asin && name && !authorByAsin[asin]) authorByAsin[asin] = name;
+  }
+  const books = {};
+  for (const s of sessions) {
+    const asin = s.asin || s.ASIN;
+    if (!asin) continue;
+    const title = s.title || s['Product Name'] || asin;
+    const minutes = Number(s.duration || s.minutes || 0);
+    if (!books[asin]) {
+      books[asin] = {
+        title,
+        minutes: 0,
+        genre: genreByAsin[asin] || 'Unknown',
+        subgenre: subgenreByAsin[asin] || 'Unknown',
+        author: authorByAsin[asin] || 'Unknown',
+      };
+    }
+    books[asin].minutes += minutes;
+  }
+  const root = { name: 'root', children: [] };
+  for (const asin in books) {
+    const b = books[asin];
+    let gNode = root.children.find((c) => c.name === b.genre);
+    if (!gNode) {
+      gNode = { name: b.genre, children: [] };
+      root.children.push(gNode);
+    }
+    let sgNode = gNode.children.find((c) => c.name === b.subgenre);
+    if (!sgNode) {
+      sgNode = { name: b.subgenre, children: [] };
+      gNode.children.push(sgNode);
+    }
+    let aNode = sgNode.children.find((c) => c.name === b.author);
+    if (!aNode) {
+      aNode = { name: b.author, children: [] };
+      sgNode.children.push(aNode);
+    }
+    aNode.children.push({ name: b.title, value: b.minutes });
+  }
+  return root;
+}
+
+module.exports = { buildGenreHierarchy };


### PR DESCRIPTION
## Summary
- build genre hierarchy from Kindle datasets
- visualize hierarchy with interactive sunburst
- expose `/api/kindle/genre-hierarchy` endpoint

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68913c71866c8324b6d5fc5402c7c3e7