### PR TITLE
feat: add highlight search endpoint and word tree

### DIFF
--- a/data/kindle/highlights.json
+++ b/data/kindle/highlights.json
@@ -1,0 +1,5 @@
+[
+  "the quick brown fox jumps over the lazy dog",
+  "the quick blue hare jumps high",
+  "the slow turtle crawls under the log"
+]

--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -7,6 +7,7 @@ const {
   getSessions,
   getGenreHierarchy,
   getGenreTransitions,
+  getHighlightExpansions,
 } = require('../services/kindleService');
 
 const router = express.Router();
@@ -65,6 +66,16 @@ router.get('/genre-transitions', (req, res) => {
     res.json(getGenreTransitions(start, end));
   } catch (err) {
     res.status(500).json({ error: 'Failed to load genre transitions' });
+  }
+});
+
+router.get('/highlights/search', (req, res) => {
+  const { keyword } = req.query;
+  if (!keyword) return res.status(400).json({ error: 'keyword query required' });
+  try {
+    res.json(getHighlightExpansions(keyword));
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to search highlights' });
   }
 });
 

--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -59,4 +59,12 @@ describe('GET /api/kindle', () => {
       expect(res.body[0]).toHaveProperty('count');
     }
   });
+
+  it('returns highlight expansions', async () => {
+    const res = await request(app).get('/api/kindle/highlights/search?keyword=the');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('word', 'quick');
+    expect(res.body[0]).toHaveProperty('count', 2);
+  });
 });

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -4,6 +4,7 @@ const { aggregateDailyReading } = require('../../src/services/readingStats');
 const { aggregateReadingSessions } = require('../../src/services/readingSessions');
 const { buildGenreHierarchy } = require('../../src/services/genreHierarchy');
 const { calculateGenreTransitions } = require('../../src/services/genreTransitions');
+const { buildHighlightIndex, getExpansions } = require('../../src/services/highlightIndex');
 
 function parseCsv(filePath) {
   const content = fs.readFileSync(filePath, 'utf-8').trim();
@@ -201,6 +202,21 @@ function getGenreTransitions(start, end) {
   return calculateGenreTransitions(aggregated, genres);
 }
 
+let highlightTrie = null;
+function getHighlightTrie() {
+  if (!highlightTrie) {
+    const filePath = path.join(__dirname, '..', '..', 'data', 'kindle', 'highlights.json');
+    const texts = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    highlightTrie = buildHighlightIndex(texts);
+  }
+  return highlightTrie;
+}
+
+function getHighlightExpansions(keyword) {
+  const trie = getHighlightTrie();
+  return getExpansions(trie, keyword);
+}
+
 module.exports = {
   getEvents,
   getPoints,
@@ -209,5 +225,6 @@ module.exports = {
   getSessions,
   getGenreHierarchy,
   getGenreTransitions,
+  getHighlightExpansions,
 };
 

--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { hierarchy, tree } from 'd3-hierarchy';
+import { select } from 'd3-selection';
+import { linkHorizontal } from 'd3-shape';
+
+async function fetchExpansions(word) {
+  const res = await fetch(`/api/kindle/highlights/search?keyword=${encodeURIComponent(word)}`);
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}
+
+export default function WordTree() {
+  const [keyword, setKeyword] = useState('');
+  const [data, setData] = useState(null);
+  const svgRef = useRef(null);
+
+  useEffect(() => {
+    if (!data) return;
+    const svg = select(svgRef.current);
+    svg.selectAll('*').remove();
+    const root = hierarchy(data);
+    const layout = tree().nodeSize([24, 120]);
+    layout(root);
+    const link = linkHorizontal().x(d => d.y).y(d => d.x);
+    svg
+      .attr('viewBox', [-20, -20, 800, 400])
+      .selectAll('path')
+      .data(root.links())
+      .join('path')
+      .attr('fill', 'none')
+      .attr('stroke', '#999')
+      .attr('d', link);
+    const node = svg
+      .selectAll('g')
+      .data(root.descendants())
+      .join('g')
+      .attr('transform', d => `translate(${d.y},${d.x})`)
+      .on('click', async (event, d) => {
+        const expansions = await fetchExpansions(d.data.word);
+        d.data.children = expansions.map(e => ({ word: e.word, count: e.count }));
+        setData({ ...data });
+      });
+    node.append('circle').attr('r', 4).attr('fill', '#555');
+    node
+      .append('text')
+      .attr('x', 8)
+      .attr('dy', '0.32em')
+      .text(d => `${d.data.word}${d.data.count ? ` (${d.data.count})` : ''}`);
+  }, [data]);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const expansions = await fetchExpansions(keyword);
+    setData({ word: keyword, children: expansions.map(e => ({ word: e.word, count: e.count })) });
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="mb-4 flex gap-2">
+        <input
+          className="border px-2 py-1"
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+          placeholder="Enter keyword"
+        />
+        <button type="submit" className="px-2 py-1 border">
+          Search
+        </button>
+      </form>
+      <svg ref={svgRef} width={800} height={400}></svg>
+    </div>
+  );
+}

--- a/src/services/__tests__/highlightIndex.test.js
+++ b/src/services/__tests__/highlightIndex.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { buildHighlightIndex, getExpansions } from '../highlightIndex';
+
+describe('highlight index', () => {
+  const texts = [
+    'the quick brown fox jumps over the lazy dog',
+    'the quick blue hare jumps high',
+    'the slow turtle crawls under the log',
+  ];
+  const trie = buildHighlightIndex(texts);
+
+  it('expands single keyword', () => {
+    const result = getExpansions(trie, 'the');
+    expect(result[0]).toEqual({ word: 'quick', count: 2 });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { word: 'lazy', count: 1 },
+        { word: 'slow', count: 1 },
+        { word: 'log', count: 1 },
+      ])
+    );
+  });
+
+  it('expands multi-word phrase', () => {
+    const result = getExpansions(trie, 'the quick');
+    expect(result).toEqual([
+      { word: 'brown', count: 1 },
+      { word: 'blue', count: 1 },
+    ]);
+  });
+});

--- a/src/services/highlightIndex.js
+++ b/src/services/highlightIndex.js
@@ -1,0 +1,44 @@
+function buildHighlightIndex(texts) {
+  const root = new Map();
+  for (const text of texts) {
+    const words = text
+      .toLowerCase()
+      .split(/\W+/)
+      .filter(Boolean);
+    for (let i = 0; i < words.length; i++) {
+      let node = root;
+      for (let j = i; j < words.length; j++) {
+        const word = words[j];
+        let entry = node.get(word);
+        if (!entry) {
+          entry = { count: 0, next: new Map() };
+          node.set(word, entry);
+        }
+        entry.count++;
+        node = entry.next;
+      }
+    }
+  }
+  return root;
+}
+
+function getExpansions(root, phrase) {
+  const words = phrase
+    .toLowerCase()
+    .split(/\W+/)
+    .filter(Boolean);
+  let node = root;
+  for (const word of words) {
+    const entry = node.get(word);
+    if (!entry) return [];
+    node = entry.next;
+  }
+  const results = [];
+  for (const [word, entry] of node.entries()) {
+    results.push({ word, count: entry.count });
+  }
+  results.sort((a, b) => b.count - a.count);
+  return results;
+}
+
+module.exports = { buildHighlightIndex, getExpansions };


### PR DESCRIPTION
## Summary
- index highlight snippets with a trie for keyword expansion
- expose `/api/kindle/highlights/search` endpoint
- add D3-based `WordTree` component with keyword controls

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6891462ab1ec8324a83eab46fe289bfd