### PR TITLE
feat: redirect to dashboard and add all visualizations route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ import BehavioralCharterMapPage from "@/pages/BehavioralCharterMap";
 import SidebarDemoPage from "@/pages/SidebarDemo";
 import VisualizationsList from "@/pages/VisualizationsList";
 
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 import { SelectionProvider } from "@/hooks/useSelection";
 
@@ -62,11 +62,15 @@ function App() {
         <SelectionProvider>
         <DashboardLayout>
           <Routes>
-            <Route path="/" element={<VisualizationsList />} />
-            <Route path="/visualizations" element={<VisualizationsList />} />
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route
+              path="/visualizations"
+              element={<Navigate to="/dashboard/all" replace />}
+            />
             <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
             <Route path="/dashboard" element={<Dashboard />}>
               <Route index element={<DashboardLanding />} />
+              <Route path="all" element={<VisualizationsList />} />
               <Route path="map" element={<MapPlaygroundPage />} />
               <Route path="route-similarity" element={<RouteSimilarityPage />} />
               <Route path="route-novelty" element={<RouteNoveltyPage />} />

--- a/src/pages/VisualizationsList.tsx
+++ b/src/pages/VisualizationsList.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { dashboardRoutes, type DashboardRoute } from "@/routes";
 
-const routes: DashboardRoute[] = dashboardRoutes.flatMap((group) => group.items);
+const routes: DashboardRoute[] = dashboardRoutes
+  .flatMap((group) => group.items)
+  .filter((route) => route.to !== "/dashboard/all");
 
 export default function VisualizationsList() {
   return (

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,12 +4,27 @@ import {
   BarChart3,
   Goal,
   Shield,
+  List,
 } from "lucide-react";
 import {
   withIcon,
   type DashboardRoute,
   type DashboardRouteGroup,
 } from "./types";
+
+export const allRoutes = withIcon(List, [
+  {
+    to: "/dashboard/all",
+    label: "All Visualizations",
+    description: "Browse all available visualizations",
+  },
+]);
+
+const allRouteGroup: DashboardRouteGroup = {
+  label: "All",
+  icon: List,
+  items: allRoutes,
+};
 
 export const mapsRoutes = withIcon(Map, [
   {
@@ -248,6 +263,7 @@ const privacyRouteGroup: DashboardRouteGroup = {
 };
 
 export const dashboardRoutes: DashboardRouteGroup[] = [
+  allRouteGroup,
   mapsRouteGroup,
   trendsRouteGroup,
   analyticalRouteGroup,


### PR DESCRIPTION
## Summary
- redirect `/` to `/dashboard` and move visualizations list under `/dashboard/all`
- add "All" navigation group so the visualizations list is reachable from sidebar and mobile tabs

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68914467b9908324a5b0cc3dbd5e68d4