### PR TITLE
Add Kindle visualization pages and routes

### DIFF
--- a/src/pages/charts/BookNetwork.jsx
+++ b/src/pages/charts/BookNetwork.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import BookNetwork from '@/components/network/BookNetwork.jsx';
+
+export default function BookNetworkPage() {
+  return (
+    <div className="p-4">
+      <BookNetwork />
+    </div>
+  );
+}

--- a/src/pages/charts/GenreSankey.jsx
+++ b/src/pages/charts/GenreSankey.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import GenreSankey from '@/components/genre/GenreSankey.jsx';
+
+export default function GenreSankeyPage() {
+  return (
+    <div className="p-4">
+      <GenreSankey />
+    </div>
+  );
+}

--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from 'react';
+import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
+
+export default function GenreSunburstPage() {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    fetch('/api/kindle/genre-hierarchy')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+  if (!data) return <div>Loading...</div>;
+  return (
+    <div className="p-4">
+      <GenreSunburst data={data} />
+    </div>
+  );
+}

--- a/src/pages/charts/ReadingCalendarHeatmap.jsx
+++ b/src/pages/charts/ReadingCalendarHeatmap.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import CalendarHeatmap from '@/components/calendar/CalendarHeatmap.jsx';
+
+export default function ReadingCalendarHeatmapPage() {
+  return (
+    <div className="p-4">
+      <CalendarHeatmap />
+    </div>
+  );
+}

--- a/src/pages/charts/ReadingMap.jsx
+++ b/src/pages/charts/ReadingMap.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReadingMap from '@/components/map/ReadingMap.jsx';
+
+export default function ReadingMapPage() {
+  return (
+    <div className="p-4">
+      <ReadingMap />
+    </div>
+  );
+}

--- a/src/pages/charts/ReadingSpeedViolin.jsx
+++ b/src/pages/charts/ReadingSpeedViolin.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReadingSpeedViolin from '@/components/stats/ReadingSpeedViolin.jsx';
+
+export default function ReadingSpeedViolinPage() {
+  return (
+    <div className="p-4">
+      <ReadingSpeedViolin />
+    </div>
+  );
+}

--- a/src/pages/charts/ReadingTimeline.jsx
+++ b/src/pages/charts/ReadingTimeline.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import useReadingSessions from '@/hooks/useReadingSessions';
+import ReadingTimeline from '@/components/timeline/ReadingTimeline.jsx';
+
+export default function ReadingTimelinePage() {
+  const { data, error, isLoading } = useReadingSessions();
+  if (error) return <div>Failed to load sessions</div>;
+  if (isLoading) return <div>Loading...</div>;
+  return (
+    <div className="p-4">
+      <ReadingTimeline sessions={data || []} />
+    </div>
+  );
+}

--- a/src/pages/charts/WordTree.jsx
+++ b/src/pages/charts/WordTree.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import WordTree from '@/components/highlights/WordTree.jsx';
+
+export default function WordTreePage() {
+  return (
+    <div className="p-4">
+      <WordTree />
+    </div>
+  );
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import {
   Goal,
   Shield,
   List,
+  BookOpen,
 } from "lucide-react";
 import {
   withIcon,
@@ -240,6 +241,71 @@ const analyticalRouteGroup: DashboardRouteGroup = {
   items: analyticalRoutes,
 };
 
+export const kindleRoutes = withIcon(BookOpen, [
+  {
+    to: "/dashboard/kindle/calendar-heatmap",
+    label: "Daily Reading Calendar",
+    description: "GitHub-style calendar of reading activity",
+    component: "@/pages/charts/ReadingCalendarHeatmap",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/timeline",
+    label: "Reading Timeline",
+    description: "Interactive timeline of sessions",
+    component: "@/pages/charts/ReadingTimeline",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/genre-sunburst",
+    label: "Genre Hierarchy Sunburst",
+    description: "Drill into genres by reading time",
+    component: "@/pages/charts/GenreSunburst",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/genre-sankey",
+    label: "Genre Transition Sankey",
+    description: "Flow of reading across genres",
+    component: "@/pages/charts/GenreSankey",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/word-tree",
+    label: "Highlight Word Tree",
+    description: "Explore highlight contexts",
+    component: "@/pages/charts/WordTree",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/reading-map",
+    label: "Reading Locations Map",
+    description: "Geospatial heatmap of reading",
+    component: "@/pages/charts/ReadingMap",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/reading-speed",
+    label: "Reading Speed Distribution",
+    description: "Violin plot of reading speed",
+    component: "@/pages/charts/ReadingSpeedViolin",
+    tags: ["kindle"],
+  },
+  {
+    to: "/dashboard/kindle/book-network",
+    label: "Related Books Network",
+    description: "Force-directed graph of books",
+    component: "@/pages/charts/BookNetwork",
+    tags: ["kindle"],
+  },
+]);
+
+const kindleRouteGroup: DashboardRouteGroup = {
+  label: "Kindle Insights",
+  icon: BookOpen,
+  items: kindleRoutes,
+};
+
 export const goalsRoutes = withIcon(Goal, [
   {
     to: "/dashboard/charts/steps-trend-with-goal",
@@ -305,6 +371,7 @@ export const dashboardRoutes: DashboardRouteGroup[] = [
   mapsRouteGroup,
   trendsRouteGroup,
   analyticalRouteGroup,
+  kindleRouteGroup,
   goalsRouteGroup,
   privacyRouteGroup,
 ];


### PR DESCRIPTION
## Summary
- add pages for calendar heatmap, timeline, genre sunburst, genre sankey, word tree, reading map, reading speed violin, and book network
- group new pages under a Kindle Insights section in dashboard routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68912520826c8324aa6dfba08bc59421