### PR TITLE
Add genre transition analysis and visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "d3-geo": "^3.1.1",
         "d3-hierarchy": "^3.1.2",
         "d3-polygon": "^3.0.1",
+        "d3-sankey": "^0.12.3",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
         "d3-selection": "^3.0.0",
@@ -5842,6 +5843,46 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "d3-geo": "^3.1.1",
     "d3-hierarchy": "^3.1.2",
     "d3-polygon": "^3.0.1",
+    "d3-sankey": "^0.12.3",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",
     "d3-selection": "^3.0.0",

--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -6,6 +6,7 @@ const {
   getDailyStats,
   getSessions,
   getGenreHierarchy,
+  getGenreTransitions,
 } = require('../services/kindleService');
 
 const router = express.Router();
@@ -55,6 +56,15 @@ router.get('/genre-hierarchy', (req, res) => {
     res.json(getGenreHierarchy());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load genre hierarchy' });
+  }
+});
+
+router.get('/genre-transitions', (req, res) => {
+  try {
+    const { start, end } = req.query;
+    res.json(getGenreTransitions(start, end));
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load genre transitions' });
   }
 });
 

--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -48,4 +48,15 @@ describe('GET /api/kindle', () => {
     expect(res.body).toHaveProperty('name', 'root');
     expect(res.body).toHaveProperty('children');
   });
+
+  it('returns genre transitions data', async () => {
+    const res = await request(app).get('/api/kindle/genre-transitions');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    if (res.body.length > 0) {
+      expect(res.body[0]).toHaveProperty('source');
+      expect(res.body[0]).toHaveProperty('target');
+      expect(res.body[0]).toHaveProperty('count');
+    }
+  });
 });

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { select } from 'd3-selection';
+import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
+import { scaleOrdinal } from 'd3-scale';
+import { schemeCategory10 } from 'd3-scale-chromatic';
+
+export default function GenreSankey() {
+  const svgRef = useRef(null);
+  const [data, setData] = useState([]);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+
+  const fetchData = async () => {
+    const params = new URLSearchParams();
+    if (start) params.append('start', start);
+    if (end) params.append('end', end);
+    const res = await fetch(`/api/kindle/genre-transitions?${params.toString()}`);
+    const json = await res.json();
+    setData(json);
+  };
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const svg = select(svgRef.current);
+    svg.selectAll('*').remove();
+    if (!data || data.length === 0) return;
+
+    const width = 600;
+    const height = 400;
+
+    const genres = Array.from(new Set(data.flatMap((d) => [d.source, d.target])));
+    const nodes = genres.map((name) => ({ name }));
+    const links = data.map((d) => ({
+      source: genres.indexOf(d.source),
+      target: genres.indexOf(d.target),
+      value: d.count,
+    }));
+
+    const { nodes: n, links: l } = sankey()
+      .nodeWidth(15)
+      .nodePadding(10)
+      .extent([
+        [1, 1],
+        [width - 1, height - 6],
+      ])({
+        nodes: nodes.map((d) => ({ ...d })),
+        links: links.map((d) => ({ ...d })),
+      });
+
+    const color = scaleOrdinal(schemeCategory10);
+
+    svg.attr('viewBox', `0 0 ${width} ${height}`);
+
+    svg
+      .append('g')
+      .selectAll('path')
+      .data(l)
+      .join('path')
+      .attr('d', sankeyLinkHorizontal())
+      .attr('stroke', '#999')
+      .attr('fill', 'none')
+      .attr('stroke-width', (d) => Math.max(1, d.width));
+
+    const node = svg
+      .append('g')
+      .selectAll('g')
+      .data(n)
+      .join('g');
+
+    node
+      .append('rect')
+      .attr('x', (d) => d.x0)
+      .attr('y', (d) => d.y0)
+      .attr('height', (d) => d.y1 - d.y0)
+      .attr('width', (d) => d.x1 - d.x0)
+      .attr('fill', (d) => color(d.name));
+
+    node
+      .append('text')
+      .attr('x', (d) => d.x0 - 6)
+      .attr('y', (d) => (d.y1 + d.y0) / 2)
+      .attr('dy', '0.35em')
+      .attr('text-anchor', 'end')
+      .text((d) => d.name)
+      .filter((d) => d.x0 < width / 2)
+      .attr('x', (d) => d.x1 + 6)
+      .attr('text-anchor', 'start');
+  }, [data]);
+
+  return (
+    <div>
+      <div>
+        <label>
+          Start
+          <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+        </label>
+        <label>
+          End
+          <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+        </label>
+        <button onClick={fetchData}>Apply</button>
+      </div>
+      <svg ref={svgRef} width="600" height="400" />
+    </div>
+  );
+}

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import React from 'react';
+import GenreSankey from '../GenreSankey';
+
+describe('GenreSankey', () => {
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          { source: 'A', target: 'B', count: 2 },
+          { source: 'B', target: 'C', count: 1 },
+        ]),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders date controls and svg', async () => {
+    const { container } = render(<GenreSankey />);
+    expect(screen.getByLabelText('Start')).toBeInTheDocument();
+    expect(screen.getByLabelText('End')).toBeInTheDocument();
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    await waitFor(() => {
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/services/__tests__/genreTransitions.test.js
+++ b/src/services/__tests__/genreTransitions.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { calculateGenreTransitions } from '../genreTransitions';
+
+describe('calculateGenreTransitions', () => {
+  it('counts transitions between genres', () => {
+    const sessions = [
+      { start: '2024-01-01T00:00:00Z', asin: 'A' },
+      { start: '2024-01-02T00:00:00Z', asin: 'B' },
+      { start: '2024-01-03T00:00:00Z', asin: 'A' },
+    ];
+    const genres = [
+      { ASIN: 'A', Genre: 'Fantasy' },
+      { ASIN: 'B', Genre: 'Sci-Fi' },
+    ];
+    const result = calculateGenreTransitions(sessions, genres);
+    expect(result).toEqual([
+      { source: 'Fantasy', target: 'Sci-Fi', count: 1 },
+      { source: 'Sci-Fi', target: 'Fantasy', count: 1 },
+    ]);
+  });
+});

--- a/src/services/genreTransitions.js
+++ b/src/services/genreTransitions.js
@@ -1,0 +1,34 @@
+function calculateGenreTransitions(sessions, genres = []) {
+  const genreByAsin = {};
+  for (const g of genres) {
+    const asin = g.ASIN;
+    const genre = g.Genre;
+    if (asin && genre && !genreByAsin[asin]) {
+      genreByAsin[asin] = genre;
+    }
+  }
+
+  const list = sessions
+    .slice()
+    .sort((a, b) => a.start.localeCompare(b.start))
+    .map((s) => ({
+      genre: genreByAsin[s.asin] || 'Unknown',
+      start: s.start,
+    }));
+
+  const map = {};
+  for (let i = 0; i < list.length - 1; i++) {
+    const source = list[i].genre;
+    const target = list[i + 1].genre;
+    if (source === target) continue;
+    const key = `${source}->${target}`;
+    map[key] = (map[key] || 0) + 1;
+  }
+
+  return Object.entries(map).map(([key, count]) => {
+    const [source, target] = key.split('->');
+    return { source, target, count };
+  });
+}
+
+module.exports = { calculateGenreTransitions };


### PR DESCRIPTION
## Summary
- derive genre-to-genre transitions from reading sessions
- expose genre transition data via new `/api/kindle/genre-transitions` endpoint
- render interactive GenreSankey with date filters using d3-sankey

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68913e8113ec83249cf9d382d4d8b2dc