### PR TITLE
feat: expand dashboard section labels

### DIFF
--- a/src/components/layout/__tests__/mobile-tab-bar.test.tsx
+++ b/src/components/layout/__tests__/mobile-tab-bar.test.tsx
@@ -58,7 +58,7 @@ describe("MobileTabBar", () => {
     );
     const input = screen.getByRole("searchbox", { name: /search routes/i });
     await user.type(input, "fragility");
-    const analyticalTab = screen.getByRole("tab", { name: /Analytical/ });
+    const analyticalTab = screen.getByRole("tab", { name: /Analytical Insights/ });
     expect(analyticalTab).toHaveClass("bg-accent");
     await user.clear(input);
     expect(analyticalTab).not.toHaveClass("bg-accent");

--- a/src/components/layout/__tests__/sidebar-navigation.test.tsx
+++ b/src/components/layout/__tests__/sidebar-navigation.test.tsx
@@ -35,7 +35,7 @@ describe("SidebarNavigation", () => {
 
   it("toggles group expansion", () => {
     renderWithProviders();
-    const trigger = screen.getByText("Maps");
+    const trigger = screen.getByText("Maps & Routes");
     expect(trigger).toHaveAttribute("aria-expanded", "true");
     fireEvent.click(trigger);
     return waitFor(() =>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -66,7 +66,7 @@ export const mapsRoutes = withIcon(Map, [
 ]);
 
 const mapsRouteGroup: DashboardRouteGroup = {
-  label: "Maps",
+  label: "Maps & Routes",
   icon: Map,
   items: mapsRoutes,
 };
@@ -117,7 +117,7 @@ export const trendsRoutes = withIcon(TrendingUp, [
 ]);
 
 const trendsRouteGroup: DashboardRouteGroup = {
-  label: "Trends",
+  label: "Trends & Comparisons",
   icon: TrendingUp,
   items: trendsRoutes,
 };
@@ -235,7 +235,7 @@ export const analyticalRoutes = withIcon(BarChart3, [
 ]);
 
 const analyticalRouteGroup: DashboardRouteGroup = {
-  label: "Analytical",
+  label: "Analytical Insights",
   icon: BarChart3,
   items: analyticalRoutes,
 };
@@ -280,7 +280,7 @@ export const goalsRoutes = withIcon(Goal, [
 ]);
 
 const goalsRouteGroup: DashboardRouteGroup = {
-  label: "Goals",
+  label: "Goals & Progress",
   icon: Goal,
   items: goalsRoutes,
 };
@@ -295,7 +295,7 @@ export const privacyRoutes = withIcon(Shield, [
 ]);
 
 const privacyRouteGroup: DashboardRouteGroup = {
-  label: "Privacy",
+  label: "Privacy & Settings",
   icon: Shield,
   items: privacyRoutes,
 };


### PR DESCRIPTION
## Summary
- expand dashboard route group labels to full names
- update navigation and tab bar tests for new labels

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68914babbaf48324a630af1dfb396a42