### PR TITLE
feat: add UMAP option and PCA axes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "html-to-image": "^1.11.13",
         "lucide-react": "^0.534.0",
         "maplibre-gl": "^3.6.0",
+        "ml-pca": "^4.1.1",
         "react": "^18.2.0",
         "react-calendar-heatmap": "^1.10.0",
         "react-dom": "^18.2.0",
@@ -51,7 +52,8 @@
         "recharts": "^2.15.4",
         "swr": "^2.3.4",
         "topojson-client": "^3.1.0",
-        "tsne-js": "^1.0.3"
+        "tsne-js": "^1.0.3",
+        "umap-js": "^1.4.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
@@ -7150,6 +7152,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -7707,6 +7715,70 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ml-array-max": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+      "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+      "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+      "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0",
+        "ml-array-max": "^1.2.4",
+        "ml-array-min": "^1.2.3"
+      }
+    },
+    "node_modules/ml-levenberg-marquardt": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ml-levenberg-marquardt/-/ml-levenberg-marquardt-2.1.1.tgz",
+      "integrity": "sha512-2+HwUqew4qFFFYujYlQtmFUrxCB4iJAPqnUYro3P831wj70eJZcANwcRaIMGUVaH9NDKzfYuA4N5u67KExmaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^0.1.0",
+        "ml-matrix": "^6.4.1"
+      }
+    },
+    "node_modules/ml-levenberg-marquardt/node_modules/is-any-array": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-0.1.1.tgz",
+      "integrity": "sha512-qTiELO+kpTKqPgxPYbshMERlzaFu29JDnpB8s3bjg+JkxBpw29/qqSaOdKv2pCdaG92rLGeG/zG2GauX58hfoA==",
+      "license": "MIT"
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.1.tgz",
+      "integrity": "sha512-TJ+8eOFdp+INvzR4zAuwBQJznDUfktMtOB6g/hUcGh3rcyjxbz4Te57Pgri8Q9bhSQ7Zys4IYOGhFdnlgeB6Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.1",
+        "ml-array-rescale": "^1.3.7"
+      }
+    },
+    "node_modules/ml-pca": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ml-pca/-/ml-pca-4.1.1.tgz",
+      "integrity": "sha512-HQwswMK1dObj+ppk3EPcQMR2djWK0Cri8mAFd2nITtXHkLfO4DBBsEtiCT5KiR+2e3hQjp+lI0UyqZpdf04AlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-matrix": "^6.8.0"
       }
     },
     "node_modules/motion-dom": {
@@ -10016,6 +10088,15 @@
       "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/umap-js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/umap-js/-/umap-js-1.4.0.tgz",
+      "integrity": "sha512-xxpviF9wUO6Nxrx+C58SoDgea+h2PnVaRPKDelWv0HotmY6BeWeh0kAPJoumfqUkzUvowGsYfMbnsWI0b9do+A==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-levenberg-marquardt": "^2.0.0"
+      }
     },
     "node_modules/union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "html-to-image": "^1.11.13",
     "lucide-react": "^0.534.0",
     "maplibre-gl": "^3.6.0",
+    "ml-pca": "^4.1.1",
     "react": "^18.2.0",
     "react-calendar-heatmap": "^1.10.0",
     "react-dom": "^18.2.0",
@@ -53,7 +54,8 @@
     "recharts": "^2.15.4",
     "swr": "^2.3.4",
     "topojson-client": "^3.1.0",
-    "tsne-js": "^1.0.3"
+    "tsne-js": "^1.0.3",
+    "umap-js": "^1.4.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/components/analytical/__tests__/SessionDetailDrawer.test.tsx
+++ b/src/components/analytical/__tests__/SessionDetailDrawer.test.tsx
@@ -51,7 +51,7 @@ const baseSession: SessionPoint = {
 
 describe('SessionDetailDrawer summary', () => {
   it('shows positive factors for good session', () => {
-    useRunningSessionsMock.mockReturnValue({ sessions: [baseSession], trend: null, error: null })
+    useRunningSessionsMock.mockReturnValue({ sessions: [baseSession], trend: null, axes: null, error: null })
     render(<SessionDetailDrawer session={baseSession} onClose={() => {}} />)
     expect(
       screen.getByText('Tailwind + Stable HR led to Δ 1.8 min/mi')
@@ -66,7 +66,7 @@ describe('SessionDetailDrawer summary', () => {
       paceDelta: -0.3,
       factors: [{ label: 'Heat', impact: -0.4 }],
     }
-    useRunningSessionsMock.mockReturnValue({ sessions: [miss], trend: null, error: null })
+    useRunningSessionsMock.mockReturnValue({ sessions: [miss], trend: null, axes: null, error: null })
     render(<SessionDetailDrawer session={miss} onClose={() => {}} />)
     expect(
       screen.getByText('Why not good? Heat added 0.3 min/mi')
@@ -80,7 +80,7 @@ describe('SessionDetailDrawer tags', () => {
   })
 
   it('allows adding emoji tags', async () => {
-    useRunningSessionsMock.mockReturnValue({ sessions: [baseSession], trend: null, error: null })
+    useRunningSessionsMock.mockReturnValue({ sessions: [baseSession], trend: null, axes: null, error: null })
     render(<SessionDetailDrawer session={baseSession} onClose={() => {}} />)
 
     const input = screen.getByPlaceholderText('Add tag or emoji')

--- a/src/pages/SessionSimilarity.tsx
+++ b/src/pages/SessionSimilarity.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { SessionSimilarityMap } from "@/components/maps";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
 
 export default function SessionSimilarityPage() {
-  const { sessions, error } = useRunningSessions();
+  const [algo, setAlgo] = useState<"tsne" | "umap">("tsne");
+  const { sessions, axes, error } = useRunningSessions(algo);
 
   return (
     <div className="p-4 space-y-4">
@@ -16,7 +17,12 @@ export default function SessionSimilarityPage() {
           Unable to load running sessions.
         </div>
       ) : (
-        <SessionSimilarityMap data={sessions} />
+        <SessionSimilarityMap
+          data={sessions}
+          axes={axes}
+          algo={algo}
+          onAlgoChange={setAlgo}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add UMAP and PCA support to running session embeddings
- toggle between t-SNE and UMAP with optional PCA axis hints
- recompute embeddings when session data updates

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689142498b188324aaee8c6b533f1a84