### PR TITLE
fix: resolve page module lookup with path alias

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,12 @@ function createDashboardRoutes() {
   return dashboardRoutes.flatMap(({ items }) =>
     items.map(({ to, component }) => {
       if (!component) return [];
+      const path = component.replace("@/", "./");
       const importer =
-        pageModules[`${component}.tsx`] ||
-        pageModules[`${component}.ts`] ||
-        pageModules[`${component}.jsx`] ||
-        pageModules[`${component}.js`];
+        pageModules[`${path}.tsx`] ||
+        pageModules[`${path}.ts`] ||
+        pageModules[`${path}.jsx`] ||
+        pageModules[`${path}.js`];
       const LazyComp = importer ? lazy(importer as any) : MissingComponent;
       return (
         <Route


### PR DESCRIPTION
## Summary
- normalize component paths to remove `@/` before looking up modules

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68916f9e168083249b3882861eaf6e7f