### PR TITLE
feat: add session insights

### DIFF
--- a/src/hooks/useSessionInsights.ts
+++ b/src/hooks/useSessionInsights.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import type { ClusterMetrics } from './useRunningSessions'
+
+function clusterName(id: number) {
+  return `Cluster ${String.fromCharCode(65 + id)}`
+}
+
+export function useSessionInsights(
+  stats: Record<number, ClusterMetrics> | null,
+): string[] {
+  return useMemo(() => {
+    if (!stats) return []
+    const entries = Object.entries(stats)
+    if (!entries.length) return []
+    const [maxGood] = entries.reduce((a, b) =>
+      b[1].goodRuns > a[1].goodRuns ? b : a,
+    )
+    const [maxVar] = entries.reduce((a, b) =>
+      b[1].variance > a[1].variance ? b : a,
+    )
+    const [maxBreach] = entries.reduce((a, b) =>
+      b[1].boundaryBreaches > a[1].boundaryBreaches ? b : a,
+    )
+    return [
+      `${clusterName(Number(maxGood))} yields most good runs.`,
+      `${clusterName(Number(maxVar))} shows highest variance.`,
+      `${clusterName(Number(maxBreach))} has most boundary breaches.`,
+    ]
+  }, [stats])
+}
+
+export default useSessionInsights

--- a/src/pages/SessionSimilarity.tsx
+++ b/src/pages/SessionSimilarity.tsx
@@ -1,13 +1,22 @@
 import React from "react";
 import { SessionSimilarityMap } from "@/components/maps";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
+import { useSessionInsights } from "@/hooks/useSessionInsights";
 
 export default function SessionSimilarityPage() {
-  const { sessions, error } = useRunningSessions();
+  const { sessions, clusterStats, error } = useRunningSessions();
+  const insights = useSessionInsights(clusterStats);
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Session Similarity</h1>
+      {insights.length > 0 && (
+        <div className="space-y-1 text-sm text-muted-foreground">
+          {insights.map((i, idx) => (
+            <p key={idx}>{i}</p>
+          ))}
+        </div>
+      )}
       <p className="text-sm text-muted-foreground">
         Visualize how recent runs cluster based on their characteristics.
       </p>


### PR DESCRIPTION
## Summary
- compute per-cluster metrics like good-run counts and variance
- add `useSessionInsights` hook to turn metrics into human phrases
- surface insights on Session Similarity page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891424651ec8324b93bcc69f900f894