### PR TITLE
feat: dynamically build dashboard routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,59 +1,40 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import DashboardLayout from "@/layouts/DashboardLayout";
 import Dashboard from "@/pages/Dashboard";
 import DashboardLanding from "@/pages/DashboardLanding";
-import MapPlaygroundPage from "@/pages/MapPlayground";
-import RouteSimilarityPage from "@/pages/RouteSimilarity";
-import RouteNoveltyPage from "@/pages/RouteNovelty";
-import MileageGlobePage from "@/pages/MileageGlobe";
-import FragilityPage from "@/pages/Fragility";
-import ClinicalFragilityDemoPage from "@/pages/ClinicalFragilityDemo";
-import SessionSimilarityPage from "@/pages/SessionSimilarity";
-import GoodDayPage from "@/pages/GoodDay";
-import HabitConsistencyPage from "@/pages/HabitConsistency";
-import StatisticsPage from "@/pages/Statistics";
-import AreaChartInteractivePage from "@/pages/charts/AreaChartInteractive";
-import StepsTrendWithGoalPage from "@/pages/charts/StepsTrendWithGoal";
-import AreaChartLoadRatioPage from "@/pages/charts/AreaChartLoadRatio";
-import TreadmillVsOutdoorPage from "@/pages/charts/TreadmillVsOutdoor";
-import WeeklyVolumeHistoryChartPage from "@/pages/charts/WeeklyVolumeHistoryChart";
-import GhostSelfRivalChartPage from "@/pages/charts/GhostSelfRivalChart";
-import BarChartInteractivePage from "@/pages/charts/BarChartInteractive";
-import BarChartDefaultPage from "@/pages/charts/BarChartDefault";
-import BarChartHorizontalPage from "@/pages/charts/BarChartHorizontal";
-import BarChartMixedPage from "@/pages/charts/BarChartMixed";
-import BarChartLabelCustomPage from "@/pages/charts/BarChartLabelCustom";
-import ShoeUsageChartPage from "@/pages/charts/ShoeUsageChart";
-import PeerBenchmarkBandsPage from "@/pages/charts/PeerBenchmarkBands";
-import TrainingEntropyHeatmapPage from "@/pages/charts/TrainingEntropyHeatmap";
-import PerfVsEnvironmentMatrixPage from "@/pages/charts/PerfVsEnvironmentMatrix";
-import ActivityByTimePage from "@/pages/charts/ActivityByTime";
-import ReadingProbabilityTimelinePage from "@/pages/charts/ReadingProbabilityTimeline";
-import LineChartInteractivePage from "@/pages/charts/LineChartInteractive";
-import TimeInBedChartPage from "@/pages/charts/TimeInBedChart";
-import ScatterChartPaceHeartRatePage from "@/pages/charts/ScatterChartPaceHeartRate";
-import ReadingStackSplitPage from "@/pages/charts/ReadingStackSplit";
-import CompactNextGameCardPage from "@/pages/charts/CompactNextGameCard";
-import RunSoundtrackCardDemoPage from "@/pages/charts/RunSoundtrackCardDemo";
-import RadarChartDefaultPage from "@/pages/charts/RadarChartDefault";
-import RadarChartWorkoutByTimePage from "@/pages/charts/RadarChartWorkoutByTime";
-import MonthlyMileagePatternPage from "@/pages/charts/MonthlyMileagePattern";
-import AvgDailyMileageRadarPage from "@/pages/charts/AvgDailyMileageRadar";
-import RadialChartLabelPage from "@/pages/charts/RadialChartLabel";
-import RadialChartTextPage from "@/pages/charts/RadialChartText";
-import RadialChartGridPage from "@/pages/charts/RadialChartGrid";
-
-import FocusHistoryPage from "@/pages/FocusHistory";
-import InterventionSettingsPage from "@/pages/InterventionSettings";
-
-import PrivacyDashboardPage from "@/pages/PrivacyDashboard";
-import BehavioralCharterMapPage from "@/pages/BehavioralCharterMap";
 import SidebarDemoPage from "@/pages/SidebarDemo";
