### PR TITLE
Enhance cluster accessibility and animations

### DIFF
--- a/src/components/maps/ClusterCard.tsx
+++ b/src/components/maps/ClusterCard.tsx
@@ -56,7 +56,18 @@ export default function ClusterCard({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
-        <Card className="cursor-pointer" onClick={onSelect}>
+        <Card
+          role="button"
+          tabIndex={0}
+          className="cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onSelect}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
+              ;(e.currentTarget as HTMLElement).click()
+            }
+          }}
+        >
           <CardHeader className="p-4 pb-2">
             <CardTitle className="text-sm flex items-center gap-2">
               {label}


### PR DESCRIPTION
## Summary
- add keyboard and focus support to cluster cards
- animate hulls and points and expose screen-reader friendly run lists
- collapse cluster cards into mobile accordions for easier navigation

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68915dda84c48324b9655fe30f0b84ff