### PR TITLE
feat: add top navigation menu

### DIFF
--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+  NavigationMenuViewport,
+} from "@/components/ui/navigation-menu";
+
+export default function TopNavigation() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        {dashboardRoutes.map((group) => {
+          const Icon = group.icon;
+          return (
+            <NavigationMenuItem key={group.label}>
+              <NavigationMenuTrigger className="flex items-center gap-2">
+                {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
+                <span>{group.label}</span>
+              </NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <ul className="flex w-48 flex-col gap-2 p-4">
+                  <li>
+                    <NavigationMenuLink asChild>
+                      <NavLink to="/dashboard" className="block px-2 py-1 text-sm">
+                        Dashboard
+                      </NavLink>
+                    </NavigationMenuLink>
+                  </li>
+                  {group.items.map((item) => (
+                    <li key={item.to}>
+                      <NavigationMenuLink asChild>
+                        <NavLink
+                          to={item.to}
+                          className="block px-2 py-1 text-sm"
+                        >
+                          {item.label}
+                        </NavLink>
+                      </NavigationMenuLink>
+                    </li>
+                  ))}
+                </ul>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          );
+        })}
+      </NavigationMenuList>
+      <NavigationMenuViewport />
+    </NavigationMenu>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `TopNavigation` component rendering dashboard groups as dropdowns
- list each group's routes and include a Dashboard link

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6891602b9c488324a995aba7f33e73e7