### PR TITLE
refactor: simplify dashboard layout routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import React, { lazy, Suspense } from "react";
-import DashboardLayout from "@/layouts/DashboardLayout";
+import RootLayout from "@/layouts/RootLayout";
+import SidebarLayout from "@/layouts/SidebarLayout";
+import MobileTabLayout from "@/layouts/MobileTabLayout";
 import Dashboard from "@/pages/Dashboard";
 import DashboardLanding from "@/pages/DashboardLanding";
 import SidebarDemoPage from "@/pages/SidebarDemo";
 import { dashboardRoutes } from "@/routes";
 
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 import { SelectionProvider } from "@/hooks/useSelection";
 
@@ -41,20 +43,37 @@ function App() {
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <DashboardFiltersProvider>
         <SelectionProvider>
-        <DashboardLayout>
-          <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route
-              path="/visualizations"
-              element={<Navigate to="/dashboard/all" replace />}
-            />
-            <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
-            <Route path="/dashboard" element={<Dashboard />}>
-              <Route index element={<DashboardLanding />} />
-              {createDashboardRoutes()}
-            </Route>
-          </Routes>
-        </DashboardLayout>
+          <RootLayout>
+            <Routes>
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route
+                path="/visualizations"
+                element={<Navigate to="/dashboard/all" replace />}
+              />
+              <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
+              <Route path="/dashboard" element={<Dashboard />}>
+                <Route
+                  element={
+                    <>
+                      <div className="hidden h-full md:block">
+                        <SidebarLayout>
+                          <Outlet />
+                        </SidebarLayout>
+                      </div>
+                      <div className="h-full md:hidden">
+                        <MobileTabLayout>
+                          <Outlet />
+                        </MobileTabLayout>
+                      </div>
+                    </>
+                  }
+                >
+                  <Route index element={<DashboardLanding />} />
+                  {createDashboardRoutes()}
+                </Route>
+              </Route>
+            </Routes>
+          </RootLayout>
         </SelectionProvider>
       </DashboardFiltersProvider>
     </BrowserRouter>

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -4,11 +4,11 @@ import CommandPalette from "@/ui/CommandPalette";
 import { ChartActionsProvider } from "@/hooks/useChartActions";
 import useRecentViews from "@/hooks/useRecentViews";
 
-interface DashboardLayoutProps {
+interface RootLayoutProps {
   children: React.ReactNode;
 }
 
-export default function DashboardLayout({ children }: DashboardLayoutProps) {
+export default function RootLayout({ children }: RootLayoutProps) {
   const location = useLocation();
   const { addRecentView } = useRecentViews();
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,21 +1,6 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
-import SidebarLayout from "@/layouts/SidebarLayout";
-import MobileTabLayout from "@/layouts/MobileTabLayout";
 
 export default function Dashboard() {
-  return (
-    <>
-      <div className="hidden h-full md:block">
-        <SidebarLayout>
-          <Outlet />
-        </SidebarLayout>
-      </div>
-      <div className="h-full md:hidden">
-        <MobileTabLayout>
-          <Outlet />
-        </MobileTabLayout>
-      </div>
-    </>
-  );
+  return <Outlet />;
 }


### PR DESCRIPTION
## Summary
- rename DashboardLayout to RootLayout and keep chart/search providers
- manage dashboard-specific layouts at the route level
- trim Dashboard page to act as an Outlet-only route

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68914a9f4bc08324a924633b5a79103d