### PR TITLE
Add reading speed visualization and API endpoint

### DIFF
--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -9,6 +9,7 @@ const {
   getGenreTransitions,
   getHighlightExpansions,
   getLocations,
+  getReadingSpeed,
 } = require('../services/kindleService');
 
 const router = express.Router();
@@ -85,6 +86,14 @@ router.get('/locations', (req, res) => {
     res.json(getLocations());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load locations' });
+  }
+});
+
+router.get('/reading-speed', (req, res) => {
+  try {
+    res.json(getReadingSpeed());
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load reading speed' });
   }
 });
 

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { aggregateDailyReading } = require('../../src/services/readingStats');
 const { aggregateReadingSessions } = require('../../src/services/readingSessions');
+const { calculateReadingSpeeds } = require('../../src/services/readingSpeed');
 const { buildGenreHierarchy } = require('../../src/services/genreHierarchy');
 const { calculateGenreTransitions } = require('../../src/services/genreTransitions');
 const { buildHighlightIndex, getExpansions } = require('../../src/services/highlightIndex');
@@ -123,6 +124,21 @@ function getSessions() {
   return aggregateReadingSessions(sessions, highlights, orders);
 }
 
+function getReadingSpeed() {
+  const sessionsPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'data',
+    'kindle',
+    'Kindle',
+    'Kindle.Devices.ReadingSession',
+    'Kindle.Devices.ReadingSession.csv',
+  );
+  const sessions = parseCsv(sessionsPath);
+  return calculateReadingSpeeds(sessions);
+}
+
 function getGenreHierarchy() {
   const base = path.join(__dirname, '..', '..', 'data', 'kindle', 'Kindle');
 
@@ -232,5 +248,6 @@ module.exports = {
   getGenreTransitions,
   getHighlightExpansions,
   getLocations,
+  getReadingSpeed,
 };
 

--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { select } from 'd3-selection';
+import { scaleLinear } from 'd3-scale';
+
+export default function ReadingSpeedViolin() {
+  const svgRef = useRef(null);
+  const [data, setData] = useState([]);
+  const [showMorning, setShowMorning] = useState(true);
+  const [showEvening, setShowEvening] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await fetch('/api/kindle/reading-speed');
+      const json = await res.json();
+      setData(json);
+    };
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    const svg = select(svgRef.current);
+    svg.selectAll('*').remove();
+    const filtered = data.filter(
+      (d) => (showMorning && d.period === 'morning') || (showEvening && d.period === 'evening'),
+    );
+    if (filtered.length === 0) return;
+
+    const values = filtered.map((d) => d.wpm);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const bins = 20;
+    const binSize = (max - min) / bins;
+    const counts = new Array(bins).fill(0);
+    for (const v of values) {
+      const idx = Math.min(bins - 1, Math.floor((v - min) / binSize));
+      counts[idx] += 1;
+    }
+    const maxCount = Math.max(...counts);
+
+    const width = 400;
+    const height = 300;
+    const x = scaleLinear().domain([0, maxCount]).range([0, width / 2]);
+    const y = scaleLinear().domain([min, max]).range([height, 0]);
+
+    const group = svg.attr('viewBox', `0 0 ${width} ${height}`).append('g');
+    counts.forEach((c, i) => {
+      const y0 = y(min + i * binSize);
+      const y1 = y(min + (i + 1) * binSize);
+      const w = x(c);
+      group
+        .append('rect')
+        .attr('x', width / 2 - w)
+        .attr('y', y1)
+        .attr('width', w * 2)
+        .attr('height', y0 - y1)
+        .attr('fill', '#69b3a2');
+    });
+  }, [data, showMorning, showEvening]);
+
+  return (
+    <div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={showMorning}
+            onChange={(e) => setShowMorning(e.target.checked)}
+          />
+          Morning
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showEvening}
+            onChange={(e) => setShowEvening(e.target.checked)}
+          />
+          Evening
+        </label>
+      </div>
+      <svg ref={svgRef} width="400" height="300" />
+    </div>
+  );
+}

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import ReadingSpeedViolin from '../ReadingSpeedViolin';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+const sample = [
+  { start: '2024-01-01T08:00:00Z', wpm: 200, period: 'morning' },
+  { start: '2024-01-01T20:00:00Z', wpm: 300, period: 'evening' },
+];
+
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve(sample) })));
+
+describe('ReadingSpeedViolin', () => {
+  it('renders toggles and chart', async () => {
+    render(<ReadingSpeedViolin />);
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+    expect(screen.getByLabelText('Morning')).toBeInTheDocument();
+    expect(screen.getByLabelText('Evening')).toBeInTheDocument();
+    await waitFor(() => {
+      const rects = document.querySelectorAll('rect');
+      expect(rects.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});

--- a/src/services/__tests__/readingSpeed.test.js
+++ b/src/services/__tests__/readingSpeed.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { calculateReadingSpeeds } from '../readingSpeed';
+
+describe('calculateReadingSpeeds', () => {
+  it('computes words per minute and period for sessions', () => {
+    const sessions = [
+      {
+        start_timestamp: '2024-01-01T08:00:00Z',
+        total_reading_millis: '600000',
+        number_of_page_flips: '10',
+      },
+      {
+        start_timestamp: '2024-01-01T20:00:00Z',
+        total_reading_millis: '300000',
+        number_of_page_flips: '5',
+      },
+    ];
+    const result = calculateReadingSpeeds(sessions);
+    expect(result).toEqual([
+      {
+        start: '2024-01-01T08:00:00Z',
+        asin: undefined,
+        wpm: 2500 / 10, // 10 pages * 250 words / 10 minutes
+        period: 'morning',
+      },
+      {
+        start: '2024-01-01T20:00:00Z',
+        asin: undefined,
+        wpm: 1250 / 5, // 5 pages * 250 words / 5 minutes
+        period: 'evening',
+      },
+    ]);
+  });
+});

--- a/src/services/readingSpeed.js
+++ b/src/services/readingSpeed.js
@@ -1,0 +1,28 @@
+function calculateReadingSpeeds(sessions) {
+  return sessions
+    .filter((s) => {
+      const ts = s.start_timestamp || s.end_timestamp;
+      return ts && ts !== 'Not Available';
+    })
+    .map((s) => {
+      const start =
+        s.start_timestamp && s.start_timestamp !== 'Not Available'
+          ? s.start_timestamp
+          : s.end_timestamp;
+      const minutes = Number(s.total_reading_millis || 0) / 60000;
+      const pages = Number(s.number_of_page_flips || 0);
+      const words = pages * 250;
+      const wpm = minutes > 0 ? words / minutes : 0;
+      const hour = new Date(start).getHours();
+      const period = hour < 12 ? 'morning' : 'evening';
+      return {
+        start,
+        asin: s.ASIN,
+        wpm,
+        period,
+      };
+    })
+    .sort((a, b) => a.start.localeCompare(b.start));
+}
+
+module.exports = { calculateReadingSpeeds };


### PR DESCRIPTION
## Summary
- calculate words-per-minute per reading session
- expose reading speed via `/api/kindle/reading-speed`
- add D3 violin chart with morning/evening toggles

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689152c8626c8324b7290f6258a45390