### PR TITLE
feat: add saved view comparison and cluster badges

### DIFF
--- a/src/components/maps/ClusterCard.tsx
+++ b/src/components/maps/ClusterCard.tsx
@@ -19,6 +19,7 @@ import {
   DialogTrigger,
   DialogContent,
 } from "@/ui/dialog";
+import { Badge } from "@/ui/badge";
 import * as React from "react";
 
 interface ClusterCardProps {
@@ -30,6 +31,7 @@ interface ClusterCardProps {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   onSelect?: () => void
+  goodDay?: boolean
 }
 
 export default function ClusterCard({
@@ -38,6 +40,7 @@ export default function ClusterCard({
   stability,
   label,
   centroid,
+  goodDay,
   open,
   onOpenChange,
   onSelect,
@@ -55,7 +58,12 @@ export default function ClusterCard({
       <DialogTrigger asChild>
         <Card className="cursor-pointer" onClick={onSelect}>
           <CardHeader className="p-4 pb-2">
-            <CardTitle className="text-sm">{label}</CardTitle>
+            <CardTitle className="text-sm flex items-center gap-2">
+              {label}
+              {goodDay && (
+                <Badge variant="secondary">Good day cluster</Badge>
+              )}
+            </CardTitle>
             <CardDescription className="text-xs">
               {temp.toFixed(1)}°F · {start.toFixed(0)}h · Δ {delta.toFixed(2)} ·
               Stability {(stability * 100).toFixed(0)}%

--- a/src/components/maps/SessionSimilarityMap.tsx
+++ b/src/components/maps/SessionSimilarityMap.tsx
@@ -157,6 +157,7 @@ export default function SessionSimilarityMap({
     const avgTemp = points.reduce((s, p) => s + p.temperature, 0) / points.length
     const avgHour = points.reduce((s, p) => s + p.startHour, 0) / points.length
     const avgDelta = points.reduce((s, p) => s + p.paceDelta, 0) / points.length
+    const goodFreq = points.filter((p) => p.good).length / points.length
     return {
       cluster: c,
       points,
@@ -164,6 +165,7 @@ export default function SessionSimilarityMap({
       centroid,
       stability: stability[c] ?? 0,
       centroidVec: { temperature: avgTemp, startHour: avgHour, paceDelta: avgDelta },
+      goodDay: goodFreq > 0.6,
     }
   })
   const [activeCluster, setActiveCluster] = useState<number | null>(null)
@@ -401,6 +403,9 @@ export default function SessionSimilarityMap({
                 label={clusterConfig[c].label}
                 centroid={
                   clusterDetails.find((d) => d.cluster === c)?.centroidVec
+                }
+                goodDay={
+                  clusterDetails.find((d) => d.cluster === c)?.goodDay
                 }
                 open={activeCluster === c}
                 onOpenChange={(o) => setActiveCluster(o ? c : null)}

--- a/src/lib/savedViewStore.ts
+++ b/src/lib/savedViewStore.ts
@@ -1,0 +1,32 @@
+export interface SavedView {
+  id: string
+  /** ISO timestamp when this view was saved */
+  created: string
+  method: 'tsne' | 'umap'
+  sessions: import('@/hooks/useRunningSessions').SessionPoint[]
+  axisHints?: import('@/hooks/useRunningSessions').AxisHint[] | null
+}
+
+const KEY = 'saved_views'
+
+export function getSavedViews(): SavedView[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || '[]') as SavedView[]
+  } catch {
+    return []
+  }
+}
+
+export function saveView(view: SavedView): void {
+  if (typeof localStorage === 'undefined') return
+  const all = getSavedViews()
+  all.push(view)
+  localStorage.setItem(KEY, JSON.stringify(all))
+}
+
+export function removeView(id: string): void {
+  if (typeof localStorage === 'undefined') return
+  const filtered = getSavedViews().filter((v) => v.id !== id)
+  localStorage.setItem(KEY, JSON.stringify(filtered))
+}

--- a/src/pages/SessionSimilarity.tsx
+++ b/src/pages/SessionSimilarity.tsx
@@ -1,12 +1,38 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { SessionSimilarityMap } from "@/components/maps";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
 import { useSessionInsights } from "@/hooks/useSessionInsights";
+import {
+  getSavedViews,
+  saveView,
+  type SavedView,
+} from "@/lib/savedViewStore";
 
 export default function SessionSimilarityPage() {
   const [method, setMethod] = useState<"tsne" | "umap">("tsne");
   const { sessions, clusterStats, axisHints, error } = useRunningSessions(method);
   const insights = useSessionInsights(clusterStats);
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  const [compareId, setCompareId] = useState<string>("");
+
+  useEffect(() => {
+    setSavedViews(getSavedViews());
+  }, []);
+
+  const handleSave = () => {
+    if (!sessions) return;
+    const view: SavedView = {
+      id: Date.now().toString(),
+      created: new Date().toISOString(),
+      method,
+      sessions,
+      axisHints,
+    };
+    saveView(view);
+    setSavedViews(getSavedViews());
+  };
+
+  const compare = savedViews.find((v) => v.id === compareId) || null;
 
   return (
     <div className="p-4 space-y-4">
@@ -21,7 +47,7 @@ export default function SessionSimilarityPage() {
       <p className="text-sm text-muted-foreground">
         Visualize how recent runs cluster based on their characteristics.
       </p>
-      <div className="flex items-center gap-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
         <label htmlFor="embed">Embedding:</label>
         <select
           id="embed"
@@ -32,10 +58,43 @@ export default function SessionSimilarityPage() {
           <option value="tsne">t-SNE</option>
           <option value="umap">UMAP</option>
         </select>
+        <button
+          onClick={handleSave}
+          className="ml-2 rounded border px-2 py-1"
+          disabled={!sessions}
+        >
+          Save View
+        </button>
+        {savedViews.length > 0 && (
+          <>
+            <label htmlFor="compare">Compare:</label>
+            <select
+              id="compare"
+              value={compareId}
+              onChange={(e) => setCompareId(e.target.value)}
+              className="border rounded p-1"
+            >
+              <option value="">None</option>
+              {savedViews.map((v) => (
+                <option key={v.id} value={v.id}>
+                  {new Date(v.created).toLocaleString()}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
       </div>
       {error ? (
         <div className="text-sm text-red-500">
           Unable to load running sessions.
+        </div>
+      ) : compare ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          <SessionSimilarityMap
+            data={compare.sessions}
+            axisHints={compare.axisHints}
+          />
+          <SessionSimilarityMap data={sessions} axisHints={axisHints} />
         </div>
       ) : (
         <SessionSimilarityMap data={sessions} axisHints={axisHints} />


### PR DESCRIPTION
## Summary
- add localStorage-backed SavedView model for session clusters
- allow saving and comparing embeddings on Session Similarity page
- mark clusters with high good-run ratios as "Good day" badges

## Testing
- `npm test`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6891564538a48324bbf7cf33a5ddb5ac