### PR TITLE
Simplify app routing and add NotFound page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,11 @@
 import React, { lazy, Suspense } from "react";
 import RootLayout from "@/layouts/RootLayout";
-import SidebarLayout from "@/layouts/SidebarLayout";
-import MobileTabLayout from "@/layouts/MobileTabLayout";
-import Dashboard from "@/pages/Dashboard";
 import DashboardLanding from "@/pages/DashboardLanding";
 import SidebarDemoPage from "@/pages/SidebarDemo";
+import NotFound from "@/pages/NotFound";
 import { dashboardRoutes } from "@/routes";
 
-import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 import { SelectionProvider } from "@/hooks/useSelection";
 
@@ -22,11 +20,10 @@ function createDashboardRoutes() {
           default: MissingComponent,
         })),
       );
-      const path = to.replace("/dashboard/", "");
       return (
         <Route
-          key={path}
-          path={path}
+          key={to}
+          path={to}
           element={
             <Suspense fallback={<div>Loading...</div>}>
               <LazyComp />
@@ -45,33 +42,14 @@ function App() {
         <SelectionProvider>
           <RootLayout>
             <Routes>
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/" element={<DashboardLanding />} />
               <Route
                 path="/visualizations"
                 element={<Navigate to="/dashboard/all" replace />}
               />
               <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
-              <Route path="/dashboard" element={<Dashboard />}>
-                <Route
-                  element={
-                    <>
-                      <div className="hidden h-full md:block">
-                        <SidebarLayout>
-                          <Outlet />
-                        </SidebarLayout>
-                      </div>
-                      <div className="h-full md:hidden">
-                        <MobileTabLayout>
-                          <Outlet />
-                        </MobileTabLayout>
-                      </div>
-                    </>
-                  }
-                >
-                  <Route index element={<DashboardLanding />} />
-                  {createDashboardRoutes()}
-                </Route>
-              </Route>
+              {createDashboardRoutes()}
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </RootLayout>
         </SelectionProvider>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const NotFound = () => <div>Page not found</div>;
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- remove dashboard-specific layout wrappers and route `/` directly to dashboard landing page
- generate dashboard routes at root level and add catch-all NotFound route
- add basic NotFound component

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68916349c7088324b52f7897d53f8d34