### PR TITLE
feat: add session narratives

### DIFF
--- a/src/hooks/useRunningSessions.ts
+++ b/src/hooks/useRunningSessions.ts
@@ -61,7 +61,7 @@ export interface AxisHint {
   y: number
 }
 
-function computeClusterMetrics(
+export function computeClusterMetrics(
   points: SessionPoint[],
 ): Record<number, ClusterMetrics> {
   const clusters = Array.from(new Set(points.map((p) => p.cluster)))

--- a/src/pages/SessionSimilarity.tsx
+++ b/src/pages/SessionSimilarity.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { SessionSimilarityMap } from "@/components/maps";
 import { useRunningSessions } from "@/hooks/useRunningSessions";
-import { useSessionInsights } from "@/hooks/useSessionInsights";
 import {
   getSavedViews,
   saveView,
@@ -10,10 +9,11 @@ import {
 
 export default function SessionSimilarityPage() {
   const [method, setMethod] = useState<"tsne" | "umap">("tsne");
-  const { sessions, clusterStats, axisHints, error } = useRunningSessions(method);
-  const insights = useSessionInsights(clusterStats);
+  const { sessions, axisHints, error } = useRunningSessions(method);
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [compareId, setCompareId] = useState<string>("");
+  const [narrative, setNarrative] = useState("");
+  const [tips, setTips] = useState<string[]>([]);
 
   useEffect(() => {
     setSavedViews(getSavedViews());
@@ -37,9 +37,10 @@ export default function SessionSimilarityPage() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Session Similarity</h1>
-      {insights.length > 0 && (
+      {narrative && <p className="text-sm font-medium">{narrative}</p>}
+      {tips.length > 0 && (
         <div className="space-y-1 text-sm text-muted-foreground">
-          {insights.map((i, idx) => (
+          {tips.map((i, idx) => (
             <p key={idx}>{i}</p>
           ))}
         </div>
@@ -94,10 +95,24 @@ export default function SessionSimilarityPage() {
             data={compare.sessions}
             axisHints={compare.axisHints}
           />
-          <SessionSimilarityMap data={sessions} axisHints={axisHints} />
+          <SessionSimilarityMap
+            data={sessions}
+            axisHints={axisHints}
+            onNarrative={(n, t) => {
+              setNarrative(n);
+              setTips(t);
+            }}
+          />
         </div>
       ) : (
-        <SessionSimilarityMap data={sessions} axisHints={axisHints} />
+        <SessionSimilarityMap
+          data={sessions}
+          axisHints={axisHints}
+          onNarrative={(n, t) => {
+            setNarrative(n);
+            setTips(t);
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- derive narratives by combining session insights with stability labels
- surface latest narrative and tips above Session Similarity map
- recompute narratives as map filters or data update

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68915b0879e08324bfdc43d44e74b2bd