-import VisualizationsList from "@/pages/VisualizationsList";
+import { dashboardRoutes } from "@/routes";
 
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 import { SelectionProvider } from "@/hooks/useSelection";
+
+const MissingComponent = () => <div>Component not found</div>;
+
+function createDashboardRoutes() {
+  return dashboardRoutes.flatMap(({ items }) =>
+    items.map(({ to, component }) => {
+      if (!component) return [];
+      const LazyComp = lazy(() =>
+        import(/* @vite-ignore */ component).catch(() => ({
+          default: MissingComponent,
+        })),
+      );
+      const path = to.replace("/dashboard/", "");
+      return (
+        <Route
+          key={path}
+          path={path}
+          element={
+            <Suspense fallback={<div>Loading...</div>}>
+              <LazyComp />
+            </Suspense>
+          }
+        />
+      );
+    }),
+  );
+}
 
 function App() {
   return (
@@ -70,57 +51,7 @@ function App() {
             <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
             <Route path="/dashboard" element={<Dashboard />}>
               <Route index element={<DashboardLanding />} />
-              <Route path="all" element={<VisualizationsList />} />
-              <Route path="map" element={<MapPlaygroundPage />} />
-              <Route path="route-similarity" element={<RouteSimilarityPage />} />
-              <Route path="route-novelty" element={<RouteNoveltyPage />} />
-              <Route path="mileage-globe" element={<MileageGlobePage />} />
-              <Route path="fragility" element={<FragilityPage />} />
-              <Route
-                path="clinical-fragility-demo"
-                element={<ClinicalFragilityDemoPage />}
-              />
-              <Route path="session-similarity" element={<SessionSimilarityPage />} />
-              <Route path="good-day" element={<GoodDayPage />} />
-              <Route path="habit-consistency" element={<HabitConsistencyPage />} />
-              <Route path="statistics" element={<StatisticsPage />} />
-              <Route path="privacy" element={<PrivacyDashboardPage />} />
-              <Route path="charts/area-chart-interactive" element={<AreaChartInteractivePage />} />
-              <Route path="charts/steps-trend-with-goal" element={<StepsTrendWithGoalPage />} />
-              <Route path="charts/area-chart-load-ratio" element={<AreaChartLoadRatioPage />} />
-              <Route path="charts/treadmill-vs-outdoor" element={<TreadmillVsOutdoorPage />} />
-              <Route path="charts/weekly-volume-history-chart" element={<WeeklyVolumeHistoryChartPage />} />
-              <Route path="charts/ghost-self-rival-chart" element={<GhostSelfRivalChartPage />} />
-              <Route path="charts/bar-chart-interactive" element={<BarChartInteractivePage />} />
-              <Route path="charts/bar-chart-default" element={<BarChartDefaultPage />} />
-              <Route path="charts/bar-chart-horizontal" element={<BarChartHorizontalPage />} />
-              <Route path="charts/bar-chart-mixed" element={<BarChartMixedPage />} />
-              <Route path="charts/bar-chart-label-custom" element={<BarChartLabelCustomPage />} />
-              <Route path="charts/shoe-usage-chart" element={<ShoeUsageChartPage />} />
-              <Route path="charts/peer-benchmark-bands" element={<PeerBenchmarkBandsPage />} />
-              <Route path="charts/training-entropy-heatmap" element={<TrainingEntropyHeatmapPage />} />
-              <Route path="charts/perf-vs-environment-matrix" element={<PerfVsEnvironmentMatrixPage />} />
-              <Route path="charts/activity-by-time" element={<ActivityByTimePage />} />
-              <Route path="charts/reading-probability-timeline" element={<ReadingProbabilityTimelinePage />} />
-              <Route path="charts/line-chart-interactive" element={<LineChartInteractivePage />} />
-              <Route path="charts/time-in-bed-chart" element={<TimeInBedChartPage />} />
-              <Route path="charts/scatter-chart-pace-heart-rate" element={<ScatterChartPaceHeartRatePage />} />
-              <Route path="charts/reading-stack-split" element={<ReadingStackSplitPage />} />
-              <Route path="charts/compact-next-game-card" element={<CompactNextGameCardPage />} />
-              <Route path="charts/run-soundtrack-card-demo" element={<RunSoundtrackCardDemoPage />} />
-              <Route path="charts/radar-chart-default" element={<RadarChartDefaultPage />} />
-              <Route path="charts/radar-chart-workout-by-time" element={<RadarChartWorkoutByTimePage />} />
-              <Route
-                path="charts/monthly-mileage-pattern"
-                element={<MonthlyMileagePatternPage />}
-              />
-              <Route path="charts/avg-daily-mileage-radar" element={<AvgDailyMileageRadarPage />} />
-              <Route path="charts/radial-chart-label" element={<RadialChartLabelPage />} />
-              <Route path="charts/radial-chart-text" element={<RadialChartTextPage />} />
-              <Route path="charts/radial-chart-grid" element={<RadialChartGridPage />} />
-              <Route path="focus-history" element={<FocusHistoryPage />} />
-              <Route path="settings" element={<InterventionSettingsPage />} />
-              <Route path="behavioral-charter-map" element={<BehavioralCharterMapPage />} />
+              {createDashboardRoutes()}
             </Route>
           </Routes>
         </DashboardLayout>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -17,6 +17,7 @@ export const allRoutes = withIcon(List, [
     to: "/dashboard/all",
     label: "All Visualizations",
     description: "Browse all available visualizations",
+    component: "@/pages/VisualizationsList",
   },
 ]);
 
@@ -31,30 +32,35 @@ export const mapsRoutes = withIcon(Map, [
     to: "/dashboard/map",
     label: "State Visits Map",
     description: "View visited states on an interactive map",
+    component: "@/pages/MapPlayground",
     tags: ["map"],
   },
   {
     to: "/dashboard/mileage-globe",
     label: "Global Mileage Map",
     description: "Visualize mileage across the world using a globe",
+    component: "@/pages/MileageGlobe",
     tags: ["map"],
   },
   {
     to: "/dashboard/route-similarity",
     label: "Route Similarity Analysis",
     description: "Compare routes based on similarity metrics",
+    component: "@/pages/RouteSimilarity",
     tags: ["map"],
   },
   {
     to: "/dashboard/route-novelty",
     label: "Route Novelty Analysis",
     description: "Assess how unique a route is compared to known paths",
+    component: "@/pages/RouteNovelty",
     tags: ["map"],
   },
   {
     to: "/dashboard/behavioral-charter-map",
     label: "Behavioral Charter Map",
     description: "Timeline of activity segments with risk scores",
+    component: "@/pages/BehavioralCharterMap",
     tags: ["map"],
   },
 ]);
@@ -70,36 +76,43 @@ export const trendsRoutes = withIcon(TrendingUp, [
     to: "/dashboard/habit-consistency",
     label: "Habit Consistency Trend",
     description: "Track how consistently habits are maintained over time",
+    component: "@/pages/HabitConsistency",
   },
   {
     to: "/dashboard/focus-history",
     label: "Focus History",
     description: "Review past focus detections and interventions",
+    component: "@/pages/FocusHistory",
   },
   {
     to: "/dashboard/charts/area-chart-interactive",
     label: "Customizable Time-Series Trend",
     description: "Play with dynamic area chart interactions",
+    component: "@/pages/charts/AreaChartInteractive",
   },
   {
     to: "/dashboard/charts/area-chart-load-ratio",
     label: "Training Load Ratio Over Time",
     description: "Monitor training load ratio changes",
+    component: "@/pages/charts/AreaChartLoadRatio",
   },
   {
     to: "/dashboard/charts/peer-benchmark-bands",
     label: "Performance Compared with Peers",
     description: "Compare performance against peers",
+    component: "@/pages/charts/PeerBenchmarkBands",
   },
   {
     to: "/dashboard/charts/reading-probability-timeline",
     label: "Reading Habit Likelihood Trend",
     description: "View reading likelihood over time",
+    component: "@/pages/charts/ReadingProbabilityTimeline",
   },
   {
     to: "/dashboard/charts/weekly-volume-history-chart",
     label: "Weekly Training Volume Trend",
     description: "Historical view of weekly training volume",
+    component: "@/pages/charts/WeeklyVolumeHistoryChart",
   },
 ]);
 
