### PR TITLE
feat: add global header with dashboard link

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import CommandPalette from "@/ui/CommandPalette";
 import { ChartActionsProvider } from "@/hooks/useChartActions";
 import useRecentViews from "@/hooks/useRecentViews";
@@ -11,6 +11,9 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   const location = useLocation();
   const { addRecentView } = useRecentViews();
+  const [commandOpen, setCommandOpen] = React.useState(false);
+
+  const isDashboard = location.pathname.startsWith("/dashboard");
 
   React.useEffect(() => {
     addRecentView(location.pathname);
@@ -18,7 +21,22 @@ export default function RootLayout({ children }: RootLayoutProps) {
 
   return (
     <ChartActionsProvider>
-      <CommandPalette />
+      <CommandPalette open={commandOpen} setOpen={setCommandOpen} />
+      {!isDashboard && (
+        <header className="flex items-center justify-between border-b p-4">
+          <Link to="/dashboard" className="font-semibold">
+            Home
+          </Link>
+          <button
+            type="button"
+            onClick={() => setCommandOpen(true)}
+            className="rounded-md border px-2 py-1 text-sm"
+            aria-label="Open command palette"
+          >
+            Search
+          </button>
+        </header>
+      )}
       <main className="flex-1 p-4">{children}</main>
     </ChartActionsProvider>
   );


### PR DESCRIPTION
## Summary
- add lightweight global header with Home link to `/dashboard`
- include command palette trigger in the new header
- hide header when viewing dashboard layouts to avoid duplication

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689152cf0a088324a51a67d6ef482dc4