### PR TITLE
fix: load dashboard routes dynamically

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,15 +11,18 @@ import { SelectionProvider } from "@/hooks/useSelection";
 
 const MissingComponent = () => <div>Component not found</div>;
 
+const pageModules = import.meta.glob("@/pages/**/*.{ts,tsx,js,jsx}");
+
 function createDashboardRoutes() {
   return dashboardRoutes.flatMap(({ items }) =>
     items.map(({ to, component }) => {
       if (!component) return [];
-      const LazyComp = lazy(() =>
-        import(/* @vite-ignore */ component).catch(() => ({
-          default: MissingComponent,
-        })),
-      );
+      const importer =
+        pageModules[`${component}.tsx`] ||
+        pageModules[`${component}.ts`] ||
+        pageModules[`${component}.jsx`] ||
+        pageModules[`${component}.js`];
+      const LazyComp = importer ? lazy(importer as any) : MissingComponent;
       return (
         <Route
           key={to}


### PR DESCRIPTION
## Summary
- resolve dashboard component paths at build-time using `import.meta.glob`

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68916ad99870832481ac3850557f3610