@@ -114,92 +127,110 @@ export const analyticalRoutes = withIcon(BarChart3, [
     to: "/dashboard/fragility",
     label: "Fragility Analysis",
     description: "Review training fragility indicators",
+    component: "@/pages/Fragility",
     preview: "fragility",
   },
   {
     to: "/dashboard/clinical-fragility-demo",
     label: "Clinical Fragility Demo",
     description: "Simulate outcome flips and fragility index",
+    component: "@/pages/ClinicalFragilityDemo",
   },
   {
     to: "/dashboard/session-similarity",
     label: "Session Similarity Analysis",
     description: "Find training sessions that resemble each other",
+    component: "@/pages/SessionSimilarity",
   },
   {
     to: "/dashboard/good-day",
     label: "Good Day Analysis",
     description: "Identify patterns that contribute to positive days",
+    component: "@/pages/GoodDay",
   },
   {
     to: "/dashboard/statistics",
     label: "Metric Correlation Matrix",
     description: "Explore correlations between daily metrics",
+    component: "@/pages/Statistics",
   },
   {
     to: "/dashboard/charts/bar-chart-interactive",
     label: "Customizable Metric Comparison",
     description: "Experiment with interactive bar comparisons",
+    component: "@/pages/charts/BarChartInteractive",
   },
   {
     to: "/dashboard/charts/bar-chart-default",
     label: "Standard Metric Comparison",
     description: "Basic bar chart for category comparison",
+    component: "@/pages/charts/BarChartDefault",
   },
   {
     to: "/dashboard/charts/bar-chart-horizontal",
     label: "Horizontal Metric Comparison",
     description: "Compare categories using horizontal bars",
+    component: "@/pages/charts/BarChartHorizontal",
   },
   {
     to: "/dashboard/charts/bar-chart-mixed",
     label: "Mixed Category Comparison",
     description: "View bars with mixed data series",
+    component: "@/pages/charts/BarChartMixed",
   },
   {
     to: "/dashboard/charts/bar-chart-label-custom",
     label: "Comparison with Custom Category Labels",
     description: "Bar chart demonstrating custom labels",
+    component: "@/pages/charts/BarChartLabelCustom",
   },
   {
     to: "/dashboard/charts/shoe-usage-chart",
     label: "Running Shoe Mileage Comparison",
     description: "Compare mileage by shoe",
+    component: "@/pages/charts/ShoeUsageChart",
   },
   {
     to: "/dashboard/charts/treadmill-vs-outdoor",
     label: "Treadmill vs. Outdoor Running Comparison",
     description: "Compare treadmill and outdoor training",
+    component: "@/pages/charts/TreadmillVsOutdoor",
   },
   {
     to: "/dashboard/charts/radar-chart-default",
     label: "Standard Multi-Metric Radar Profile",
     description: "Basic radar chart profile",
+    component: "@/pages/charts/RadarChartDefault",
   },
   {
     to: "/dashboard/charts/radar-chart-workout-by-time",
     label: "Workout Time Distribution Radar",
     description: "Radar view of workout distribution by time",
+    component: "@/pages/charts/RadarChartWorkoutByTime",
   },
   {
     to: "/dashboard/charts/monthly-mileage-pattern",
     label: "Monthly Mileage Distribution Radar",
     description: "Radar chart with highlighted data points",
+    component: "@/pages/charts/MonthlyMileagePattern",
   },
   {
     to: "/dashboard/charts/avg-daily-mileage-radar",
     label: "Average Daily Mileage Profile",
     description: "Compare average daily mileage",
+    component: "@/pages/charts/AvgDailyMileageRadar",
   },
   {
     to: "/dashboard/charts/activity-by-time",
     label: "Activity Time Allocation Radar",
     description: "Visualize activity levels across time",
+    component: "@/pages/charts/ActivityByTime",
   },
   {
     to: "/dashboard/charts/reading-stack-split",
     label: "Stacked Radial Chart of Reading Time Split",
     description: "Segment reading activity across categories",
+    component: "@/pages/charts/ReadingStackSplit",
   },
 ]);
 
