### PR TITLE
fix routing page import glob

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { SelectionProvider } from "@/hooks/useSelection";
 
 const MissingComponent = () => <div>Component not found</div>;
 
-const pageModules = import.meta.glob("@/pages/**/*.{ts,tsx,js,jsx}");
+const pageModules = import.meta.glob("./pages/**/*.{ts,tsx,js,jsx}");
 
 function createDashboardRoutes() {
   return dashboardRoutes.flatMap(({ items }) =>


### PR DESCRIPTION
## Summary
- fix glob imports to pull pages with "./" keys

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891732f7e208324906e80bc32418b5e