### PR TITLE
Add Dashboard link and adjust breadcrumbs

### DIFF
--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -8,6 +8,7 @@ for (const group of dashboardRoutes) {
     routeLabelMap[item.to] = item.label;
   }
 }
+routeLabelMap["/"] = "Dashboard";
 
 interface BreadcrumbsProps {
   /**
@@ -34,7 +35,10 @@ export default function Breadcrumbs({ labels = {} }: BreadcrumbsProps) {
   }
 
   const crumbs = segments.map((segment, index) => {
-    const to = "/" + segments.slice(0, index + 1).join("/");
+    let to = "/" + segments.slice(0, index + 1).join("/");
+    if (index === 0 && segment === "dashboard") {
+      to = "/";
+    }
     let label: string | undefined;
 
     const paramEntry = Object.entries(params).find(([, value]) => value === segment);

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -15,6 +15,13 @@ export default function TopNavigation() {
   return (
     <NavigationMenu>
       <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <NavLink to="/" className="block px-2 py-1 text-sm">
+              Dashboard
+            </NavLink>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
         {dashboardRoutes.map((group) => {
           const Icon = group.icon;
           return (
@@ -25,13 +32,6 @@ export default function TopNavigation() {
               </NavigationMenuTrigger>
               <NavigationMenuContent>
                 <ul className="flex w-48 flex-col gap-2 p-4">
-                  <li>
-                    <NavigationMenuLink asChild>
-                      <NavLink to="/dashboard" className="block px-2 py-1 text-sm">
-                        Dashboard
-                      </NavLink>
-                    </NavigationMenuLink>
-                  </li>
                   {group.items.map((item) => (
                     <li key={item.to}>
                       <NavigationMenuLink asChild>

--- a/src/components/layout/__tests__/breadcrumbs.test.tsx
+++ b/src/components/layout/__tests__/breadcrumbs.test.tsx
@@ -22,7 +22,7 @@ describe("Breadcrumbs", () => {
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveTextContent("Dashboard");
-    expect(links[0]).toHaveAttribute("href", "/dashboard");
+    expect(links[0]).toHaveAttribute("href", "/");
     expect(links[1]).toHaveTextContent("Charts");
     expect(links[1]).toHaveAttribute("href", "/dashboard/charts");
     expect(

--- a/src/components/trends/HabitConsistencyHeatmap.tsx
+++ b/src/components/trends/HabitConsistencyHeatmap.tsx
@@ -49,7 +49,7 @@ export default function HabitConsistencyHeatmap({
         <div className="flex flex-col items-center justify-center gap-4 h-64 md:h-80 lg:h-96 text-sm text-muted-foreground text-center">
           <p>No session data yet.</p>
           <Button asChild size="sm">
-            <Link to="/dashboard">Log a session</Link>
+            <Link to="/">Log a session</Link>
           </Button>
         </div>
       </ChartCard>


### PR DESCRIPTION
## Summary
- add Dashboard link to top navigation
- map breadcrumbs root to Dashboard and update tests
- point heatmap session link to dashboard landing

## Testing
- `npm run lint` (fails: Missing script "lint")
- `CI=true npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689167810c4c832489265100b25c5fb8