@@ -214,31 +245,37 @@ export const goalsRoutes = withIcon(Goal, [
     to: "/dashboard/charts/steps-trend-with-goal",
     label: "Daily Step-Goal Achievement Trend",
     description: "Track steps against a target over time",
+    component: "@/pages/charts/StepsTrendWithGoal",
   },
   {
     to: "/dashboard/charts/time-in-bed-chart",
     label: "Sleep Duration Trend",
     description: "Examine time spent in bed",
+    component: "@/pages/charts/TimeInBedChart",
   },
   {
     to: "/dashboard/charts/radial-chart-label",
     label: "Radial Progress Indicator with Segment Labels",
     description: "Radial progress chart with labels",
+    component: "@/pages/charts/RadialChartLabel",
   },
   {
     to: "/dashboard/charts/radial-chart-text",
     label: "Radial Progress Indicator with Center Text",
     description: "Radial progress chart with text",
+    component: "@/pages/charts/RadialChartText",
   },
   {
     to: "/dashboard/charts/radial-chart-grid",
     label: "Grid-Based Radial Progress Indicator",
     description: "Radial progress chart with grid",
+    component: "@/pages/charts/RadialChartGrid",
   },
   {
     to: "/dashboard/settings",
     label: "Intervention Settings",
     description: "Configure reminder preferences",
+    component: "@/pages/InterventionSettings",
   },
 ]);
 
@@ -253,6 +290,7 @@ export const privacyRoutes = withIcon(Shield, [
     to: "/dashboard/privacy",
     label: "Privacy Dashboard",
     description: "Manage data retention and export/delete options",
+    component: "@/pages/PrivacyDashboard",
   },
 ]);
 

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -5,6 +5,12 @@ export interface DashboardRoute {
   label: string;
   icon: LucideIcon;
   description: string;
+  /**
+   * Resolvable module path for the React component that should render this
+   * route. The path is used with a dynamic `import()` call so it should be a
+   * valid module specifier (e.g. "@/pages/Foo").
+   */
+  component?: string;
   tooltip?: string;
   tags?: string[];
   badge?: string;


### PR DESCRIPTION
## Summary
- build dashboard routes from `dashboardRoutes` config
- add lazy module paths to route definitions
- include fallback component for missing modules

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6891485ec1908324b5bf74a1d7c2ec1b