### PR TITLE
Generate reading speed data from sessions

### DIFF
--- a/scripts/generate-reading-speed.js
+++ b/scripts/generate-reading-speed.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const { getReadingSpeed } = require('../server/services/kindleService');
+
+function main() {
+  const data = getReadingSpeed();
+  const outPath = path.join(__dirname, '..', 'src', 'data', 'kindle', 'reading-speed.json');
+  fs.writeFileSync(outPath, JSON.stringify(data, null, 2) + '\n');
+  console.log(`Wrote ${data.length} records to ${outPath}`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/src/data/kindle/reading-speed.json
+++ b/src/data/kindle/reading-speed.json
@@ -1,4 +1,34844 @@
 [
-  { "start": "2024-01-01T08:00:00Z", "wpm": 200, "period": "morning" },
-  { "start": "2024-01-01T20:00:00Z", "wpm": 300, "period": "evening" }
+  {
+    "start": "2018-01-09T22:49:43Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 10465.116279069767,
+    "period": "evening"
+  },
+  {
+    "start": "2018-01-12T04:36:39Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 612.2448979591837,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-13T03:49:45Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-13T03:49:54Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 1198.4021304926764,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-16T20:39:06Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 3260.8695652173915,
+    "period": "evening"
+  },
+  {
+    "start": "2018-01-18T01:27:44Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 2142.8571428571427,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-18T01:27:57Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 1282.051282051282,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-18T01:40:51Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 432.8587918430165,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-19T03:01:55Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 145.08045370614616,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-19T03:28:53Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 1785.7142857142856,
+    "period": "morning"
+  },
+  {
+    "start": "2018-01-20T19:46:13Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 958.4664536741215,
+    "period": "evening"
+  },
+  {
+    "start": "2018-01-20T19:47:56Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 5487.804878048781,
+    "period": "evening"
+  },
+  {
+    "start": "2018-01-20T19:48:07Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 40909.09090909091,
+    "period": "evening"
+  },
+  {
+    "start": "2018-01-21T19:25:23Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 1906.7796610169491,
+    "period": "evening"
+  },
+  {
+    "start": "2018-01-22T18:40:52Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 770.0205338809035,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-01T22:40:29Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 167.46168679589974,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-01T22:58:47Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 173.81228273464657,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-02T01:48:04Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 294.9852507374631,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-02T02:41:51Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 363.9973527465255,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-02T18:17:08Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 227.99817601459188,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-02T19:12:39Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 436.43688451208595,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-03T12:06:21Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 306.85305148312307,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-04T04:10:32Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 234.78260869565216,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-04T12:34:37Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 222.8826151560178,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-04T12:38:11Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 481.92771084337346,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-07T03:15:37Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 529.333921482135,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-09T07:21:10Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 528.9139633286319,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-13T22:08:36Z",
+    "asin": "B01MAWT2MO",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-13T22:08:59Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJTMFYwMEhJUktPR1MmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMU1BV1QyTU8mZW5kdGltZT0xNTE4NTU2MzcwNzk3",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-19T03:15:33Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 579.1505791505792,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-19T03:16:28Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 467.2558678643871,
+    "period": "morning"
+  },
+  {
+    "start": "2018-02-19T14:43:15Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 2941.176470588235,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-19T14:56:46Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 1923.076923076923,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-19T16:33:25Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 5000,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-19T17:04:27Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 1685.3932584269662,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-20T18:54:59Z",
+    "asin": "B00NLLYN4Y",
+    "wpm": 3260.8695652173915,
+    "period": "evening"
+  },
+  {
+    "start": "2018-02-20T18:56:09Z",
+    "asin": "B01KE61LPW",
+    "wpm": 19060.77348066298,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-09T18:27:48Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJIVUFEWUYyRkc3WlgmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMUtFNjFMUFcmZW5kdGltZT0xNTE5MTUzMDMyNjQ2",
+    "wpm": 3488.3720930232557,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-18T03:27:56Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QU9KUjBXMFRHVUJLQiZtYXJrZXRwbGFjZT1BVFZQREtJS1gwREVSJmFzaW49QjAxMjA4TzAwSyZlbmR0aW1lPTE1MjEyMjc1MjIyNzQ",
+    "wpm": 2112.676056338028,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-18T03:28:10Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 414.9760236075249,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-19T02:26:58Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 596.0264900662252,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-19T02:29:52Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 401.2588512981904,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-21T01:44:08Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 5263.157894736842,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-21T02:06:48Z",
+    "asin": "B079ZLBXV6",
+    "wpm": 2205.8823529411766,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-21T02:08:32Z",
+    "asin": "B074ST9DGK",
+    "wpm": 246.0697197539303,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-22T02:23:10Z",
+    "asin": "B074ST9DGK",
+    "wpm": 317.6844334627603,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-22T02:28:54Z",
+    "asin": "B071Y385Q1",
+    "wpm": 781.25,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-22T02:29:15Z",
+    "asin": "B071Y385Q1",
+    "wpm": 6779.661016949152,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-22T02:30:45Z",
+    "asin": "B071Y385Q1",
+    "wpm": 449.10179640718565,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-22T02:31:20Z",
+    "asin": "B071Y385Q1",
+    "wpm": 253.80710659898477,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T02:20:13Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 291.13804203749294,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T09:54:27Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 3529.4117647058824,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T09:55:22Z",
+    "asin": "B071Y385Q1",
+    "wpm": 2000,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T10:12:19Z",
+    "asin": "B071Y385Q1",
+    "wpm": 10150.375939849624,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T10:12:45Z",
+    "asin": "B071Y385Q1",
+    "wpm": 3061.2244897959185,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T10:13:04Z",
+    "asin": "B071Y385Q1",
+    "wpm": 828.7292817679557,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T10:18:55Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 6000,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T10:19:05Z",
+    "asin": "B01A4AXM3W",
+    "wpm": 6976.7441860465115,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-23T20:08:19Z",
+    "asin": "B071Y385Q1",
+    "wpm": 2054.794520547945,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-23T20:08:29Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 1973.6842105263156,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-24T23:34:01Z",
+    "asin": "B071Y385Q1",
+    "wpm": 3872.8897715988087,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-24T23:35:48Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 3125,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T03:52:07Z",
+    "asin": "B071Y385Q1",
+    "wpm": 3061.2244897959185,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-25T21:15:09Z",
+    "asin": "B07B2L77BJ",
+    "wpm": 31.840373593716834,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T21:23:12Z",
+    "asin": "B07B6W7GRQ",
+    "wpm": 401.5650741350906,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T21:39:33Z",
+    "asin": "B079ZLBXV6",
+    "wpm": 74.25742574257426,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T21:43:03Z",
+    "asin": "B07B6NPXHV",
+    "wpm": 38.32396525293817,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T21:49:43Z",
+    "asin": "B079ZQBV4H",
+    "wpm": 304.25963488843814,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T21:50:38Z",
+    "asin": "B07B9GK76Z",
+    "wpm": 57.78120184899846,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-25T22:21:24Z",
+    "asin": "B071Y385Q1",
+    "wpm": 316.32222690847743,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-26T04:00:22Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 1209.6774193548388,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-26T04:02:12Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 1261.1097766034109,
+    "period": "morning"
+  },
+  {
+    "start": "2018-03-26T13:48:37Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 630.2521008403361,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-26T13:49:01Z",
+    "asin": "B071Y385Q1",
+    "wpm": 3157.8947368421054,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-26T13:49:18Z",
+    "asin": "B071Y385Q1",
+    "wpm": 1000,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-26T13:49:28Z",
+    "asin": "B071Y385Q1",
+    "wpm": 683.8905775075988,
+    "period": "evening"
+  },
+  {
+    "start": "2018-03-26T13:50:39Z",
+    "asin": "B071Y385Q1",
+    "wpm": 2941.176470588235,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-03T03:17:09Z",
+    "asin": "B071Y385Q1",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-03T03:17:20Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 844.9936398328184,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-03T19:40:16Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 3947.368421052631,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-05T03:26:37Z",
+    "asin": "B01LXZZ1L5",
+    "wpm": 888.3248730964467,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-12T02:07:11Z",
+    "asin": "B00280LYIM",
+    "wpm": 5847.953216374269,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-12T02:12:25Z",
+    "asin": "B00280LYIM",
+    "wpm": 906.6945416534109,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-12T03:05:42Z",
+    "asin": "B00280LYIM",
+    "wpm": 243.53284987552766,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-13T01:59:08Z",
+    "asin": "B00280LYIM",
+    "wpm": 1492.3998157531094,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-18T03:07:41Z",
+    "asin": "B06W2J89PV",
+    "wpm": 1032.608695652174,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-18T03:16:50Z",
+    "asin": "B06W2J89PV",
+    "wpm": 218.50476951271088,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-18T21:36:07Z",
+    "asin": "B06W2J89PV",
+    "wpm": 246.7781738415136,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-18T22:12:46Z",
+    "asin": "B06W2J89PV",
+    "wpm": 73.03416375882496,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-19T02:29:18Z",
+    "asin": "B06W2J89PV",
+    "wpm": 210.8857200241012,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-19T21:13:49Z",
+    "asin": "B06W2J89PV",
+    "wpm": 4347.826086956522,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-21T02:57:38Z",
+    "asin": "B06W2J89PV",
+    "wpm": 395.77836411609496,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-21T02:58:21Z",
+    "asin": "B06W2J89PV",
+    "wpm": 248.45406360424028,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-21T17:10:11Z",
+    "asin": "B06W2J89PV",
+    "wpm": 102.83951322630406,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-21T20:05:00Z",
+    "asin": "B06W2J89PV",
+    "wpm": 246.6062285687444,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-22T03:20:36Z",
+    "asin": "B06W2J89PV",
+    "wpm": 202.7209658527795,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-22T03:46:50Z",
+    "asin": "B06W2J89PV",
+    "wpm": 379.0271636133923,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-23T03:21:23Z",
+    "asin": "B06W2J89PV",
+    "wpm": 283.0856334041047,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-23T16:17:11Z",
+    "asin": "B06W2J89PV",
+    "wpm": 498.33887043189367,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-24T01:57:44Z",
+    "asin": "B06W2J89PV",
+    "wpm": 802.1390374331552,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-24T02:28:33Z",
+    "asin": "B06W2J89PV",
+    "wpm": 364.8700550505697,
+    "period": "morning"
+  },
+  {
+    "start": "2018-04-24T21:25:39Z",
+    "asin": "B06W2J89PV",
+    "wpm": 9615.384615384615,
+    "period": "evening"
+  },
+  {
+    "start": "2018-04-25T01:50:34Z",
+    "asin": "B06W2J89PV",
+    "wpm": 241.31274131274134,
+    "period": "morning"
+  },
+  {
+    "start": "2018-05-04T02:10:36Z",
+    "asin": "B06W2J89PV",
+    "wpm": 326.0869565217391,
+    "period": "morning"
+  },
+  {
+    "start": "2018-05-06T18:42:04Z",
+    "asin": "B06W2J89PV",
+    "wpm": 10606.060606060606,
+    "period": "evening"
+  },
+  {
+    "start": "2018-06-13T03:23:30Z",
+    "asin": "B009UW5X4C",
+    "wpm": 633.2931242460796,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:29:19Z",
+    "asin": "B009UW5X4C",
+    "wpm": 3376.2057877813504,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:29:53Z",
+    "asin": "B009UW5X4C",
+    "wpm": 4285.714285714285,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:30:26Z",
+    "asin": "B009UW5X4C",
+    "wpm": 10227.272727272728,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:30:52Z",
+    "asin": "B009UW5X4C",
+    "wpm": 8522.727272727272,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:33:11Z",
+    "asin": "B009UW5X4C",
+    "wpm": 6521.739130434782,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:33:19Z",
+    "asin": "B009UW5X4C",
+    "wpm": 3000,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:33:31Z",
+    "asin": "B009UW5X4C",
+    "wpm": 5000,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:33:36Z",
+    "asin": "B009UW5X4C",
+    "wpm": 3947.368421052631,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:33:55Z",
+    "asin": "B009UW5X4C",
+    "wpm": 1303.3873343151695,
+    "period": "morning"
+  },
+  {
+    "start": "2018-06-13T03:47:14Z",
+    "asin": "B009UW5X4C",
+    "wpm": 1098.4699882306788,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-21T15:29:25Z",
+    "asin": "B07192GP7F",
+    "wpm": 1327.4336283185842,
+    "period": "evening"
+  },
+  {
+    "start": "2018-09-21T16:17:38Z",
+    "asin": "B07192GP7F",
+    "wpm": 475.6871035940803,
+    "period": "evening"
+  },
+  {
+    "start": "2018-09-23T02:31:40Z",
+    "asin": "B07192GP7F",
+    "wpm": 247.29156853509184,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-24T01:19:40Z",
+    "asin": "B07192GP7F",
+    "wpm": 360.30341340075853,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-25T03:03:06Z",
+    "asin": "B07192GP7F",
+    "wpm": 253.22959483264827,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-25T22:01:28Z",
+    "asin": "B00BBPVYUS",
+    "wpm": 131.12604491067037,
+    "period": "evening"
+  },
+  {
+    "start": "2018-09-26T02:12:45Z",
+    "asin": "B00BBPVYUS",
+    "wpm": 300.5510101853398,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-26T03:19:28Z",
+    "asin": "B07192GP7F",
+    "wpm": 243.55042395814542,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-26T11:04:22Z",
+    "asin": "B07192GP7F",
+    "wpm": 1271.1864406779662,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-26T18:21:15Z",
+    "asin": "B07192GP7F",
+    "wpm": 1775.1479289940828,
+    "period": "evening"
+  },
+  {
+    "start": "2018-09-27T02:01:45Z",
+    "asin": "B07192GP7F",
+    "wpm": 215.51724137931038,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-27T03:00:58Z",
+    "asin": "B07192GP7F",
+    "wpm": 409.3012219717641,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-27T09:31:11Z",
+    "asin": "B07192GP7F",
+    "wpm": 1376.1467889908256,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-28T01:23:28Z",
+    "asin": "B07192GP7F",
+    "wpm": 242.44684819097353,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-28T08:31:28Z",
+    "asin": "B07192GP7F",
+    "wpm": 3658.536585365854,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-28T08:50:15Z",
+    "asin": "B06W2J89PV",
+    "wpm": 903.6144578313252,
+    "period": "morning"
+  },
+  {
+    "start": "2018-09-29T03:51:58Z",
+    "asin": "B07192GP7F",
+    "wpm": 3000,
+    "period": "morning"
+  },
+  {
+    "start": "2018-10-06T03:25:34Z",
+    "asin": "B07192GP7F",
+    "wpm": 388.39979285344384,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-04T03:49:20Z",
+    "asin": "B0143V938Q",
+    "wpm": 7054.455445544554,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-05T04:00:36Z",
+    "asin": "B00KFEK0I8",
+    "wpm": 1510.0671140939598,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-05T04:07:23Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 347.6514215080346,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-05T23:50:21Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 239.84983314794218,
+    "period": "evening"
+  },
+  {
+    "start": "2018-11-06T00:23:32Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 243.34847501622323,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-06T00:44:06Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 140.8090117767537,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-06T04:31:22Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 220.14886256421008,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-06T12:00:55Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 1369.86301369863,
+    "period": "evening"
+  },
+  {
+    "start": "2018-11-07T02:36:41Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 387.5968992248062,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-07T02:38:03Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 1304.3478260869565,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-07T02:39:39Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 247.97942689199118,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-07T08:54:51Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 389.4755063181582,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-07T09:47:25Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 5940.59405940594,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-08T00:40:33Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 309.80603448275866,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-08T00:59:14Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 328.3173734610123,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-08T03:20:48Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 198.01980198019803,
+    "period": "morning"
+  },
+  {
+    "start": "2018-11-08T21:56:11Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 659.824046920821,
+    "period": "evening"
+  },
+  {
+    "start": "2018-11-09T12:18:42Z",
+    "asin": "B07BDKJVWS",
+    "wpm": 1875,
+    "period": "evening"
+  },
+  {
+    "start": "2019-01-06T13:42:41Z",
+    "asin": "B00O2RPEE4",
+    "wpm": 625.3722453841573,
+    "period": "evening"
+  },
+  {
+    "start": "2019-01-06T13:45:50Z",
+    "asin": "B00O2RPEE4",
+    "wpm": 907.1592023537103,
+    "period": "evening"
+  },
+  {
+    "start": "2019-01-06T14:10:18Z",
+    "asin": "B00O2RPEE4",
+    "wpm": 3943.9088518843123,
+    "period": "evening"
+  },
+  {
+    "start": "2019-01-15T02:49:28Z",
+    "asin": "B00O2RPEE4",
+    "wpm": 1226.537818249396,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-07T15:52:12Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-08T23:05:52Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 791.3961038961039,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-08T23:10:29Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 1395.3488372093022,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-08T23:58:15Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 968.8784497944803,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-09T09:31:47Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 454.57144490822805,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-11T02:22:05Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 1935.4838709677417,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-13T15:45:56Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 1293.103448275862,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-13T22:01:14Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 1435.4066985645934,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-14T21:51:57Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 2255.6390977443607,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-16T13:39:41Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 914.6341463414635,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-20T04:28:05Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 773.1958762886599,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-20T04:30:18Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 626.1927480916031,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-20T12:19:33Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 2279.6352583586627,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-26T05:11:48Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 924.0246406570841,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-26T05:15:56Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 694.0549635445877,
+    "period": "morning"
+  },
+  {
+    "start": "2019-02-26T21:55:27Z",
+    "asin": "B074ZDRGBC",
+    "wpm": 1530.6122448979593,
+    "period": "evening"
+  },
+  {
+    "start": "2019-02-28T20:15:16Z",
+    "asin": "B078W5XGZD",
+    "wpm": 1882.8451882845188,
+    "period": "evening"
+  },
+  {
+    "start": "2019-03-03T18:37:00Z",
+    "asin": "B078W5XGZD",
+    "wpm": 2205.8823529411766,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-13T15:16:36Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 703.125,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-13T15:33:40Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 6521.739130434783,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-21T22:36:50Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 2631.578947368421,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-21T22:36:59Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 718.9934092270821,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-21T23:00:11Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 8955.223880597016,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-22T00:09:06Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 461.8226600985222,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-22T03:02:07Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 1136.3636363636363,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-22T03:02:22Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 691.2442396313363,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-22T03:03:02Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 289.7151134717528,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-22T11:01:41Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 508.4745762711865,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-22T11:02:36Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 505.0505050505051,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-22T21:15:32Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 140.6050276949297,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-22T21:56:05Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 9375,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-22T21:56:11Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 9375,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-23T04:35:31Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 162.28748068006183,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-23T12:42:47Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 182.46941947692102,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-24T04:31:47Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 1079.136690647482,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-24T04:34:31Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 382.9461322440643,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-25T04:00:11Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 1785.7142857142856,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-25T20:44:42Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 206.3273727647868,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T20:48:32Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 30000,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T20:48:39Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 21428.571428571428,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:16:22Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:16:39Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:17:05Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 269.29982046678634,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:24:41Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 156.1822125813449,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:43:59Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:44:07Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 33.34815473543797,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T21:51:46Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 29.126213592233007,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-25T23:26:02Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 838.6581469648563,
+    "period": "evening"
+  },
+  {
+    "start": "2019-11-26T01:07:49Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 265.0762094102054,
+    "period": "morning"
+  },
+  {
+    "start": "2019-11-27T17:43:01Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 4166.666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-10T19:56:27Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 5106.382978723404,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-10T20:04:26Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 6818.181818181819,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-10T21:28:55Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 107.3020414901227,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-10T22:56:31Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 3813.5593220338983,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-10T23:03:12Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 300.1715265866209,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-10T23:10:04Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 340.522133938706,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-11T03:02:00Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 555.5555555555555,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-11T03:06:35Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 117.6470588235294,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-11T03:10:50Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 339.1746749576032,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-11T03:22:07Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 214.40351841671247,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-11T04:16:17Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 234.74178403755866,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-11T15:15:31Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-11T15:46:28Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 5882.35294117647,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-12T03:52:30Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 185.5687899188676,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-15T01:17:39Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 1219.5121951219512,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-15T01:18:14Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 191.0828025477707,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-15T01:18:51Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 2068.965517241379,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-15T04:15:22Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 217.23388848660392,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-16T04:28:05Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 245.52150586523598,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-17T06:16:30Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 335.0413874655104,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-17T06:31:04Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 263.12238564296314,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-17T23:11:20Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 550.1222493887531,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-17T23:17:13Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 357.56853396901073,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-18T05:04:08Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 261.437908496732,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-18T05:15:52Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 237.0916754478398,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-18T14:10:10Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 1276.595744680851,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-19T04:13:26Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 505.3908355795149,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-19T04:20:15Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 10344.827586206897,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-20T03:05:09Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 489.4962267999184,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-20T03:14:09Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 12244.897959183674,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-20T03:19:32Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 399.2015968063872,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-20T03:23:01Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 387.0043000477783,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-20T13:23:20Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 815.2173913043479,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-21T03:51:52Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 773.1958762886599,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-21T22:14:46Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 1315.7894736842104,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-22T02:03:07Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 82.96460176991151,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-22T03:33:56Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 323.888771855909,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-22T09:33:27Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 346.6666666666667,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-22T19:37:39Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 186.08645863154882,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-22T22:21:15Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 4477.611940298508,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-22T22:27:35Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 407.4161549362305,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-23T03:10:56Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 337.62057877813504,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-23T22:21:02Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 4545.454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-23T22:21:58Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 412.5128910278446,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-23T22:32:39Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 591.2918831750583,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-24T04:21:09Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 227.99817601459185,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-24T22:19:22Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 3211.0091743119265,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-24T22:25:08Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 416.4096236890808,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-24T23:38:29Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QVpZVlgyNFVKSk1ZQSZtYXJrZXRwbGFjZT1BVFZQREtJS1gwREVSJmFzaW49QjA3Qlo0Rjc1VCZlbmR0aW1lPTE1NzQ4ODQ2Mzg2ODg",
+    "wpm": 657.8947368421052,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-24T23:39:36Z",
+    "asin": "B00II6SY4W",
+    "wpm": 643.7768240343348,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-24T23:40:04Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 225.42831379621282,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-25T04:08:49Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 336.7833086906522,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-25T20:58:43Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 360.8247422680413,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-25T21:28:59Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 1304.3478260869565,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-25T21:31:38Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 761.4213197969543,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-26T04:33:14Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 336.322869955157,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-26T12:31:31Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 2419.3548387096776,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-26T12:34:39Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 9677.41935483871,
+    "period": "evening"
+  },
+  {
+    "start": "2020-01-27T03:46:51Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 7792.207792207792,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-27T03:50:30Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 2031.602708803612,
+    "period": "morning"
+  },
+  {
+    "start": "2020-01-27T03:52:30Z",
+    "asin": "B000OZ0NXA",
+    "wpm": 4838.709677419355,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-07T02:51:12Z",
+    "asin": "B000QCS932",
+    "wpm": 6132.075471698113,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-07T02:53:45Z",
+    "asin": "B000QCS932",
+    "wpm": 936.9907658881043,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-07T03:17:40Z",
+    "asin": "B000QCS932",
+    "wpm": 484.6153846153846,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-07T03:28:53Z",
+    "asin": "B000QCS932",
+    "wpm": 224.7191011235955,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-07T04:01:26Z",
+    "asin": "B000QCS932",
+    "wpm": 689.655172413793,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-07T21:07:37Z",
+    "asin": "B000QCS932",
+    "wpm": 2238.805970149254,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T21:08:16Z",
+    "asin": "B001FXK8XU",
+    "wpm": 557.6208178438662,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T21:11:30Z",
+    "asin": "B001FXK8XU",
+    "wpm": 219.61932650073206,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T21:14:49Z",
+    "asin": "B001FXK8XU",
+    "wpm": 24.181847493148478,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T21:48:56Z",
+    "asin": "B001FXK8XU",
+    "wpm": 857.1428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T22:02:06Z",
+    "asin": "B001FXK8XU",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T22:02:14Z",
+    "asin": "B001FXK8XU",
+    "wpm": 110.02200440088018,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T22:27:32Z",
+    "asin": "B001FXK8XU",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-07T22:35:56Z",
+    "asin": "B001FXK8XU",
+    "wpm": 140.01244555071563,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-08T00:56:52Z",
+    "asin": "B001FXK8XU",
+    "wpm": 1554.4041450777202,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-08T00:57:15Z",
+    "asin": "B001FXK8XU",
+    "wpm": 12012.320328542095,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-08T00:59:10Z",
+    "asin": "B001FXK8XU",
+    "wpm": 386.4680183712333,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-08T04:14:49Z",
+    "asin": "B001FXK8XU",
+    "wpm": 6382.978723404255,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-08T04:36:01Z",
+    "asin": "B001FXK8XU",
+    "wpm": 380.184331797235,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-08T12:14:35Z",
+    "asin": "B001FXK8XU",
+    "wpm": 815.2173913043479,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-08T12:14:57Z",
+    "asin": "B001FXK8XU",
+    "wpm": 2571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-08T19:33:19Z",
+    "asin": "B000QCS932",
+    "wpm": 2396.1661341853037,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-09T03:55:18Z",
+    "asin": "B001FXK8XU",
+    "wpm": 169.8162501088566,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-09T14:22:47Z",
+    "asin": "B001FXK8XU",
+    "wpm": 1171.875,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-09T14:54:56Z",
+    "asin": "B001FXK8XU",
+    "wpm": 814.4796380090498,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-09T15:18:21Z",
+    "asin": "B001FXK8XU",
+    "wpm": 555.0193050193051,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-09T16:06:45Z",
+    "asin": "B001FXK8XU",
+    "wpm": 445.76523031203567,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-09T16:09:53Z",
+    "asin": "B001FXK8XU",
+    "wpm": 517.3099880620772,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-09T16:23:31Z",
+    "asin": "B001FXK8XU",
+    "wpm": 8571.42857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-10T04:05:41Z",
+    "asin": "B001FXK8XU",
+    "wpm": 346.58040665434385,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-10T04:16:24Z",
+    "asin": "B001FXK8XU",
+    "wpm": 349.2433061699651,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-11T01:34:21Z",
+    "asin": "B001FXK8XU",
+    "wpm": 162.04537270435722,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-11T03:16:33Z",
+    "asin": "B001FXK8XU",
+    "wpm": 281.74042625851814,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-11T05:12:27Z",
+    "asin": "B001FXK8XU",
+    "wpm": 347.84981072877946,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-11T06:07:16Z",
+    "asin": "B001FXK8XU",
+    "wpm": 506.9965524234435,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-12T01:06:18Z",
+    "asin": "B001FXK8XU",
+    "wpm": 385.60411311053986,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-12T01:08:56Z",
+    "asin": "B001FXK8XU",
+    "wpm": 420.4821528686227,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-12T03:37:41Z",
+    "asin": "B001FXK8XU",
+    "wpm": 343.38809587934287,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-12T17:43:37Z",
+    "asin": "B001FXK8XU",
+    "wpm": 203.00642853690366,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-12T18:18:35Z",
+    "asin": "B001FXK8XU",
+    "wpm": 15.91849729385546,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-13T02:57:28Z",
+    "asin": "B001FXK8XU",
+    "wpm": 1744.1860465116279,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-13T03:18:54Z",
+    "asin": "B001FXK8XU",
+    "wpm": 763.6237417563347,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-14T04:16:05Z",
+    "asin": "B001FXK8XU",
+    "wpm": 191.17412776804207,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-14T16:27:59Z",
+    "asin": "B001FXK8XU",
+    "wpm": 205.1632757736365,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-14T16:37:50Z",
+    "asin": "B001FXK8XU",
+    "wpm": 6000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-14T16:37:59Z",
+    "asin": "B001FXK8XU",
+    "wpm": 1388.888888888889,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-14T16:38:24Z",
+    "asin": "B001FXK8XU",
+    "wpm": 10606.060606060606,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T14:58:20Z",
+    "asin": "B001FXK8XU",
+    "wpm": 526.207181180355,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T20:17:52Z",
+    "asin": "B001FXK8XU",
+    "wpm": 1327.4336283185842,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T20:18:05Z",
+    "asin": "B001FXK8XU",
+    "wpm": 714.2857142857143,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T22:37:09Z",
+    "asin": "B001FXK8XU",
+    "wpm": 627.6150627615064,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T22:38:04Z",
+    "asin": "B001FXK8XU",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T23:09:09Z",
+    "asin": "B001FXK8XU",
+    "wpm": 382.6530612244898,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T23:31:32Z",
+    "asin": "B001FXK8XU",
+    "wpm": 481.54093097913324,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-15T23:32:47Z",
+    "asin": "B001FXK8XU",
+    "wpm": 373.2006397725253,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-16T00:08:38Z",
+    "asin": "B001FXK8XU",
+    "wpm": 563.6449037106623,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T00:12:27Z",
+    "asin": "B001FXK8XU",
+    "wpm": 1748.7046632124352,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T02:37:44Z",
+    "asin": "B001FXK8XU",
+    "wpm": 2631.578947368421,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T02:38:13Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7473.684210526316,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T05:21:41Z",
+    "asin": "B004DI7JNG",
+    "wpm": 628.5714285714286,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T08:19:55Z",
+    "asin": "B004DI7JNG",
+    "wpm": 307.12530712530713,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T11:22:42Z",
+    "asin": "B004DI7JNG",
+    "wpm": 291.34295227524973,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T11:30:00Z",
+    "asin": "B004DI7JNG",
+    "wpm": 270.27027027027026,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T11:35:30Z",
+    "asin": "B004DI7JNG",
+    "wpm": 127.94995735001423,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-16T13:43:15Z",
+    "asin": "B004DI7JNG",
+    "wpm": 149.92503748125938,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-16T16:43:34Z",
+    "asin": "B004DI7JNG",
+    "wpm": 268.5284640171858,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-16T16:58:03Z",
+    "asin": "B004DI7JNG",
+    "wpm": 304.01297122010544,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-16T17:10:08Z",
+    "asin": "B004DI7JNG",
+    "wpm": 974.025974025974,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-16T17:18:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4285.714285714285,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-16T18:28:43Z",
+    "asin": "B004DI7JNG",
+    "wpm": 878.3344176968119,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T02:23:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3391.1077618688773,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-17T02:34:55Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1133.0255979857322,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-17T17:39:16Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3690.303907380608,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T17:43:49Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1310.0436681222707,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T17:47:25Z",
+    "asin": "B004DI7JNG",
+    "wpm": 768.5738684884714,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T17:55:13Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1822.9166666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T18:12:35Z",
+    "asin": "B004DI7JNG",
+    "wpm": 8069.620253164558,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T18:19:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1559.2515592515592,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T18:33:09Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4797.979797979798,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T18:34:16Z",
+    "asin": "B004DI7JNG",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T18:57:08Z",
+    "asin": "B004DI7JNG",
+    "wpm": 21428.57142857143,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:06:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 8577.712609970675,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:21:00Z",
+    "asin": "B004DI7JNG",
+    "wpm": 961.9238476953908,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:31:40Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1750.9727626459144,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:32:41Z",
+    "asin": "B004DI7JNG",
+    "wpm": 444.44444444444446,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:44:48Z",
+    "asin": "B004DI7JNG",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:49:04Z",
+    "asin": "B004DI7JNG",
+    "wpm": 528.169014084507,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:51:05Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4054.054054054054,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T19:56:13Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7142.857142857142,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:04:19Z",
+    "asin": "B004DI7JNG",
+    "wpm": 8823.529411764706,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:04:23Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1530.6122448979593,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:08:09Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4411.764705882353,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:39:35Z",
+    "asin": "B004DI7JNG",
+    "wpm": 346.4203233256351,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:48:37Z",
+    "asin": "B004DI7JNG",
+    "wpm": 21428.571428571428,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:48:47Z",
+    "asin": "B004DI7JNG",
+    "wpm": 37.11034141514102,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:56:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7894.736842105262,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T20:56:45Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3114.1868512110727,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T21:08:26Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3348.214285714286,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T21:18:57Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1445.2856159669648,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T21:24:49Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1188.7608069164264,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T21:36:38Z",
+    "asin": "B004DI7JNG",
+    "wpm": 13636.363636363636,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T21:43:40Z",
+    "asin": "B004DI7JNG",
+    "wpm": 15789.473684210525,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T21:56:22Z",
+    "asin": "B004DI7JNG",
+    "wpm": 86.93132425383946,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T22:02:09Z",
+    "asin": "B004DI7JNG",
+    "wpm": 15000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-17T23:56:46Z",
+    "asin": "B004DI7JNG",
+    "wpm": 5345.394736842105,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T00:03:01Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3024.1935483870966,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-18T00:04:46Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2166.0649819494583,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-18T03:01:38Z",
+    "asin": "B004DI7JNG",
+    "wpm": 192.6163723916533,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-18T16:26:32Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2162.7188465499485,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T16:32:56Z",
+    "asin": "B004DI7JNG",
+    "wpm": 107.80702542449016,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T16:51:54Z",
+    "asin": "B004DI7JNG",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T16:56:32Z",
+    "asin": "B004DI7JNG",
+    "wpm": 903.6144578313254,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T17:34:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T18:56:53Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3383.458646616541,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T19:10:43Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1642.7104722792608,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T19:23:36Z",
+    "asin": "B004DI7JNG",
+    "wpm": 15000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T19:36:00Z",
+    "asin": "B004DI7JNG",
+    "wpm": 21428.571428571428,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T19:36:11Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1021.7983651226158,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T19:58:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4212.16848673947,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T20:00:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3071.6723549488056,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T20:01:23Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1666.6666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-18T20:02:20Z",
+    "asin": "B004DI7JNG",
+    "wpm": 842.6966292134831,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T03:40:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 12078.651685393259,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-19T03:46:04Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7912.087912087913,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-19T03:48:16Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1838.879159369527,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-19T14:16:07Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1161.9718309859154,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T14:23:52Z",
+    "asin": "B004DI7JNG",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T15:01:24Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2346.5703971119133,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T15:03:43Z",
+    "asin": "B004DI7JNG",
+    "wpm": 6818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T15:04:11Z",
+    "asin": "B004DI7JNG",
+    "wpm": 632.9113924050632,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T15:05:03Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2380.952380952381,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T15:05:30Z",
+    "asin": "B004DI7JNG",
+    "wpm": 386.59793814432993,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T15:06:29Z",
+    "asin": "B004DI7JNG",
+    "wpm": 319.8294243070363,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T16:12:56Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1909.7222222222224,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T16:32:04Z",
+    "asin": "B004DI7JNG",
+    "wpm": 13636.363636363638,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T16:50:18Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1856.0179977502812,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T16:54:31Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7276.119402985075,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T16:56:01Z",
+    "asin": "B004DI7JNG",
+    "wpm": 511.1976630963973,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T17:25:14Z",
+    "asin": "B004DI7JNG",
+    "wpm": 693.8775510204082,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T19:22:42Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1304.3478260869565,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T19:32:55Z",
+    "asin": "B004DI7JNG",
+    "wpm": 616.5590135055784,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T20:16:25Z",
+    "asin": "B004DI7JNG",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T20:16:45Z",
+    "asin": "B004DI7JNG",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T22:59:07Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1363.6363636363637,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-19T22:59:25Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3345.7249070631974,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T12:30:53Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2614.678899082569,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T12:32:52Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3260.8695652173915,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T15:44:16Z",
+    "asin": "B004DI7JNG",
+    "wpm": 5084.745762711865,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T16:21:28Z",
+    "asin": "B004DI7JNG",
+    "wpm": 13221.884498480244,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T18:56:45Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1973.6842105263156,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:05:26Z",
+    "asin": "B004DI7JNG",
+    "wpm": 13573.61963190184,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:29:28Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7350.2722323049,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:36:02Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2687.5699888017916,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:39:21Z",
+    "asin": "B004DI7JNG",
+    "wpm": 649.3506493506493,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:42:30Z",
+    "asin": "B004DI7JNG",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:42:38Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7317.073170731708,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:44:48Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2176.5417170495766,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:48:31Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4054.054054054054,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:50:45Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1785.7142857142856,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:52:11Z",
+    "asin": "B004DI7JNG",
+    "wpm": 660.7929515418501,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:53:03Z",
+    "asin": "B004DI7JNG",
+    "wpm": 372.67080745341616,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:56:33Z",
+    "asin": "B004DI7JNG",
+    "wpm": 6818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T20:59:56Z",
+    "asin": "B004DI7JNG",
+    "wpm": 25000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T21:14:29Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1033.0578512396694,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T21:17:01Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3990.1477832512314,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T21:19:05Z",
+    "asin": "B004DI7JNG",
+    "wpm": 993.3774834437087,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T21:21:37Z",
+    "asin": "B004DI7JNG",
+    "wpm": 462.67735965453426,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T21:24:46Z",
+    "asin": "B004DI7JNG",
+    "wpm": 607.2874493927126,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-20T21:50:11Z",
+    "asin": "B004DI7JNG",
+    "wpm": 8823.529411764706,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T05:15:56Z",
+    "asin": "B004DI7JNG",
+    "wpm": 655.5544262628316,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-21T14:04:19Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1648.3516483516485,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T17:54:38Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3846.1538461538457,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T17:56:48Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1829.268292682927,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T17:59:14Z",
+    "asin": "B004DI7JNG",
+    "wpm": 483.35123523093444,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:24:25Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7894.736842105262,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:24:44Z",
+    "asin": "B004DI7JNG",
+    "wpm": 30000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:32:58Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2330.6401491609695,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:36:33Z",
+    "asin": "B004DI7JNG",
+    "wpm": 2808.9887640449438,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:37:01Z",
+    "asin": "B004DI7JNG",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:38:11Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1535.8361774744028,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:39:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1923.076923076923,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:43:34Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3532.182103610675,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:44:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:44:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:48:53Z",
+    "asin": "B004DI7JNG",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T18:48:53Z",
+    "asin": "B004DI7JNG",
+    "wpm": 392.96407185628743,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T19:54:51Z",
+    "asin": "B004DI7JNG",
+    "wpm": 88.86255924170615,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T20:14:39Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T20:24:07Z",
+    "asin": "B004DI7JNG",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T20:24:32Z",
+    "asin": "B004DI7JNG",
+    "wpm": 1415.0943396226414,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T20:48:29Z",
+    "asin": "B004DI7JNG",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T20:57:59Z",
+    "asin": "B004DI7JNG",
+    "wpm": 13636.363636363636,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T20:59:21Z",
+    "asin": "B004DI7JNG",
+    "wpm": 238.09523809523807,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T21:23:32Z",
+    "asin": "B004DI7JNG",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-21T21:51:55Z",
+    "asin": "B004DI7JNG",
+    "wpm": 30000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-23T20:42:03Z",
+    "asin": "B004DI7JNG",
+    "wpm": 4401.408450704225,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-24T00:56:49Z",
+    "asin": "B004DI7JNG",
+    "wpm": 3922.052294030587,
+    "period": "morning"
+  },
+  {
+    "start": "2020-02-24T17:36:17Z",
+    "asin": "B004DI7JNG",
+    "wpm": 12029.459901800328,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-24T17:42:34Z",
+    "asin": "B004DI7JNG",
+    "wpm": 7078.039927404719,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-24T18:05:30Z",
+    "asin": "B004DI7JNG",
+    "wpm": 11603.37552742616,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-26T19:59:04Z",
+    "asin": "B004DI7JNG",
+    "wpm": 5483.490566037736,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-28T17:36:12Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QUozNk1KS0pFTk5LJm1hcmtldHBsYWNlPUFUVlBES0lLWDBERVImYXNpbj1CMDA0REk3Sk5HJmVuZHRpbWU9MTU4Mjc0NzI0MDA5OQ",
+    "wpm": 34.932463903120635,
+    "period": "evening"
+  },
+  {
+    "start": "2020-02-28T17:43:28Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QUozNk1KS0pFTk5LJm1hcmtldHBsYWNlPUFUVlBES0lLWDBERVImYXNpbj1CMDA0REk3Sk5HJmVuZHRpbWU9MTU4Mjc0NzI0MDA5OQ",
+    "wpm": 2272.7272727272725,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-02T23:52:42Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 826.4462809917355,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-03T04:16:04Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 583.8090295796576,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-04T03:44:21Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 764.2799678197908,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-04T03:51:00Z",
+    "asin": "B077WWXZ41",
+    "wpm": 675.0241080038572,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-04T21:38:38Z",
+    "asin": "B077WWXZ41",
+    "wpm": 158.1065542353392,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-05T03:40:33Z",
+    "asin": "B077WWXZ41",
+    "wpm": 394.0375099273016,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-06T03:37:55Z",
+    "asin": "B077WWXZ41",
+    "wpm": 586.1919235779418,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-06T03:49:31Z",
+    "asin": "B077WWXZ41",
+    "wpm": 2777.777777777778,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-06T03:53:41Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 194.64720194647202,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-06T21:19:23Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 2941.176470588235,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-07T01:51:40Z",
+    "asin": "B077WWXZ41",
+    "wpm": 4285.714285714285,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-07T01:51:54Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 493.2182490752158,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-08T03:16:49Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 93.54536950420953,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-09T02:51:12Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 400.3002251688767,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-09T03:25:55Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 355.0024812001374,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-09T21:23:46Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 1503.6294503975114,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-10T04:10:21Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 1041.6666666666667,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-10T04:32:51Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 652.3407521105142,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-16T02:53:14Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 621.9374293252921,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-16T03:18:14Z",
+    "asin": "B07BZ4F75T",
+    "wpm": 3082.706766917293,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-19T06:59:11Z",
+    "asin": "B000FBJDF2",
+    "wpm": 404.0758959943781,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-20T01:05:28Z",
+    "asin": "B000FBJDF2",
+    "wpm": 241.6570771001151,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-20T06:15:04Z",
+    "asin": "B000FBJDF2",
+    "wpm": 276.4127764127764,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-21T03:37:27Z",
+    "asin": "B000FBJDF2",
+    "wpm": 306.96321826700415,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-21T15:58:58Z",
+    "asin": "B000FBJDF2",
+    "wpm": 144.17531718569782,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-22T04:09:19Z",
+    "asin": "B000FBJDF2",
+    "wpm": 270.148581719946,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-22T19:14:03Z",
+    "asin": "B000FBJDF2",
+    "wpm": 161.49554663795635,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-23T03:16:36Z",
+    "asin": "B000FBJDF2",
+    "wpm": 316.5208440555842,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-24T02:35:13Z",
+    "asin": "B000FBJDF2",
+    "wpm": 292.6194862902352,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-24T03:21:54Z",
+    "asin": "B000FBJDF2",
+    "wpm": 303.4761817178591,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-24T12:36:05Z",
+    "asin": "B000FBJDF2",
+    "wpm": 1851.8518518518517,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-24T12:37:12Z",
+    "asin": "B000FBJDF2",
+    "wpm": 7627.118644067797,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-24T21:01:38Z",
+    "asin": "B000FBJDF2",
+    "wpm": 378.78787878787875,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-24T21:05:10Z",
+    "asin": "B000FBJDF2",
+    "wpm": 287.91678276214355,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-25T02:21:18Z",
+    "asin": "B000FBJDF2",
+    "wpm": 320.80659945004584,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-25T21:46:59Z",
+    "asin": "B000FC1MBO",
+    "wpm": 646.551724137931,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-25T21:47:33Z",
+    "asin": "B000FBJDF2",
+    "wpm": 183.87986515476555,
+    "period": "evening"
+  },
+  {
+    "start": "2020-03-28T02:42:49Z",
+    "asin": "B000FC1MBO",
+    "wpm": 1363.6363636363637,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-28T02:43:06Z",
+    "asin": "B000FBJDF2",
+    "wpm": 175.01555693839452,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-29T03:54:06Z",
+    "asin": "B000FBJDF2",
+    "wpm": 128.6449399656947,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-30T02:32:28Z",
+    "asin": "B000FBJDF2",
+    "wpm": 262.0545073375262,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-31T02:58:41Z",
+    "asin": "B000FBJDF2",
+    "wpm": 286.9996897300652,
+    "period": "morning"
+  },
+  {
+    "start": "2020-03-31T22:33:15Z",
+    "asin": "B000FBJDF2",
+    "wpm": 227.2235446872971,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-01T04:08:56Z",
+    "asin": "B000FBJDF2",
+    "wpm": 340.22177419354836,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-01T21:19:26Z",
+    "asin": "B000FBJDF2",
+    "wpm": 295.612488331086,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-02T00:53:17Z",
+    "asin": "B000FBJDF2",
+    "wpm": 6000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-02T01:24:39Z",
+    "asin": "B000FBJDF2",
+    "wpm": 898.4753146176186,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-02T01:54:34Z",
+    "asin": "B000FC1MBO",
+    "wpm": 393.7007874015748,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-02T01:56:01Z",
+    "asin": "B000FC1MBO",
+    "wpm": 52.1557719054242,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-04T02:57:36Z",
+    "asin": "B000FC1MBO",
+    "wpm": 262.3688155922039,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-04T18:29:37Z",
+    "asin": "B000FC1MBO",
+    "wpm": 151.82186234817814,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-05T03:00:08Z",
+    "asin": "B000FC1MBO",
+    "wpm": 348.5070131658205,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-05T04:00:53Z",
+    "asin": "B000FC1MBO",
+    "wpm": 349.5994173343044,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-05T17:57:07Z",
+    "asin": "B000FC1MBO",
+    "wpm": 256.3940238034945,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-06T02:54:37Z",
+    "asin": "B000FC1MBO",
+    "wpm": 306.2185929648241,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-06T03:32:42Z",
+    "asin": "B000FC1MBO",
+    "wpm": 377.92587776332897,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-07T02:06:21Z",
+    "asin": "B000FC1MBO",
+    "wpm": 308.9183381088825,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-07T03:22:21Z",
+    "asin": "B000FC1MBO",
+    "wpm": 309.583632447954,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-07T20:36:06Z",
+    "asin": "B000FC1MBO",
+    "wpm": 781.25,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-08T02:48:51Z",
+    "asin": "B000FC1MBO",
+    "wpm": 408.74684608915055,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-08T03:40:14Z",
+    "asin": "B000FC1MBO",
+    "wpm": 286.88916515252936,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-10T02:49:12Z",
+    "asin": "B000FC1MBO",
+    "wpm": 409.4631483166515,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-10T03:01:38Z",
+    "asin": "B000FC1MBO",
+    "wpm": 250.214147243136,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-11T18:28:58Z",
+    "asin": "B000FC1MBO",
+    "wpm": 341.9452887537994,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-12T05:48:08Z",
+    "asin": "B000FC1MBO",
+    "wpm": 349.0557594200304,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-12T16:25:32Z",
+    "asin": "B000FC1MBO",
+    "wpm": 359.82160956821406,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-12T17:18:11Z",
+    "asin": "B000FC1MBO",
+    "wpm": 286.6331096196868,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-12T18:05:02Z",
+    "asin": "B000FC1MBO",
+    "wpm": 488.5330438322703,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-13T03:05:23Z",
+    "asin": "B000FCK5PI",
+    "wpm": 858.1235697940504,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-15T13:36:13Z",
+    "asin": "B000FCK5PI",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-15T13:36:26Z",
+    "asin": "B000FCK5PI",
+    "wpm": 3082.1917808219177,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-15T19:51:17Z",
+    "asin": "B000FCK5PI",
+    "wpm": 2112.676056338028,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-15T19:51:25Z",
+    "asin": "B000FCK5PI",
+    "wpm": 3846.153846153846,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-15T19:51:41Z",
+    "asin": "B07L2J8P4S",
+    "wpm": 1219.5121951219512,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-16T02:56:48Z",
+    "asin": "B000FCK5PI",
+    "wpm": 3409.090909090909,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-16T03:02:11Z",
+    "asin": "B000FCK5PI",
+    "wpm": 4128.440366972477,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-16T17:00:44Z",
+    "asin": "B000FCK5PI",
+    "wpm": 3409.090909090909,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-16T17:01:25Z",
+    "asin": "B000FCK5PI",
+    "wpm": 5513.307984790875,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-20T03:14:00Z",
+    "asin": "B000GCFG7E",
+    "wpm": 997.7827050997782,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-20T03:15:26Z",
+    "asin": "B000GCFG7E",
+    "wpm": 3947.368421052631,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-20T03:15:32Z",
+    "asin": "B07L2J8P4S",
+    "wpm": 7500,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-20T03:15:51Z",
+    "asin": "B000GCFG7E",
+    "wpm": 320.17075773745995,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-20T03:22:08Z",
+    "asin": "B000GCFG7E",
+    "wpm": 563.1625441696112,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-22T01:33:36Z",
+    "asin": "B000GCFG7E",
+    "wpm": 862.0689655172414,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-22T01:59:56Z",
+    "asin": "B000GCFG7E",
+    "wpm": 4615.384615384616,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-22T02:09:54Z",
+    "asin": "B000GCFG7E",
+    "wpm": 435.0089232599643,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-22T13:27:07Z",
+    "asin": "B000GCFG7E",
+    "wpm": 6122.448979591837,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-23T02:28:28Z",
+    "asin": "B000GCFG7E",
+    "wpm": 2142.8571428571427,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-23T02:32:19Z",
+    "asin": "B000GCFG7E",
+    "wpm": 345.3512295483492,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-23T03:12:12Z",
+    "asin": "B000GCFG7E",
+    "wpm": 382.06826286296484,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-23T16:23:51Z",
+    "asin": "B000GCFG7E",
+    "wpm": 1485.148514851485,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-24T01:21:57Z",
+    "asin": "B000GCFG7E",
+    "wpm": 5555.555555555556,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-24T19:31:58Z",
+    "asin": "B000GCFG7E",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-24T21:06:30Z",
+    "asin": "B000GCFG7E",
+    "wpm": 2205.8823529411766,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-25T19:36:03Z",
+    "asin": "B000GCFG7E",
+    "wpm": 623.7006237006237,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-27T09:16:36Z",
+    "asin": "B000GCFG7E",
+    "wpm": 460.8294930875576,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-28T02:00:21Z",
+    "asin": "B000GCFG7E",
+    "wpm": 1027.3972602739725,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-28T02:05:18Z",
+    "asin": "B000GCFG7E",
+    "wpm": 143.95393474088291,
+    "period": "morning"
+  },
+  {
+    "start": "2020-04-29T15:05:18Z",
+    "asin": "B000GCFG7E",
+    "wpm": 2830.188679245283,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-29T17:34:43Z",
+    "asin": "B000GCFG7E",
+    "wpm": 2216.7487684729067,
+    "period": "evening"
+  },
+  {
+    "start": "2020-04-30T10:48:31Z",
+    "asin": "B000GCFG7E",
+    "wpm": 1500,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-01T03:14:11Z",
+    "asin": "B000GCFG7E",
+    "wpm": 1736.1543248288735,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-10T23:47:57Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 2319.5876288659797,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-11T00:22:58Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 2710.843373493976,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-12T02:16:26Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 1759.5307917888563,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-12T02:19:09Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 400.4576659038902,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-12T11:12:21Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 625.9780907668232,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-12T23:50:06Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 1079.136690647482,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-12T23:55:59Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 1485.148514851485,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-13T00:09:02Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 3658.536585365854,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-13T00:46:27Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 2272.7272727272725,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-13T02:47:07Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 1931.3304721030045,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-13T02:58:23Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 2830.188679245283,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-13T03:31:26Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 3061.2244897959185,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-13T04:18:45Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-13T04:27:28Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 661.6939364773821,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-15T00:25:24Z",
+    "asin": "B07TRVW6VX",
+    "wpm": 5882.35294117647,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-15T00:26:11Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 11264.822134387352,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-15T00:44:42Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 3797.4683544303803,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-15T02:18:34Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 3781.5126050420167,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-18T21:15:31Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 3435.1145038167942,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-18T22:50:48Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 2960.5263157894733,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-20T13:46:12Z",
+    "asin": "B077WWXZ41",
+    "wpm": 715.4213036565977,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-20T19:49:42Z",
+    "asin": "B077WWXZ41",
+    "wpm": 4054.054054054054,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-20T19:49:48Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 2760.7361963190183,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-20T20:12:45Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 3383.458646616541,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-22T02:34:06Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 1638.5302879841113,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-22T03:07:37Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 10645.16129032258,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-22T15:46:40Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 2542.3728813559323,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-22T15:51:06Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-22T17:21:34Z",
+    "asin": "B000QCQ8Y4",
+    "wpm": 2542.3728813559323,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-22T20:35:42Z",
+    "asin": "B000YJ54DU",
+    "wpm": 3191.489361702128,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-25T03:42:17Z",
+    "asin": "B000YJ54DU",
+    "wpm": 497.3474801061008,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-25T04:01:07Z",
+    "asin": "B000YJ54DU",
+    "wpm": 441.95639363582796,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-25T04:08:27Z",
+    "asin": "B000YJ54DU",
+    "wpm": 367.9142441860465,
+    "period": "morning"
+  },
+  {
+    "start": "2020-05-25T17:11:26Z",
+    "asin": "B000YJ54DU",
+    "wpm": 2205.8823529411766,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-25T18:50:48Z",
+    "asin": "B000YJ54DU",
+    "wpm": 2707.581227436823,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-29T22:13:27Z",
+    "asin": "B000YJ54DU",
+    "wpm": 6009.244992295839,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-29T22:44:38Z",
+    "asin": "B001NLL8LA",
+    "wpm": 553.5055350553506,
+    "period": "evening"
+  },
+  {
+    "start": "2020-05-29T22:45:07Z",
+    "asin": "B001NLL8LA",
+    "wpm": 7205.240174672489,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-01T04:01:25Z",
+    "asin": "B001NLL8LA",
+    "wpm": 351.4780100937275,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-01T08:51:37Z",
+    "asin": "B001NLL8LA",
+    "wpm": 286.47822765469823,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-02T02:51:29Z",
+    "asin": "B000GCFG7E",
+    "wpm": 3448.2758620689656,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-02T02:52:16Z",
+    "asin": "B001NLL8LA",
+    "wpm": 90.14423076923076,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-02T03:03:16Z",
+    "asin": "B001NLL8LA",
+    "wpm": 297.39343401947633,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-02T21:38:39Z",
+    "asin": "B001NLL8LA",
+    "wpm": 365.7507268123417,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-03T02:22:47Z",
+    "asin": "B001NLL8LA",
+    "wpm": 488.7585532746823,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-03T02:32:59Z",
+    "asin": "B001NLL8LA",
+    "wpm": 433.2755632582323,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-03T02:46:38Z",
+    "asin": "B001NLL8LA",
+    "wpm": 338.62593122131085,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-03T03:35:07Z",
+    "asin": "B001NLL8LA",
+    "wpm": 578.9562007048163,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-04T00:52:20Z",
+    "asin": "B001NLL8LA",
+    "wpm": 251.03602167676124,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-04T06:23:52Z",
+    "asin": "B001NLL8LA",
+    "wpm": 469.49561290984656,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-05T03:42:52Z",
+    "asin": "B001NLL8LA",
+    "wpm": 1239.6694214876034,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-05T03:47:07Z",
+    "asin": "B001NLL8LA",
+    "wpm": 325.02708559046584,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-05T17:44:57Z",
+    "asin": "B001NLL8LA",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T03:32:35Z",
+    "asin": "B001NLL8LA",
+    "wpm": 319.7893152746426,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-06T15:17:58Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 2980.132450331126,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T15:30:33Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 25.65856996236743,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T15:42:04Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 498.3959670027498,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T16:47:58Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 577.039886616724,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T17:06:10Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 646.551724137931,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T17:06:35Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-06T17:09:08Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 1595.7446808510638,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-07T03:58:49Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 3296.7032967032965,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-07T03:59:04Z",
+    "asin": "B001NLL8LA",
+    "wpm": 519.2107995846313,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-07T04:08:32Z",
+    "asin": "B001NLL8LA",
+    "wpm": 436.5140143973044,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-07T16:49:39Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 1001.6366612111293,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-07T17:18:24Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 1298.8094246940304,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-07T17:38:30Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-07T17:38:36Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 1278.409090909091,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-07T17:40:56Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 535.7142857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-08T09:44:52Z",
+    "asin": "B001NLL8LA",
+    "wpm": 2803.738317757009,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-09T01:06:37Z",
+    "asin": "B001NLL8LA",
+    "wpm": 197.5070224719101,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-09T01:50:29Z",
+    "asin": "B001NLL8LA",
+    "wpm": 2142.8571428571427,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-09T01:50:39Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 478.4493334423816,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-09T05:21:31Z",
+    "asin": "B001NLL8LA",
+    "wpm": 392.5349493836512,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-09T06:07:54Z",
+    "asin": "B001NLL8LA",
+    "wpm": 361.8817852834741,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-09T06:30:05Z",
+    "asin": "B001NLL8LA",
+    "wpm": 331.2172232956114,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-10T17:01:25Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 181.59806295399514,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-10T17:03:05Z",
+    "asin": "B07QBNKJTZ",
+    "wpm": 6521.739130434783,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-11T00:19:18Z",
+    "asin": "B001NLL8LA",
+    "wpm": 555.5555555555555,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-11T00:34:03Z",
+    "asin": "B001NLL8LA",
+    "wpm": 260.81458454080826,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-11T08:10:27Z",
+    "asin": "B001NLL8LA",
+    "wpm": 1662.0498614958449,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-11T08:11:07Z",
+    "asin": "B001NLL8LA",
+    "wpm": 385.64917611312376,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-11T21:40:34Z",
+    "asin": "B001NLL8LA",
+    "wpm": 544.9591280653951,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-11T21:46:32Z",
+    "asin": "B001NLL8LA",
+    "wpm": 300.40053404539384,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-11T23:37:23Z",
+    "asin": "B001NLL8LA",
+    "wpm": 2777.777777777778,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-11T23:43:32Z",
+    "asin": "B001NLL8LA",
+    "wpm": 1554.4041450777202,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-11T23:45:10Z",
+    "asin": "B001NLL8LA",
+    "wpm": 266.5277862876049,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-13T15:59:11Z",
+    "asin": "B001NLL8LA",
+    "wpm": 121.83235867446395,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-13T21:24:06Z",
+    "asin": "B001NLL8LA",
+    "wpm": 6976.7441860465115,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-14T18:29:39Z",
+    "asin": "B001NLL8LA",
+    "wpm": 188.83759966428872,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-14T18:47:57Z",
+    "asin": "B001NLL8LA",
+    "wpm": 126.02016322611618,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-14T19:19:37Z",
+    "asin": "B001NLL8LA",
+    "wpm": 73.71007371007371,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-14T20:45:40Z",
+    "asin": "B001NLL8LA",
+    "wpm": 315.2131836531549,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-15T01:39:45Z",
+    "asin": "B001NLL8LA",
+    "wpm": 286.9248647648039,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-15T03:11:11Z",
+    "asin": "B001NLL8LA",
+    "wpm": 3529.4117647058824,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-15T03:11:33Z",
+    "asin": "B0036S4CWA",
+    "wpm": 761.4213197969543,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-15T03:11:55Z",
+    "asin": "B0036S4CWA",
+    "wpm": 2290.0763358778627,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-15T03:12:11Z",
+    "asin": "B0036S4CWA",
+    "wpm": 446.8718967229394,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-15T03:50:43Z",
+    "asin": "B0036S4CWA",
+    "wpm": 481.4550641940086,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-17T03:58:05Z",
+    "asin": "B0036S4CWA",
+    "wpm": 431.91361727654464,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-17T19:58:55Z",
+    "asin": "B0036S4CWA",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-17T19:59:05Z",
+    "asin": "B003EY7IWC",
+    "wpm": 1937.984496124031,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-18T02:25:01Z",
+    "asin": "B003EY7IWC",
+    "wpm": 7142.857142857142,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-18T02:25:16Z",
+    "asin": "B003EY7IWC",
+    "wpm": 6000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-18T02:25:21Z",
+    "asin": "B003EY7IWC",
+    "wpm": 409.8360655737705,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-18T02:26:36Z",
+    "asin": "B003EY7IWC",
+    "wpm": 585.9375,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-18T11:18:20Z",
+    "asin": "B07THBZ4VD",
+    "wpm": 3813.5593220338983,
+    "period": "morning"
+  },
+  {
+    "start": "2020-06-18T20:32:46Z",
+    "asin": "B07THBZ4VD",
+    "wpm": 3750,
+    "period": "evening"
+  },
+  {
+    "start": "2020-06-19T11:09:16Z",
+    "asin": "B004P8JPS6",
+    "wpm": 2255.6390977443607,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-04T03:15:11Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 630.7031669350511,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T00:39:01Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T00:48:24Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 4639.175257731959,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T02:33:13Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 1914.8936170212767,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T02:36:10Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 2419.3548387096776,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T02:42:51Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 2238.805970149254,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T02:47:05Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 2803.738317757009,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T03:20:33Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 328.90228861175825,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T03:33:07Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 337.9103196738897,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T11:07:31Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 1071.4285714285713,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-05T14:36:14Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 1181.1023622047244,
+    "period": "evening"
+  },
+  {
+    "start": "2020-08-05T16:00:42Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 3278.688524590164,
+    "period": "evening"
+  },
+  {
+    "start": "2020-08-06T03:25:38Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 557.2198921509886,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-06T17:18:41Z",
+    "asin": "B07NCNVZ5P",
+    "wpm": 686.4988558352402,
+    "period": "evening"
+  },
+  {
+    "start": "2020-08-22T03:34:44Z",
+    "asin": "B07GNX99VJ",
+    "wpm": 403.72322529998877,
+    "period": "morning"
+  },
+  {
+    "start": "2020-08-28T19:59:59Z",
+    "asin": "B07GNX99VJ",
+    "wpm": 1048.951048951049,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-12T19:55:52Z",
+    "asin": "B00U27BMT4",
+    "wpm": 3949.934980494148,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-12T20:01:04Z",
+    "asin": "B00U27BMT4",
+    "wpm": 493.4210526315789,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-12T20:01:05Z",
+    "asin": "B00U27BMT4",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-12T20:02:07Z",
+    "asin": "B00U27BMT4",
+    "wpm": 2586.206896551724,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-12T20:02:19Z",
+    "asin": "B00U27BMT4",
+    "wpm": 3846.153846153846,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-12T20:02:26Z",
+    "asin": "B00U27BMT4",
+    "wpm": 1178.0104712041884,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-13T15:58:42Z",
+    "asin": "B00U27BMT4",
+    "wpm": 2050.78125,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-13T21:45:47Z",
+    "asin": "B00U27BMT4",
+    "wpm": 3000,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-13T21:51:28Z",
+    "asin": "B00U27BMT4",
+    "wpm": 4481.132075471698,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-13T22:23:02Z",
+    "asin": "B00U27BMT4",
+    "wpm": 541.5162454873646,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-13T22:28:14Z",
+    "asin": "B00U27BMT4",
+    "wpm": 1407.7163712200208,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-16T16:36:40Z",
+    "asin": "B086JN68M6",
+    "wpm": 4687.5,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-17T00:48:33Z",
+    "asin": "B086JN68M6",
+    "wpm": 3947.368421052631,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-17T01:33:44Z",
+    "asin": "B086JN68M6",
+    "wpm": 3409.090909090909,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-17T01:33:56Z",
+    "asin": "B086JN68M6",
+    "wpm": 3191.489361702128,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-17T02:03:22Z",
+    "asin": "B086JN68M6",
+    "wpm": 354.40047253396335,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-17T02:06:28Z",
+    "asin": "B003ODIZL6",
+    "wpm": 374.7657713928794,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-17T02:47:03Z",
+    "asin": "B086JN68M6",
+    "wpm": 340.31413612565444,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-18T03:56:58Z",
+    "asin": "B086JN68M6",
+    "wpm": 383.16894912367843,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-19T01:29:19Z",
+    "asin": "B086JN68M6",
+    "wpm": 308.0812070463702,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-19T02:02:50Z",
+    "asin": "B086JN68M6",
+    "wpm": 464.2046626779451,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-19T02:14:44Z",
+    "asin": "B086JN68M6",
+    "wpm": 398.88033589923026,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-19T03:37:37Z",
+    "asin": "B086JN68M6",
+    "wpm": 110.13215859030836,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-19T03:42:36Z",
+    "asin": "B086JN68M6",
+    "wpm": 384.55277936029955,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-19T23:23:37Z",
+    "asin": "B086JN68M6",
+    "wpm": 569.2599620493359,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-21T02:42:45Z",
+    "asin": "B0084B57VO",
+    "wpm": 585.9375,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-21T02:46:12Z",
+    "asin": "B085GKR5BL",
+    "wpm": 11729.857819905214,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-25T03:28:36Z",
+    "asin": "B0084B57VO",
+    "wpm": 1754.3859649122808,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-25T03:28:56Z",
+    "asin": "B0084B57VO",
+    "wpm": 404.3126684636119,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-25T03:30:05Z",
+    "asin": "B0084B57VO",
+    "wpm": 354.05192761605036,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-28T14:42:24Z",
+    "asin": "B07ZN51NL3",
+    "wpm": 1419.5583596214512,
+    "period": "evening"
+  },
+  {
+    "start": "2020-09-29T03:30:19Z",
+    "asin": "B07ZN51NL3",
+    "wpm": 456.0379423568041,
+    "period": "morning"
+  },
+  {
+    "start": "2020-09-30T04:09:57Z",
+    "asin": "B0084B57VO",
+    "wpm": 1010.4102878138395,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-11T03:58:36Z",
+    "asin": "B07N2X3ST6",
+    "wpm": 1319.8757763975154,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-11T04:03:13Z",
+    "asin": "B081NHX6LN",
+    "wpm": 437.21973094170403,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-12T04:22:46Z",
+    "asin": "B081NHX6LN",
+    "wpm": 391.26181936746,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-12T18:42:18Z",
+    "asin": "B081NHX6LN",
+    "wpm": 3191.4893617021276,
+    "period": "evening"
+  },
+  {
+    "start": "2020-10-12T18:42:33Z",
+    "asin": "B081NHX6LN",
+    "wpm": 240.09603841536614,
+    "period": "evening"
+  },
+  {
+    "start": "2020-10-12T18:53:58Z",
+    "asin": "B081NHX6LN",
+    "wpm": 467.2897196261682,
+    "period": "evening"
+  },
+  {
+    "start": "2020-10-12T18:57:22Z",
+    "asin": "B081NHX6LN",
+    "wpm": 614.2506142506143,
+    "period": "evening"
+  },
+  {
+    "start": "2020-10-12T19:00:09Z",
+    "asin": "B081NHX6LN",
+    "wpm": 312.89111389236547,
+    "period": "evening"
+  },
+  {
+    "start": "2020-10-14T03:55:27Z",
+    "asin": "B07ZG57WBH",
+    "wpm": 1162.7906976744187,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-14T03:55:48Z",
+    "asin": "B07ZG57WBH",
+    "wpm": 584.1121495327103,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-14T04:08:41Z",
+    "asin": "B07ZG57WBH",
+    "wpm": 617.3700732472969,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-14T04:42:45Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 538.737814263725,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-14T04:46:11Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 393.9592908732764,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-15T04:09:27Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 428.6939125464418,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-28T04:46:44Z",
+    "asin": "B089T77W63",
+    "wpm": 6194.690265486726,
+    "period": "morning"
+  },
+  {
+    "start": "2020-10-28T05:04:56Z",
+    "asin": "B07THQLGBT",
+    "wpm": 488.3186518575259,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-18T05:39:56Z",
+    "asin": "B00AHC9PZW",
+    "wpm": 1242.8793371310203,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-18T05:45:29Z",
+    "asin": "B00AHC9PZW",
+    "wpm": 831.0249307479224,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-18T05:58:15Z",
+    "asin": "B08NHG3PKK",
+    "wpm": 8727.272727272728,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-18T06:30:58Z",
+    "asin": "B08NHG3PKK",
+    "wpm": 2654.8672566371683,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-27T16:22:07Z",
+    "asin": "B089T77W63",
+    "wpm": 2941.176470588235,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-27T16:22:17Z",
+    "asin": "B089T77W63",
+    "wpm": 2884.6153846153843,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T04:33:37Z",
+    "asin": "B08NHG3PKK",
+    "wpm": 4545.454545454545,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T04:35:35Z",
+    "asin": "B08NHG3PKK",
+    "wpm": 9090.90909090909,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T04:35:47Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2074.235807860262,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T04:39:54Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2220.1665124884366,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T04:43:47Z",
+    "asin": "B081ZXQB52",
+    "wpm": 1790.7902217168846,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T04:47:16Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2215.088282504013,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T04:58:04Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2209.0407036203724,
+    "period": "morning"
+  },
+  {
+    "start": "2020-11-30T13:10:18Z",
+    "asin": "B081ZXQB52",
+    "wpm": 1111.111111111111,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T13:32:31Z",
+    "asin": "B081ZXQB52",
+    "wpm": 4477.611940298508,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T20:02:52Z",
+    "asin": "B081ZXQB52",
+    "wpm": 1003.0649205906939,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T20:11:08Z",
+    "asin": "B081ZXQB52",
+    "wpm": 865.9638554216868,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T20:20:14Z",
+    "asin": "B081ZXQB52",
+    "wpm": 1951.951951951952,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T20:33:09Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 3132.2505800464037,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T20:36:57Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 318.41255191509,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T22:33:19Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 313.9717425431711,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T22:43:51Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T22:45:43Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 595.2380952380953,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:00:29Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:03:07Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:03:08Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 1630.4347826086957,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:04:09Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 1704.5454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:04:14Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:04:15Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:06:32Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 252.84450063211125,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:29:59Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 279.3296089385475,
+    "period": "evening"
+  },
+  {
+    "start": "2020-11-30T23:35:26Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T00:03:44Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 2000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T00:33:30Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 3409.090909090909,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T04:24:19Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 167.0843776106934,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:40:01Z",
+    "asin": "B081ZXQB52",
+    "wpm": 1256.9832402234636,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:40:42Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 1363.6363636363637,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:40:56Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2459.0163934426228,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:42:47Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:42:57Z",
+    "asin": "B081ZXQB52",
+    "wpm": 1079.136690647482,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:43:14Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 2795.031055900621,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:43:34Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2852.614896988907,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T05:47:44Z",
+    "asin": "B081ZXQB52",
+    "wpm": 2149.3212669683257,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-01T22:25:25Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 144.53398738612472,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T22:44:33Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 49.73474801061008,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T22:56:35Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 110.75559931085405,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T23:09:33Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 83.56545961002786,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T23:15:40Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 72.92882147024504,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T23:32:49Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 7500,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T23:33:53Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T23:36:46Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-01T23:38:40Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 11538.461538461537,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-02T00:15:41Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 0,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-02T04:22:26Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 73.74631268436578,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-02T04:23:46Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 0,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-02T04:30:10Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 646.551724137931,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-02T04:30:35Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 425.3962670653154,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-02T23:36:31Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 232.66120097496122,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-02T23:36:51Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 2205.8823529411766,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-02T23:59:53Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 165.380374862183,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-03T00:14:20Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 10000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:19:13Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 11538.461538461537,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:20:18Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 25000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:22:51Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 1415.0943396226414,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:23:22Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 6818.181818181818,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:24:35Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 10000,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:24:44Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 8823.529411764706,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:28:20Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 1456.3106796116506,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:31:34Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 8823.529411764706,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:32:34Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 18750,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:38:37Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 2678.5714285714284,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T00:38:44Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 5555.555555555556,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T02:58:44Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 655.2538370720189,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T03:15:29Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 369.45812807881777,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T03:27:12Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 415.2249134948097,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T03:35:59Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 385.1420746319754,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T07:25:55Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 404.515952097998,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T08:04:03Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 418.9719073964656,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-03T08:35:43Z",
+    "asin": "B07RL58ZDG",
+    "wpm": 1363.6363636363637,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-05T05:44:01Z",
+    "asin": "B07N2X3ST6",
+    "wpm": 1458.198314970836,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-05T05:49:03Z",
+    "asin": "B0764BV94D",
+    "wpm": 3832.116788321168,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-05T06:45:49Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 0,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-05T06:46:02Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 3501.9455252918287,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-06T01:44:26Z",
+    "asin": "B07YXS82KD",
+    "wpm": 6382.978723404256,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-06T04:56:45Z",
+    "asin": "B07YXS82KD",
+    "wpm": 527.3159144893111,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-06T05:32:08Z",
+    "asin": "B07YXS82KD",
+    "wpm": 533.415082771306,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-08T04:46:56Z",
+    "asin": "B07YXSLVX7",
+    "wpm": 1973.6842105263156,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-08T04:48:02Z",
+    "asin": "B07YXSLVX7",
+    "wpm": 10362.400906002265,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-25T06:24:26Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 482.3151125401929,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-28T06:03:56Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 378.35358862646183,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-29T04:04:30Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 360.86607858861265,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-29T06:56:30Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 344.0366972477064,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-30T04:51:14Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 528.4791544333528,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-30T04:57:27Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 481.3960485407683,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-30T17:54:56Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 121.4902807775378,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-30T19:45:14Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 460.5641911341393,
+    "period": "evening"
+  },
+  {
+    "start": "2020-12-31T04:30:07Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 1875,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-31T05:02:18Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 484.698726477856,
+    "period": "morning"
+  },
+  {
+    "start": "2020-12-31T05:11:06Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 800,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-01T04:31:52Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 371.3838936669273,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-04T18:00:31Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 1578.9473684210527,
+    "period": "evening"
+  },
+  {
+    "start": "2021-01-05T04:12:39Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 443.7869822485207,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-05T04:15:15Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 392.95070254822576,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-05T04:37:04Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 289.01734104046244,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-05T22:15:28Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 250.37091988130564,
+    "period": "evening"
+  },
+  {
+    "start": "2021-01-06T05:06:09Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 415.7916841663167,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T04:18:30Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 1807.2289156626505,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T04:18:35Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 0,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T05:44:40Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 996.6777408637873,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T05:45:12Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 810.8108108108107,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T05:49:02Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 1648.3516483516482,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T05:49:30Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 5202.312138728324,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T05:51:14Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 1512.0967741935483,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-07T05:53:58Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 507.61421319796955,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-11T20:53:43Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 3125,
+    "period": "evening"
+  },
+  {
+    "start": "2021-01-11T20:56:06Z",
+    "asin": "B00O2RPEE4",
+    "wpm": 10194.174757281553,
+    "period": "evening"
+  },
+  {
+    "start": "2021-01-18T05:01:20Z",
+    "asin": "B00O2RPEE4",
+    "wpm": 3333.3333333333335,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-18T05:01:45Z",
+    "asin": "B00CH3DBNQ",
+    "wpm": 1998.3347210657787,
+    "period": "morning"
+  },
+  {
+    "start": "2021-01-29T22:31:03Z",
+    "asin": "B089T77W63",
+    "wpm": 3896.103896103896,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-10T05:15:33Z",
+    "asin": "B089T77W63",
+    "wpm": 2343.75,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-10T05:16:43Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 3112.033195020747,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-10T05:24:37Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 2760.7361963190183,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-10T05:25:12Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 949.3670886075951,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-10T05:43:15Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 774.633340218963,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-10T18:35:58Z",
+    "asin": "B001NLL8LA",
+    "wpm": 3260.8695652173915,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-10T18:36:40Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 3947.368421052631,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-10T19:55:54Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 92.85051067780873,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-10T21:15:33Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 183.66276018891026,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-10T21:26:19Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 310.9717201786094,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-11T05:12:25Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 2400,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-11T05:12:40Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 2112.676056338028,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-11T05:12:51Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 3191.4893617021276,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-11T05:13:19Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 285.3850688675706,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-11T05:13:33Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 2941.176470588235,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-12T04:16:30Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 302.9690971520905,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-12T18:51:13Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 2521.0084033613443,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-13T05:28:02Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 328.8078065337293,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-13T05:56:12Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 326.92125461953947,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-13T06:13:55Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 6521.739130434783,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-14T12:28:19Z",
+    "asin": "B07YRWHGYD",
+    "wpm": 2777.777777777778,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-14T12:28:33Z",
+    "asin": "B08478T2CK",
+    "wpm": 2727.2727272727275,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-14T17:42:59Z",
+    "asin": "B08478T2CK",
+    "wpm": 489.28238583410996,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-15T03:19:30Z",
+    "asin": "B08478T2CK",
+    "wpm": 266.6594839196251,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-16T04:20:19Z",
+    "asin": "B08478T2CK",
+    "wpm": 529.1005291005291,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-16T04:27:33Z",
+    "asin": "B08478T2CK",
+    "wpm": 314.7379464489349,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-17T04:41:01Z",
+    "asin": "B08478T2CK",
+    "wpm": 451.3540621865597,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-17T05:01:04Z",
+    "asin": "B08478T2CK",
+    "wpm": 293.4034803723189,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-17T16:53:19Z",
+    "asin": "B08478T2CK",
+    "wpm": 176.57445556209535,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-17T21:36:28Z",
+    "asin": "B08478T2CK",
+    "wpm": 457.27834702345666,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-18T02:47:06Z",
+    "asin": "B08478T2CK",
+    "wpm": 211.64595430618115,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-18T03:25:47Z",
+    "asin": "B08478T2CK",
+    "wpm": 293.3234006890772,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-19T04:18:13Z",
+    "asin": "B08478T2CK",
+    "wpm": 2922.0779220779223,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-19T04:23:04Z",
+    "asin": "B08478T2CK",
+    "wpm": 1546.3917525773197,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-19T04:39:06Z",
+    "asin": "B08478T2CK",
+    "wpm": 330.6198019220031,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-19T05:58:19Z",
+    "asin": "B08478T2CK",
+    "wpm": 593.6675461741424,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-19T06:02:56Z",
+    "asin": "B08478T2CK",
+    "wpm": 474.6835443037974,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-19T12:49:42Z",
+    "asin": "B08478T2CK",
+    "wpm": 1324.5033112582782,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-22T04:46:43Z",
+    "asin": "B08478T2CK",
+    "wpm": 2678.5714285714284,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-22T21:15:17Z",
+    "asin": "B08478T2CK",
+    "wpm": 600,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T04:57:07Z",
+    "asin": "B07R5KC59C",
+    "wpm": 7178.841309823678,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-28T04:58:00Z",
+    "asin": "B07R5KC59C",
+    "wpm": 768.6676427525623,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-28T05:11:54Z",
+    "asin": "B07R5KC59C",
+    "wpm": 489.02412519017605,
+    "period": "morning"
+  },
+  {
+    "start": "2021-02-28T16:03:32Z",
+    "asin": "B07R5KC59C",
+    "wpm": 825.3094910591471,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:08:31Z",
+    "asin": "B07R5KC59C",
+    "wpm": 268.81720430107526,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:09:48Z",
+    "asin": "B07R5KC59C",
+    "wpm": 777.2020725388601,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:12:18Z",
+    "asin": "B07R5KC59C",
+    "wpm": 925.9259259259259,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:13:07Z",
+    "asin": "B07R5KC59C",
+    "wpm": 249.16943521594683,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:14:16Z",
+    "asin": "B07R5KC59C",
+    "wpm": 286.62420382165607,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:17:40Z",
+    "asin": "B07R5KC59C",
+    "wpm": 1744.1860465116279,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:19:20Z",
+    "asin": "B07R5KC59C",
+    "wpm": 293.5420743639922,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:20:48Z",
+    "asin": "B07R5KC59C",
+    "wpm": 355.4502369668246,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:21:45Z",
+    "asin": "B07R5KC59C",
+    "wpm": 1039.8613518197574,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:24:54Z",
+    "asin": "B07R5KC59C",
+    "wpm": 240.3846153846154,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:29:13Z",
+    "asin": "B07R5KC59C",
+    "wpm": 769.8887938408897,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:36:58Z",
+    "asin": "B07R5KC59C",
+    "wpm": 721.1538461538461,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:38:29Z",
+    "asin": "B07R5KC59C",
+    "wpm": 1094.890510948905,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:39:54Z",
+    "asin": "B07R5KC59C",
+    "wpm": 383.63171355498724,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T16:45:45Z",
+    "asin": "B07R5KC59C",
+    "wpm": 1346.1538461538462,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T17:17:40Z",
+    "asin": "B07R5KC59C",
+    "wpm": 1367.5922088686284,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T17:25:19Z",
+    "asin": "B07R5KC59C",
+    "wpm": 650.7592190889371,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T17:26:56Z",
+    "asin": "B07R5KC59C",
+    "wpm": 735.2941176470588,
+    "period": "evening"
+  },
+  {
+    "start": "2021-02-28T17:30:28Z",
+    "asin": "B07R5KC59C",
+    "wpm": 8333.333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-01T00:38:34Z",
+    "asin": "B08478T2CK",
+    "wpm": 1630.4347826086957,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T00:39:06Z",
+    "asin": "B07R5KC59C",
+    "wpm": 840.6725380304243,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T00:47:30Z",
+    "asin": "B07R5KC59C",
+    "wpm": 511.98105321816666,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T03:16:30Z",
+    "asin": "B07R5KC59C",
+    "wpm": 800.1561280249805,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T03:42:15Z",
+    "asin": "B07R5KC59C",
+    "wpm": 2884.6153846153843,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T03:42:23Z",
+    "asin": "B07R5KC59C",
+    "wpm": 207.4688796680498,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T03:43:48Z",
+    "asin": "B07R5KC59C",
+    "wpm": 1785.7142857142856,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T03:44:56Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 728.1553398058253,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T03:45:51Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 373.26239917624855,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T04:56:55Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 417.98253761842835,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-01T21:36:58Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 98.6842105263158,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-01T21:42:30Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 268.91358910003584,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-02T04:53:37Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 393.6832740213523,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-02T22:32:30Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 503.16383319356555,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-03T00:27:26Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 422.9964522878195,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:17:39Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 318.2821252758445,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:37:19Z",
+    "asin": "B003ODIZL6",
+    "wpm": 678.7330316742082,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:38:04Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 323.45013477088946,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:52:52Z",
+    "asin": "B083JKGK15",
+    "wpm": 1376.1467889908256,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:53:16Z",
+    "asin": "B083JKGK15",
+    "wpm": 1973.6842105263156,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:57:30Z",
+    "asin": "B07ZTTH5VD",
+    "wpm": 2884.6153846153843,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:58:02Z",
+    "asin": "B083JKGK15",
+    "wpm": 349.65034965034965,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T04:59:29Z",
+    "asin": "B003ODIZL6",
+    "wpm": 3260.8695652173915,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T05:00:12Z",
+    "asin": "B083JKGK15",
+    "wpm": 301.9429371608612,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-03T19:36:10Z",
+    "asin": "B083JKGK15",
+    "wpm": 1025.0569476082005,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-03T21:10:39Z",
+    "asin": "B083JKGK15",
+    "wpm": 267.51993285774233,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-03T21:45:02Z",
+    "asin": "B083JKGK15",
+    "wpm": 292.08506738956135,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-03T23:29:18Z",
+    "asin": "B083JKGK15",
+    "wpm": 2500,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-03T23:55:36Z",
+    "asin": "B083JKGK15",
+    "wpm": 488.599348534202,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-04T00:09:12Z",
+    "asin": "B083JKGK15",
+    "wpm": 4724.4094488188975,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-04T05:27:47Z",
+    "asin": "B083JKGK15",
+    "wpm": 342.3520624118184,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-05T06:14:34Z",
+    "asin": "B083JKGK15",
+    "wpm": 470.7933740191805,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-05T06:24:11Z",
+    "asin": "B083JKGK15",
+    "wpm": 480.7692307692308,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-07T04:25:47Z",
+    "asin": "B083JKGK15",
+    "wpm": 331.6653089724194,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-08T03:40:20Z",
+    "asin": "B083JKGK15",
+    "wpm": 374.489332728098,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-08T03:53:49Z",
+    "asin": "B083JKGK15",
+    "wpm": 388.7353144436766,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-08T04:05:35Z",
+    "asin": "B083JKGK15",
+    "wpm": 358.37536501194586,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-09T03:36:21Z",
+    "asin": "B083JKGK15",
+    "wpm": 95.48058561425844,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-09T03:57:26Z",
+    "asin": "B083JKGK15",
+    "wpm": 284.4860285750411,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-09T04:16:51Z",
+    "asin": "B083JKGK15",
+    "wpm": 437.8980891719745,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-10T04:34:50Z",
+    "asin": "B083JKGK15",
+    "wpm": 275.88018917498687,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-10T22:27:14Z",
+    "asin": "B083JKGK15",
+    "wpm": 429.1845493562232,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-10T22:35:27Z",
+    "asin": "B083JKGK15",
+    "wpm": 2180.232558139535,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-10T22:36:11Z",
+    "asin": "B083JKGK15",
+    "wpm": 126.6891891891892,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-10T22:40:45Z",
+    "asin": "B084V823SR",
+    "wpm": 371.74721189591077,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-11T20:19:23Z",
+    "asin": "B084V823SR",
+    "wpm": 1176.4705882352941,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-12T04:29:00Z",
+    "asin": "B084V823SR",
+    "wpm": 426.42566191446025,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-12T13:00:15Z",
+    "asin": "B084V823SR",
+    "wpm": 2343.75,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-12T13:00:26Z",
+    "asin": "B08478T2CK",
+    "wpm": 1442.3076923076922,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-13T03:42:18Z",
+    "asin": "B08478T2CK",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-13T03:42:30Z",
+    "asin": "B084V823SR",
+    "wpm": 4411.764705882353,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-13T03:45:52Z",
+    "asin": "B08478T2CK",
+    "wpm": 556.6600397614314,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-18T15:20:13Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 835.4606637270829,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-18T17:56:31Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 918.9031505250875,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-18T18:07:59Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 548.7326887901751,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-18T18:41:17Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 513.3789670192906,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-18T18:50:07Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 297.96391325939413,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-18T20:51:55Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 821.2428141253764,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-18T20:58:19Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 736.2967002999727,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T00:56:51Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 190.83969465648855,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T01:07:08Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 1153.8461538461538,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T01:35:11Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 7317.073170731708,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T01:39:47Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 1263.0930375847197,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T01:47:55Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 285.17110266159693,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T01:54:27Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 202.97699594046009,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T02:16:48Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 3795.1807228915663,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T03:31:07Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 389.6103896103896,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T03:37:16Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 445.21709633649937,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T04:06:09Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 7894.736842105262,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-19T21:08:09Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 733.9104252916823,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:09:08Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 3125,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:10:46Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 160.42780748663102,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:20:35Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 4411.764705882353,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:30:49Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 3947.368421052631,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:31:09Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 115.62921564848719,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:40:05Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 6000,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:40:52Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:42:10Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 1562.5,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:42:22Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 109.01162790697674,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T21:48:05Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 195.05851755526658,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T22:01:18Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 3260.8695652173915,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T22:22:02Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 199.8667554963358,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T23:38:34Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 237.71790808240885,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-19T23:38:57Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 11820.652173913044,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-20T03:10:14Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 440.94894275399685,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-21T02:35:47Z",
+    "asin": "B084V823SR",
+    "wpm": 4477.611940298508,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-21T02:37:38Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 287.6530461720018,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-21T02:38:07Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 4969.879518072289,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-21T02:52:56Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 435.35045711798,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-21T03:04:36Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 1685.3932584269662,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-21T23:34:32Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 230.20846655582557,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-22T00:20:47Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 205.1632757736365,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-23T04:05:11Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 260.2158828064765,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-23T20:38:42Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 275.35566773749423,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-23T21:45:22Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 197.81800743316148,
+    "period": "evening"
+  },
+  {
+    "start": "2021-03-27T03:21:05Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 563.9097744360902,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-27T03:21:33Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 6132.518796992481,
+    "period": "morning"
+  },
+  {
+    "start": "2021-03-27T03:38:45Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 649.3506493506493,
+    "period": "morning"
+  },
+  {
+    "start": "2021-04-06T03:17:01Z",
+    "asin": "B07TPFTG1S",
+    "wpm": 3781.512605042017,
+    "period": "morning"
+  },
+  {
+    "start": "2021-04-20T14:42:00Z",
+    "asin": "B086HB336Y",
+    "wpm": 750.8892109076538,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T15:15:47Z",
+    "asin": "B086HB336Y",
+    "wpm": 4411.764705882353,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T15:20:08Z",
+    "asin": "B086HB336Y",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T16:31:33Z",
+    "asin": "B086HB336Y",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T16:51:54Z",
+    "asin": "B086HB336Y",
+    "wpm": 510.2040816326531,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T16:52:26Z",
+    "asin": "B086HB336Y",
+    "wpm": 336.322869955157,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T17:03:28Z",
+    "asin": "B086HB336Y",
+    "wpm": 872.0930232558139,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-20T17:04:35Z",
+    "asin": "B086HB336Y",
+    "wpm": 2380.952380952381,
+    "period": "evening"
+  },
+  {
+    "start": "2021-04-29T18:50:03Z",
+    "asin": "B086HB336Y",
+    "wpm": 4213.483146067415,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-19T03:12:22Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 1694.9152542372883,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-19T20:12:42Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 499.66688874083945,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-19T20:20:24Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 496.68874172185434,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-19T20:28:13Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 313.24157570004746,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-19T21:54:45Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 1129.9435028248588,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-20T03:10:05Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 513.9186295503213,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-20T03:31:59Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 467.91443850267376,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-20T03:52:46Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 490.2333358668389,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-20T04:21:26Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 426.88266199649735,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-20T21:52:58Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 2112.676056338028,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-21T02:38:51Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 466.7703934207602,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-24T20:28:46Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 445.1038575667656,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-24T20:33:03Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 590.4736911166514,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-24T20:33:47Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-25T03:00:58Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 162.51354279523292,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-25T03:05:17Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 682.8528072837632,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-25T03:15:25Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 532.2431348349276,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-25T03:26:53Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 301.5774822146613,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-26T19:07:14Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 461.19444703251656,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-26T20:16:10Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 452.4886877828054,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-27T04:26:18Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 477.7070063694268,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-27T21:27:33Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 2459.0163934426228,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-27T22:18:10Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 1456.3106796116504,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-27T22:20:22Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 515.3983201832527,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-28T03:26:06Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 470.12435547467396,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-28T21:03:20Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 805.9100067159168,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-28T21:09:37Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 154.87334801762114,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-28T22:57:05Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 196.3350785340314,
+    "period": "evening"
+  },
+  {
+    "start": "2021-05-29T03:47:21Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 433.52601156069363,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-29T03:50:25Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 565.0151823807511,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-29T04:33:52Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 2631.578947368421,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-29T04:34:02Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 1265.8227848101264,
+    "period": "morning"
+  },
+  {
+    "start": "2021-05-29T04:35:49Z",
+    "asin": "B07ZC6W6SV",
+    "wpm": 842.6966292134831,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-02T13:00:39Z",
+    "asin": "B08DHSFM4Q",
+    "wpm": 3420.1954397394134,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-06T12:02:44Z",
+    "asin": "B08DHSFM4Q",
+    "wpm": 2777.777777777778,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-20T00:43:16Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 882.3529411764706,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-20T03:52:11Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 950.2783643693607,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-20T04:02:57Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 516.2622612287041,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-21T03:28:49Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 532.9094988780853,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-21T05:08:59Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 302.4193548387097,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-21T17:02:23Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 610.3515625,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-21T17:21:54Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 388.668163758853,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-22T00:42:42Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 775.9155803848541,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-22T00:52:08Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 737.1007371007371,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-22T01:07:43Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 611.4769520225776,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-22T02:42:44Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 609.1132716410917,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-22T03:41:19Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 592.6344010159446,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-22T21:13:38Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 1500,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-23T00:48:36Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 759.7684515195369,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-23T01:45:07Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 609.9019373355657,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-23T02:00:10Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 332.5020781379884,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-23T15:22:37Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 680.7351940095303,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-23T21:24:56Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 593.0656934306569,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-24T02:58:05Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 724.0547063555913,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-24T03:04:46Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 548.4460694698355,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-24T03:07:30Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 597.8419364246136,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-24T03:50:38Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 380.517503805175,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-24T04:09:28Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 396.930404869013,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-24T17:14:50Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 638.0942252472615,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-24T17:31:15Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 168.7051876845213,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-24T19:13:40Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 459.69966288691387,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-25T04:15:54Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 425.56887267674136,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-25T04:45:26Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 372.3932472691162,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-25T18:46:23Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 336.3914373088685,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-25T19:32:36Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 330.48746901679976,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-26T03:25:32Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 194.0491591203105,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-26T03:27:21Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 419.701866949684,
+    "period": "morning"
+  },
+  {
+    "start": "2021-06-26T22:12:21Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 430.3749043611324,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-26T22:31:16Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 860.4206500956022,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-26T22:32:54Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 536.1305361305361,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-26T22:53:30Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 415.24181729360043,
+    "period": "evening"
+  },
+  {
+    "start": "2021-06-26T23:10:54Z",
+    "asin": "B081Y4J7LD",
+    "wpm": 323.2758620689655,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-17T03:59:09Z",
+    "asin": "B00C8S9VKM",
+    "wpm": 663.7168141592921,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-17T04:03:01Z",
+    "asin": "B00C8S9VKM",
+    "wpm": 363.48949919224555,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-17T17:08:49Z",
+    "asin": "B00C8S9VKM",
+    "wpm": 440.9171075837743,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-17T17:11:44Z",
+    "asin": "B00C8S9VKM",
+    "wpm": 1086.9565217391305,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-18T03:41:37Z",
+    "asin": "B00C8S9VKM",
+    "wpm": 748.704165866769,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-18T19:19:37Z",
+    "asin": "B00C8S9VKM",
+    "wpm": 2041.7602748777588,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-18T19:32:56Z",
+    "asin": "B009U9S6FI",
+    "wpm": 765.4507654507654,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-18T21:13:56Z",
+    "asin": "B009U9S6FI",
+    "wpm": 264.70588235294116,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-18T21:38:38Z",
+    "asin": "B009U9S6FI",
+    "wpm": 343.24942791762015,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-18T21:42:50Z",
+    "asin": "B009U9S6FI",
+    "wpm": 621.2349397590361,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-19T03:26:34Z",
+    "asin": "B009U9S6FI",
+    "wpm": 2173.913043478261,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-19T03:26:44Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 459.4792568422455,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-19T19:56:11Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 486.3362667901807,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-20T03:00:28Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 496.90242643262775,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-20T23:11:27Z",
+    "asin": "B08BLMJ576",
+    "wpm": 632.7900287631832,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-20T23:20:19Z",
+    "asin": "B08BLMJ576",
+    "wpm": 3000,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-20T23:29:50Z",
+    "asin": "B08BLMJ576",
+    "wpm": 510.2040816326531,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-20T23:57:37Z",
+    "asin": "B08BLMJ576",
+    "wpm": 478.9272030651341,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-21T00:03:22Z",
+    "asin": "B08BLMJ576",
+    "wpm": 515.0705837466616,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-21T00:13:12Z",
+    "asin": "B08BLMJ576",
+    "wpm": 551.828608526293,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-21T03:09:11Z",
+    "asin": "B08BLMJ576",
+    "wpm": 419.9720018665422,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-21T03:13:06Z",
+    "asin": "B08BLMJ576",
+    "wpm": 445.64837469416284,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-21T03:22:48Z",
+    "asin": "B08BLMJ576",
+    "wpm": 398.6099754701553,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-21T03:39:15Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 441.82621502209133,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-21T03:43:07Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 445.9507670353193,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-22T01:39:03Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 1785.7142857142856,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-22T01:39:14Z",
+    "asin": "B08BLMJ576",
+    "wpm": 6302.5210084033615,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-22T03:05:32Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 263.3889376646181,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-22T08:50:47Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 365.0190114068441,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-22T18:40:23Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 551.1811023622048,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-22T18:47:01Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 295.44175576814854,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-22T20:30:33Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 703.3997655334115,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-23T03:56:39Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 818.677986658581,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-23T03:59:24Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 523.4027192876911,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-23T04:13:20Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 694.954128440367,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-23T04:50:56Z",
+    "asin": "B008TY8BQ4",
+    "wpm": 2586.206896551724,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-23T05:07:11Z",
+    "asin": "B08BLMJ576",
+    "wpm": 415.38461538461536,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T00:44:53Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1442.3076923076922,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T00:45:37Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1550.3875968992247,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T00:46:57Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 938.8038942976357,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T00:49:28Z",
+    "asin": "B07VGYRGH4",
+    "wpm": 2890.204520990312,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T01:18:53Z",
+    "asin": "",
+    "wpm": 1562.5,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T01:22:24Z",
+    "asin": "B08BLMJ576",
+    "wpm": 960.1181683899557,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T01:27:16Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 746.2686567164179,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T02:12:22Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 887.5739644970414,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T03:14:41Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1006.7114093959732,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T03:17:43Z",
+    "asin": "B08BLMJ576",
+    "wpm": 1562.5,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T03:18:15Z",
+    "asin": "B08BLMJ576",
+    "wpm": 1546.3917525773197,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T03:34:16Z",
+    "asin": "B003EI2EH2",
+    "wpm": 3742.2037422037424,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T03:39:12Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1262.7781118460614,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T03:42:31Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 649.6173231286168,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T04:27:31Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 2777.777777777778,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T04:31:08Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 442.87226338365554,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-24T15:23:22Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 225.79026593075764,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T21:15:30Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 443.26241134751774,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T21:18:39Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 549.9827049463854,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T23:39:30Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 663.7168141592921,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T23:48:57Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1485.148514851485,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T23:51:26Z",
+    "asin": "B098GBS3BH",
+    "wpm": 2971.576227390181,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T23:53:31Z",
+    "asin": "B098GBS3BH",
+    "wpm": 8933.518005540165,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-24T23:57:18Z",
+    "asin": "B095YHMBSL",
+    "wpm": 4861.660079051383,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-25T02:36:12Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 5208.333333333334,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-25T03:19:42Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 2500,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-25T03:43:54Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 640.34151547492,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-25T10:02:00Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 933.6099585062241,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-26T03:05:26Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 3896.103896103896,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-26T03:34:11Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 514.2744115513945,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-26T23:44:59Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 657.8947368421052,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-26T23:52:36Z",
+    "asin": "B009U9S6FI",
+    "wpm": 560.485754320411,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-26T23:58:29Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1200,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-27T01:01:23Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 690.7137375287798,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-27T03:11:05Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 516.0875647472494,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-27T20:24:23Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 61.67763157894736,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-28T03:51:24Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 581.2076202776881,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-28T04:24:25Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 428.46014022331866,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-28T04:30:56Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 739.3715341959335,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-29T04:14:17Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 2222.222222222222,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-29T04:18:38Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 463.46361810597864,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-30T03:40:21Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 1208.7912087912089,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-30T03:43:29Z",
+    "asin": "B07MYXB26N",
+    "wpm": 1204.8192771084339,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-30T04:31:35Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 462.7249357326478,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-30T18:59:14Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 3045.6852791878173,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T19:01:01Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 207.09818890603427,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T20:37:29Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 304.1054232133806,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T20:57:46Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 811.3659705580282,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T21:47:17Z",
+    "asin": "B07CL5ZLHX",
+    "wpm": 739.593332751549,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T22:27:04Z",
+    "asin": "B009U9S6FI",
+    "wpm": 1956.5217391304348,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T22:28:14Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2542.3728813559323,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-30T22:28:51Z",
+    "asin": "B07MYXB26N",
+    "wpm": 1612.9032258064517,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T03:27:08Z",
+    "asin": "B07MYXB26N",
+    "wpm": 557.6208178438662,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T03:27:41Z",
+    "asin": "B07MYXB26N",
+    "wpm": 1363.6363636363637,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T03:28:29Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2631.578947368421,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T03:29:11Z",
+    "asin": "B07MYXB26N",
+    "wpm": 1775.1479289940828,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T03:30:16Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 506.7567567567568,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T03:30:54Z",
+    "asin": "B07MYXB26N",
+    "wpm": 393.1236673773987,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T04:13:59Z",
+    "asin": "B07MYXB26N",
+    "wpm": 385.1684470008217,
+    "period": "morning"
+  },
+  {
+    "start": "2021-07-31T18:22:07Z",
+    "asin": "B07MYXB26N",
+    "wpm": 750,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T18:34:27Z",
+    "asin": "B07MYXB26N",
+    "wpm": 516.6255633982481,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T19:44:29Z",
+    "asin": "B07MYXB26N",
+    "wpm": 654.0697674418604,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T20:20:58Z",
+    "asin": "B07MYXB26N",
+    "wpm": 797.8723404255319,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T20:21:25Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2830.188679245283,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T20:22:24Z",
+    "asin": "B07MYXB26N",
+    "wpm": 833.3333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T20:44:41Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2613.240418118467,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T21:18:46Z",
+    "asin": "B07MYXB26N",
+    "wpm": 5668.60465116279,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T21:19:24Z",
+    "asin": "B07MYXB26N",
+    "wpm": 6097.5609756097565,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T21:20:29Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2631.578947368421,
+    "period": "evening"
+  },
+  {
+    "start": "2021-07-31T23:27:57Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2445.6521739130435,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-01T04:39:00Z",
+    "asin": "B07MYXB26N",
+    "wpm": 438.5964912280702,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-01T12:24:54Z",
+    "asin": "B07MYXB26N",
+    "wpm": 71.51938970120788,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-01T12:56:20Z",
+    "asin": "B07MYXB26N",
+    "wpm": 765.3061224489796,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-01T13:37:13Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2173.913043478261,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-01T14:38:20Z",
+    "asin": "B07MYXB26N",
+    "wpm": 3169.0140845070423,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-01T14:39:25Z",
+    "asin": "B07MYXB26N",
+    "wpm": 1818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-01T21:51:13Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2513.966480446927,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-02T02:42:20Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2777.777777777778,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-02T02:42:29Z",
+    "asin": "B07MYXB26N",
+    "wpm": 2307.6923076923076,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-02T02:51:38Z",
+    "asin": "B07MYXB26N",
+    "wpm": 1190.4761904761906,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-02T04:20:06Z",
+    "asin": "B0987XFGZF",
+    "wpm": 3287.1198568872987,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-02T04:24:45Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 868.1273253410501,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-02T04:33:57Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 453.0581424616159,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-02T19:03:57Z",
+    "asin": "B009U9S6FI",
+    "wpm": 2777.777777777778,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-02T19:28:11Z",
+    "asin": "B009U9S6FI",
+    "wpm": 2158.273381294964,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-02T19:28:31Z",
+    "asin": "B009U9S6FI",
+    "wpm": 2884.6153846153843,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-02T19:54:14Z",
+    "asin": "B009U9S6FI",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-02T20:47:29Z",
+    "asin": "B009U9S6FI",
+    "wpm": 1363.6363636363637,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-03T03:44:48Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 967.7419354838709,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-03T03:50:39Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 568.3253346804748,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-03T03:58:39Z",
+    "asin": "B07P9DC6TY",
+    "wpm": 1944.3385436523063,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-03T04:07:40Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 25.016677785190126,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-03T21:35:21Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 470.21943573667716,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-03T21:37:06Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 234.76712180905608,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-03T22:26:41Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 298.2107355864811,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-03T22:44:58Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 389.242745930644,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-03T22:52:19Z",
+    "asin": "B08681BNKV",
+    "wpm": 263.22386563048383,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-04T02:58:45Z",
+    "asin": "B08681BNKV",
+    "wpm": 301.9323671497585,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-04T03:15:23Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 240.9730722154223,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-04T03:50:01Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 394.8967193195626,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-04T22:03:48Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 1102.9411764705883,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-04T22:04:50Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 537.6344086021505,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-04T23:19:12Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 1517.7065767284992,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-04T23:20:15Z",
+    "asin": "B08681BNKV",
+    "wpm": 2000,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-04T23:21:45Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 542.9650613786591,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-05T03:55:30Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 602.6257263792238,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-05T12:21:10Z",
+    "asin": "B098GBS3BH",
+    "wpm": 5928.853754940711,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-05T12:21:47Z",
+    "asin": "B098GBS3BH",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-05T23:22:00Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 317.1135618899968,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-06T00:12:31Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 332.4560188391744,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-06T00:43:05Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 622.3073240785064,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-06T01:02:52Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 427.9335152567601,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-06T02:55:19Z",
+    "asin": "B07C3XLBHG",
+    "wpm": 710.9004739336492,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-07T03:05:58Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 789.6814951302974,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-07T12:24:08Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 48.82017900732303,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-08T03:23:31Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 24.715768660405338,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-08T03:43:22Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 243.9859601061553,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-08T04:12:21Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 689.607132906102,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-08T11:40:14Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 769.2307692307692,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-08T12:14:39Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 1036.2694300518135,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-09T03:07:46Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 446.2872697347598,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-09T08:47:47Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 423.620025673941,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-10T00:05:11Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 655.4085970713273,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-10T00:19:49Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 395.5174686882004,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-10T02:13:56Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 487.8577623590633,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-11T02:08:15Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 232.8331731835317,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-12T02:29:32Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 428.1636536631779,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-12T06:51:53Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 586.7612004156225,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-12T15:03:07Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 449.10179640718565,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-12T15:04:39Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 7142.857142857142,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-12T19:54:07Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 288.95547945205476,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-12T20:02:10Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 2343.75,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-12T20:03:49Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 542.753761188345,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-12T20:28:00Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 521.7785843920145,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-13T01:54:44Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 694.7557149260422,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-13T02:06:10Z",
+    "asin": "B08681BNKV",
+    "wpm": 237.8255945639864,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-14T02:16:13Z",
+    "asin": "B08681BNKV",
+    "wpm": 980.3921568627451,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-14T02:16:32Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 150,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-14T02:51:08Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 1171.875,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-14T02:51:24Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 362.3188405797102,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-14T02:52:12Z",
+    "asin": "B08681BNKV",
+    "wpm": 303.71358888224194,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-14T12:53:06Z",
+    "asin": "B08681BNKV",
+    "wpm": 255.56426968115315,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T13:54:50Z",
+    "asin": "B08681BNKV",
+    "wpm": 173.15135465471582,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T14:52:55Z",
+    "asin": "B08681BNKV",
+    "wpm": 565.7175183858194,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T17:48:19Z",
+    "asin": "B08681BNKV",
+    "wpm": 173.48333508569024,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T18:51:57Z",
+    "asin": "B08681BNKV",
+    "wpm": 277.3629187113292,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T20:12:17Z",
+    "asin": "B08681BNKV",
+    "wpm": 442.4053744060298,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T20:38:33Z",
+    "asin": "B08681BNKV",
+    "wpm": 550.7474429583006,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T21:04:44Z",
+    "asin": "B08681BNKV",
+    "wpm": 343.9980214492884,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T22:27:51Z",
+    "asin": "B08681BNKV",
+    "wpm": 332.1371306406047,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T23:15:25Z",
+    "asin": "B08681BNKV",
+    "wpm": 402.0071848092604,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-14T23:54:17Z",
+    "asin": "B08681BNKV",
+    "wpm": 424.55911169170474,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-15T01:40:50Z",
+    "asin": "B08681BNKV",
+    "wpm": 833.3333333333334,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-15T01:45:19Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 877.1929824561404,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-15T03:29:06Z",
+    "asin": "B08681BNKV",
+    "wpm": 195.18542615484708,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-15T19:06:34Z",
+    "asin": "B08681BNKV",
+    "wpm": 212.04871683340585,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-15T19:45:06Z",
+    "asin": "B08681BNKV",
+    "wpm": 412.4116260801257,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-16T03:16:51Z",
+    "asin": "B08681BNKV",
+    "wpm": 341.525480479475,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-17T03:02:46Z",
+    "asin": "B08681BNKV",
+    "wpm": 281.1094452773613,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-18T02:39:07Z",
+    "asin": "B08681BNKV",
+    "wpm": 413.34966319657076,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-19T03:35:07Z",
+    "asin": "B08681BNKV",
+    "wpm": 437.06293706293707,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-20T03:08:46Z",
+    "asin": "B08681BNKV",
+    "wpm": 448.9041457618168,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-21T03:59:48Z",
+    "asin": "B08681BNKV",
+    "wpm": 463.38155515370704,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-21T17:56:40Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 657.1362693105833,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-21T22:23:23Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 1875,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-22T04:06:26Z",
+    "asin": "B0893YWV5Q",
+    "wpm": 662.1187800963082,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-23T03:52:07Z",
+    "asin": "B0893YWV5Q",
+    "wpm": 968.688845401174,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-23T04:01:34Z",
+    "asin": "B09D3K2MCY",
+    "wpm": 2027.0270270270269,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-25T02:46:43Z",
+    "asin": "B083SN8RF7",
+    "wpm": 1751.4270887389725,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-25T03:27:08Z",
+    "asin": "B072KZWHW4",
+    "wpm": 4477.611940298507,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-25T20:32:44Z",
+    "asin": "B08LDL3PJ3",
+    "wpm": 9.500613221398837,
+    "period": "evening"
+  },
+  {
+    "start": "2021-08-26T01:24:04Z",
+    "asin": "B08LDL3PJ3",
+    "wpm": 431.94268857985674,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-26T01:48:09Z",
+    "asin": "B07FKB3V5S",
+    "wpm": 5.476342201688705,
+    "period": "morning"
+  },
+  {
+    "start": "2021-08-28T04:01:49Z",
+    "asin": "B07SKWFVYW",
+    "wpm": 1656.2384983437614,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-05T14:24:42Z",
+    "asin": "B000FC0R7O",
+    "wpm": 773.1958762886599,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T14:25:10Z",
+    "asin": "B000FC0R7O",
+    "wpm": 2027.027027027027,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T22:54:51Z",
+    "asin": "B000FC0R7O",
+    "wpm": 3846.153846153846,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T22:54:58Z",
+    "asin": "B000FC0R7O",
+    "wpm": 2900.5524861878453,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T22:56:29Z",
+    "asin": "B09F8RV343",
+    "wpm": 5421.686746987952,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T22:56:51Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1137.3688866422344,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T23:19:19Z",
+    "asin": "B09F8RV343",
+    "wpm": 1437.6176621598495,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T23:29:10Z",
+    "asin": "B09F8RV343",
+    "wpm": 809.7165991902834,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T23:36:15Z",
+    "asin": "B09F8RV343",
+    "wpm": 3827.679375562894,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-05T23:50:59Z",
+    "asin": "B000FC0R7O",
+    "wpm": 509.77060322854715,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-06T00:10:11Z",
+    "asin": "B000FC0R7O",
+    "wpm": 642.2018348623853,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-06T00:18:18Z",
+    "asin": "B000FC0R7O",
+    "wpm": 440.06705783738477,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-06T01:10:41Z",
+    "asin": "B000FC0R7O",
+    "wpm": 631.768953068592,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-06T03:28:26Z",
+    "asin": "B000FC0R7O",
+    "wpm": 24.2600679281902,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-06T03:57:36Z",
+    "asin": "B000FC0R7O",
+    "wpm": 388.67562380038385,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-06T18:51:19Z",
+    "asin": "B000FC0R7O",
+    "wpm": 206.84305782987158,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-07T01:34:40Z",
+    "asin": "B000FC0R7O",
+    "wpm": 872.0930232558139,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-07T01:35:54Z",
+    "asin": "B000FC0R7O",
+    "wpm": 248.62935101364272,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-07T05:53:34Z",
+    "asin": "B000FC0R7O",
+    "wpm": 429.7994269340974,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-08T01:57:10Z",
+    "asin": "B000FC0R7O",
+    "wpm": 434.74855083816385,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-09T02:49:04Z",
+    "asin": "B000FC0R7O",
+    "wpm": 499.27641099855276,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-10T01:59:11Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1086.9565217391305,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-10T02:00:16Z",
+    "asin": "B000FC0R7O",
+    "wpm": 315.58504612396825,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-11T01:47:47Z",
+    "asin": "B000FC0R7O",
+    "wpm": 362.6220362622036,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-11T02:05:55Z",
+    "asin": "B0865TSTWM",
+    "wpm": 186.58501578796287,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-13T03:19:34Z",
+    "asin": "B0865TSTWM",
+    "wpm": 490.9983633387889,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-13T03:29:01Z",
+    "asin": "B000FC0R7O",
+    "wpm": 177.86880827898452,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-14T00:21:51Z",
+    "asin": "B000FC0R7O",
+    "wpm": 721.1538461538461,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-14T01:57:11Z",
+    "asin": "B000FC0R7O",
+    "wpm": 304.35317265125434,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-14T19:02:42Z",
+    "asin": "B000FC0R7O",
+    "wpm": 837.9888268156425,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-14T21:32:43Z",
+    "asin": "B000FC0R7O",
+    "wpm": 515.8761897144685,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-15T01:45:38Z",
+    "asin": "B000FC0R7O",
+    "wpm": 394.51437159496527,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-17T02:38:53Z",
+    "asin": "B000FC0R7O",
+    "wpm": 132.90017720023627,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-17T21:24:37Z",
+    "asin": "B000FC0R7O",
+    "wpm": 2571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-17T21:24:57Z",
+    "asin": "B07FKB3V5S",
+    "wpm": 3076.9230769230767,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-17T21:28:36Z",
+    "asin": "B07FKB3V5S",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-18T19:25:21Z",
+    "asin": "B000FC0R7O",
+    "wpm": 640.8952187182095,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-23T03:04:10Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJJMlVDN0tPRUhFQk8mbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMEQwSzNGUUkmZW5kdGltZT0xNjMxODk2Njk3MjYx",
+    "wpm": 549.4505494505495,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-23T03:04:48Z",
+    "asin": "B000FC0R7O",
+    "wpm": 426.43923240938165,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-24T02:25:16Z",
+    "asin": "B000FC0R7O",
+    "wpm": 797.8723404255319,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-24T02:26:17Z",
+    "asin": "B000FC0R7O",
+    "wpm": 421.4393775664577,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-25T03:33:47Z",
+    "asin": "B000FC0R7O",
+    "wpm": 564.8197955890264,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-25T03:37:41Z",
+    "asin": "B000FC0R7O",
+    "wpm": 406.28385698808233,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-26T03:03:40Z",
+    "asin": "B000FC0R7O",
+    "wpm": 430.0869731434579,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-26T03:21:13Z",
+    "asin": "B07FKB3V5S",
+    "wpm": 1898.7341772151901,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-26T03:21:23Z",
+    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTMwRDhOSkYyM0NKQzUmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMDBGQzBSN08mZW5kdGltZT0xNjMyNTU0NTQyMzc5",
+    "wpm": 833.3333333333334,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-26T03:49:29Z",
+    "asin": "B0865TSTWM",
+    "wpm": 456.7600487210718,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-26T03:55:46Z",
+    "asin": "B0865TSTWM",
+    "wpm": 604.8387096774194,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-29T02:52:01Z",
+    "asin": "B0865TSTWM",
+    "wpm": 735.2941176470589,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-29T02:56:05Z",
+    "asin": "B08PK59474",
+    "wpm": 489.44792379348456,
+    "period": "morning"
+  },
+  {
+    "start": "2021-09-29T20:59:53Z",
+    "asin": "B08XP24KR8",
+    "wpm": 1158.7982832618027,
+    "period": "evening"
+  },
+  {
+    "start": "2021-09-30T03:31:07Z",
+    "asin": "B08XP24KR8",
+    "wpm": 377.8914420948164,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-01T03:30:39Z",
+    "asin": "B08XP24KR8",
+    "wpm": 419.4877833382396,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-02T21:54:53Z",
+    "asin": "B08XP24KR8",
+    "wpm": 197.2818939061815,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-03T04:01:20Z",
+    "asin": "B08XP24KR8",
+    "wpm": 387.2936389953838,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-03T20:54:12Z",
+    "asin": "B08XP24KR8",
+    "wpm": 97.10533616942568,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-04T03:31:49Z",
+    "asin": "B08XP24KR8",
+    "wpm": 454.077617000666,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-04T04:25:55Z",
+    "asin": "B08XP24KR8",
+    "wpm": 393.50713231677327,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-06T21:35:16Z",
+    "asin": "B08XP24KR8",
+    "wpm": 848.8278092158448,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T21:37:36Z",
+    "asin": "B08XP24KR8",
+    "wpm": 575.8157389635317,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T21:39:12Z",
+    "asin": "B08XP24KR8",
+    "wpm": 415.81962668637965,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T21:52:45Z",
+    "asin": "B08XP24KR8",
+    "wpm": 632.9113924050632,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T21:56:27Z",
+    "asin": "B08XP24KR8",
+    "wpm": 658.0751302440362,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T22:13:18Z",
+    "asin": "B08XP24KR8",
+    "wpm": 747.8519147130582,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T22:30:53Z",
+    "asin": "B08XP24KR8",
+    "wpm": 600,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T22:35:02Z",
+    "asin": "B08XP24KR8",
+    "wpm": 717.2743574417213,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T22:40:04Z",
+    "asin": "B08XP24KR8",
+    "wpm": 1168.8311688311687,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-06T22:45:56Z",
+    "asin": "B08XP24KR8",
+    "wpm": 285.57829604950024,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-07T03:12:20Z",
+    "asin": "B08XP24KR8",
+    "wpm": 1699.7167138810198,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-07T03:34:48Z",
+    "asin": "B08XP24KR8",
+    "wpm": 639.0627080282253,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-07T03:47:23Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 355.5373927257867,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-07T22:36:40Z",
+    "asin": "B08XP24KR8",
+    "wpm": 4761.904761904762,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-07T22:40:26Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 1171.875,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-07T22:41:56Z",
+    "asin": "B005NY4QGM",
+    "wpm": 1157.7377091710987,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-07T23:07:41Z",
+    "asin": "B005NY4QGM",
+    "wpm": 646.551724137931,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-09T02:35:21Z",
+    "asin": "B005NY4QGM",
+    "wpm": 845.0704225352113,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-09T02:36:16Z",
+    "asin": "B08XP24KR8",
+    "wpm": 795.0530035335689,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-10T05:13:11Z",
+    "asin": "B08XP24KR8",
+    "wpm": 1203.3195020746887,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-11T03:18:40Z",
+    "asin": "B08XP24KR8",
+    "wpm": 984.9404039683106,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-25T01:00:42Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 2586.206896551724,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-25T01:01:21Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 1491.0536779324054,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-25T02:52:39Z",
+    "asin": "B08XP24KR8",
+    "wpm": 3822.3938223938226,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-25T02:59:41Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 717.7033492822967,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-25T03:00:13Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 425.73320719016084,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-25T21:07:52Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 429.6455424274973,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-25T21:17:49Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 223.2142857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-26T03:24:41Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 396.78603313163376,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-26T21:40:30Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 183.80305224462515,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-26T22:25:21Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 302.094522019334,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-26T22:57:25Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 201.47161878065873,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-27T00:52:19Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 298.40848806366046,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-27T01:06:21Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 648.311189370898,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-27T04:40:53Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 213.9800285306705,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-27T05:37:31Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 382.56011658974984,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-27T19:51:27Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 206.9441250862267,
+    "period": "evening"
+  },
+  {
+    "start": "2021-10-28T03:28:21Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 266.5573098216116,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-28T04:35:59Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 459.8628479225494,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-30T03:24:23Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 411.32112427773967,
+    "period": "morning"
+  },
+  {
+    "start": "2021-10-31T04:00:39Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 281.9731639333636,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-01T01:57:43Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 2459.0163934426228,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-01T01:59:01Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 3877.9731127197515,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-01T03:25:25Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 443.7038978544951,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-01T22:43:11Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 420.37285244303644,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-01T22:58:56Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 2459.0163934426228,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-02T01:29:15Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 1255.9808612440193,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-02T01:32:47Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 456.71725688589095,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T03:56:44Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 741.839762611276,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T04:08:42Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 1200,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T04:11:59Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 1282.051282051282,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T04:16:03Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 903.6144578313254,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T04:16:55Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 1379.242883693632,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T04:39:06Z",
+    "asin": "B0955FXRLM",
+    "wpm": 424.32814710042436,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T04:45:08Z",
+    "asin": "B08WC6VC8S",
+    "wpm": 443.31855604813177,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-03T16:19:17Z",
+    "asin": "B08SJQSWYM",
+    "wpm": 2135.2313167259786,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-03T18:08:20Z",
+    "asin": "B08WC6VC8S",
+    "wpm": 398.93617021276594,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-03T18:11:20Z",
+    "asin": "B08SJQSWYM",
+    "wpm": 157.51338863803423,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-03T20:19:34Z",
+    "asin": "B08SJQSWYM",
+    "wpm": 1986.7549668874171,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-04T03:28:42Z",
+    "asin": "B08SJQSWYM",
+    "wpm": 445.1038575667656,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-04T03:30:10Z",
+    "asin": "B08WC6VC8S",
+    "wpm": 955.4140127388536,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-04T03:34:25Z",
+    "asin": "B0865Z9S5L",
+    "wpm": 637.6195536663125,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-06T13:50:36Z",
+    "asin": "B0865Z9S5L",
+    "wpm": 498.33887043189367,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-06T13:51:36Z",
+    "asin": "B00MYEQGFI",
+    "wpm": 4838.709677419355,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-07T05:24:08Z",
+    "asin": "B0865Z9S5L",
+    "wpm": 1500,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-07T05:24:35Z",
+    "asin": "B09GYVRQWF",
+    "wpm": 678.6739754633255,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-07T05:44:44Z",
+    "asin": "B09GYVRQWF",
+    "wpm": 920.2453987730062,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-07T05:45:07Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 1153.846153846154,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-07T05:47:38Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 787.1064467766117,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-23T18:25:37Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 2564.102564102564,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-23T18:30:02Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 6000,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-23T18:30:31Z",
+    "asin": "B09KKPHDHC",
+    "wpm": 1041.6666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-24T14:38:05Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 1219.5121951219512,
+    "period": "evening"
+  },
+  {
+    "start": "2021-11-29T04:02:34Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 1145.0381679389313,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-29T04:03:31Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 725.0622528196865,
+    "period": "morning"
+  },
+  {
+    "start": "2021-11-29T04:18:13Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 185.72976319455194,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-10T00:09:37Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 474.68354430379753,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-10T00:10:16Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1685.3932584269662,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-10T22:47:14Z",
+    "asin": "B000FC0R7O",
+    "wpm": 466.9260700389105,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-10T22:58:01Z",
+    "asin": "B09887KBTZ",
+    "wpm": 248.98745103246796,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-10T23:24:07Z",
+    "asin": "B09887KBTZ",
+    "wpm": 54.904831625183014,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-10T23:45:22Z",
+    "asin": "B09887KBTZ",
+    "wpm": 188.79798615481434,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-11T02:57:11Z",
+    "asin": "B09887KBTZ",
+    "wpm": 341.92407889839967,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-12T04:54:18Z",
+    "asin": "B09887KBTZ",
+    "wpm": 246.33431085043986,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T04:52:44Z",
+    "asin": "B09887KBTZ",
+    "wpm": 524.7813411078718,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T04:55:55Z",
+    "asin": "B09887KBTZ",
+    "wpm": 672.645739910314,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T04:56:57Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1691.7293233082705,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T05:05:42Z",
+    "asin": "B000FC0R7O",
+    "wpm": 612.2448979591836,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T05:19:22Z",
+    "asin": "B000FC0R7O",
+    "wpm": 91.1854103343465,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T05:22:09Z",
+    "asin": "B000FC0R7O",
+    "wpm": 466.5920119447555,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-27T19:13:11Z",
+    "asin": "B000FC0R7O",
+    "wpm": 285.8875508966473,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-27T20:26:29Z",
+    "asin": "B000FC0R7O",
+    "wpm": 528.9672544080604,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-27T21:48:07Z",
+    "asin": "B000FC0R7O",
+    "wpm": 254.72413917693393,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-28T22:07:31Z",
+    "asin": "B000FC0R7O",
+    "wpm": 646.9500924214418,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-29T06:39:21Z",
+    "asin": "B000FC0R7O",
+    "wpm": 294.81429219372075,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-29T20:21:27Z",
+    "asin": "B000FC0R7O",
+    "wpm": 3896.103896103896,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-29T20:21:35Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1162.7906976744187,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-29T20:21:51Z",
+    "asin": "B000FC0R7O",
+    "wpm": 2112.6760563380285,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-29T20:22:14Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1542.4164524421594,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-29T22:45:35Z",
+    "asin": "B000FC0R7O",
+    "wpm": 439.57154405820535,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-30T05:09:55Z",
+    "asin": "B000FC0R7O",
+    "wpm": 555.5555555555555,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-30T05:11:32Z",
+    "asin": "B000FC0R7O",
+    "wpm": 569.2031156381066,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-30T05:36:46Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 439.177413733008,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-30T06:06:16Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 535.7142857142857,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-30T07:30:00Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 445.651060342178,
+    "period": "morning"
+  },
+  {
+    "start": "2021-12-30T12:17:42Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 49.63600264725347,
+    "period": "evening"
+  },
+  {
+    "start": "2021-12-31T17:20:07Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 827.5862068965517,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-02T03:25:35Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 1209.6774193548388,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-02T03:27:43Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 479.2701235708511,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-02T11:59:28Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 470.36688617121354,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-02T23:03:29Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 441.8853776111408,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-03T04:30:22Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 332.8967474350578,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-03T22:50:20Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 652.1739130434783,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-04T04:50:26Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 518.5646131507986,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-05T04:17:13Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 355.9385537654552,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-06T04:54:35Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 368.67977528089887,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-06T05:13:13Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 459.1792531839316,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-06T22:37:56Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 248.57698681461198,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-07T04:25:11Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 619.0353366004642,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-07T04:31:56Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 664.9282920469361,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-07T04:44:50Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 570.6203667577058,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-07T21:58:54Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 543.4782608695652,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-07T21:59:32Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 2884.6153846153843,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-07T23:36:51Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 598.2367758186398,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-08T00:12:27Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 2586.206896551724,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-08T12:24:38Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 1250,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-09T05:28:11Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 536.3237445148708,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-10T04:27:53Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 317.02617019954,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-10T20:48:35Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 1041.6666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-10T20:51:04Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 378.76270848561364,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-11T05:35:22Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 371.8010622887494,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-12T00:27:48Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 281.6161009312106,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-12T05:14:57Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 670.5954074375128,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-12T05:50:08Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 436.3097524833983,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-12T07:03:35Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 542.92343387471,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-12T22:10:07Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 289.74552784076593,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T22:30:49Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 751.8796992481202,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T22:35:28Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 817.8844056706653,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T22:42:15Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 815.2173913043479,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T22:45:18Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 695.8250497017892,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T22:48:56Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 378.7281047814423,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T23:13:09Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 891.4100486223663,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T23:24:00Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 961.8065235572902,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T23:31:12Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 689.6551724137931,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-12T23:33:46Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 230.14959723820485,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T05:17:53Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 502.6996834853845,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-13T19:18:54Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 1923.076923076923,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T19:19:11Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 269.3753858241203,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T19:57:25Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 802.4401689347724,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:23:59Z",
+    "asin": "B08TRMSR3Z",
+    "wpm": 1181.1023622047244,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:24:29Z",
+    "asin": "B08PK59474",
+    "wpm": 256.8493150684931,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:27:29Z",
+    "asin": "B08PK59474",
+    "wpm": 831.0249307479224,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:28:08Z",
+    "asin": "B08PK59474",
+    "wpm": 1053.5557506584723,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:30:06Z",
+    "asin": "B08PK59474",
+    "wpm": 2358.490566037736,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:30:40Z",
+    "asin": "B08PK59474",
+    "wpm": 2307.6923076923076,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:31:15Z",
+    "asin": "B08PK59474",
+    "wpm": 2047.7815699658702,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T20:33:06Z",
+    "asin": "B08PK59474",
+    "wpm": 1363.6363636363635,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T21:01:13Z",
+    "asin": "B08PK59474",
+    "wpm": 238.03478481655452,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-13T21:59:54Z",
+    "asin": "B08PK59474",
+    "wpm": 955.4140127388536,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-14T05:28:59Z",
+    "asin": "B08PK59474",
+    "wpm": 526.9320843091335,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-14T05:40:32Z",
+    "asin": "B08PF965W9",
+    "wpm": 495.5947136563877,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-15T02:36:21Z",
+    "asin": "B08PF965W9",
+    "wpm": 275.01069486035567,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-15T06:20:03Z",
+    "asin": "B08PF965W9",
+    "wpm": 408.3484573502722,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-15T19:55:08Z",
+    "asin": "B08PF965W9",
+    "wpm": 422.96545782094466,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-16T22:53:19Z",
+    "asin": "B08PF965W9",
+    "wpm": 372.9024238657551,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-17T05:01:45Z",
+    "asin": "B08PF965W9",
+    "wpm": 24.888003982080637,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-17T19:20:30Z",
+    "asin": "B08PF965W9",
+    "wpm": 1006.7114093959732,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-18T06:23:01Z",
+    "asin": "B08PK59474",
+    "wpm": 584.0363400389358,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-18T06:28:15Z",
+    "asin": "B08PF965W9",
+    "wpm": 419.71588463194144,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-19T04:19:29Z",
+    "asin": "B08PF965W9",
+    "wpm": 630.2521008403361,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-19T04:21:37Z",
+    "asin": "B08PK59474",
+    "wpm": 2489.6265560165975,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-20T04:54:29Z",
+    "asin": "B08PF965W9",
+    "wpm": 307.66976778258004,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-20T05:17:18Z",
+    "asin": "B08PF965W9",
+    "wpm": 474.5762711864407,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-21T05:15:12Z",
+    "asin": "B093B4BGRK",
+    "wpm": 2238.805970149254,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-21T05:37:02Z",
+    "asin": "B08PF965W9",
+    "wpm": 548.3549351944168,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-21T05:42:11Z",
+    "asin": "B013X9F1IK",
+    "wpm": 941.4225941422593,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-21T05:48:03Z",
+    "asin": "B08VRP55V1",
+    "wpm": 453.64662091427243,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-21T15:58:54Z",
+    "asin": "B08VRP55V1",
+    "wpm": 961.5384615384615,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-23T15:59:55Z",
+    "asin": "B08VRP55V1",
+    "wpm": 1388.888888888889,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-23T16:01:33Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 10047.846889952154,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-23T16:04:56Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 969.6668324216807,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-24T04:06:05Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 765.3061224489796,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-24T04:06:39Z",
+    "asin": "B08VRP55V1",
+    "wpm": 472.21461812209145,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-24T22:15:29Z",
+    "asin": "B08VRP55V1",
+    "wpm": 535.8032895829872,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-24T22:36:29Z",
+    "asin": "B08VRP55V1",
+    "wpm": 411.1198120595145,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-24T23:42:53Z",
+    "asin": "B08VRP55V1",
+    "wpm": 594.2275042444821,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T00:22:28Z",
+    "asin": "B08VRP55V1",
+    "wpm": 253.41262332747667,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-25T00:57:00Z",
+    "asin": "B08VRP55V1",
+    "wpm": 478.8160185722577,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-25T20:58:25Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 13157.894736842105,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T21:00:00Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 2533.7837837837837,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T21:01:41Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 2380.952380952381,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T21:02:09Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 1948.051948051948,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T21:02:46Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 3488.3720930232557,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T21:08:03Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 6000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T23:07:41Z",
+    "asin": "B08VRP55V1",
+    "wpm": 317.9444760378431,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-25T23:40:21Z",
+    "asin": "B08VRP55V1",
+    "wpm": 187.87182966287443,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-26T01:03:29Z",
+    "asin": "B08VRP55V1",
+    "wpm": 576.5199161425577,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-26T04:30:04Z",
+    "asin": "B08VRP55V1",
+    "wpm": 151.82186234817814,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-26T05:14:18Z",
+    "asin": "B08VRP55V1",
+    "wpm": 470.45800470458005,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-26T20:54:07Z",
+    "asin": "B08VRP55V1",
+    "wpm": 249.02760648894795,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-26T22:07:19Z",
+    "asin": "B08VRP55V1",
+    "wpm": 294.0984249395465,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-26T22:35:37Z",
+    "asin": "B08VRP55V1",
+    "wpm": 112.54501800720287,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-27T05:00:03Z",
+    "asin": "B08VRP55V1",
+    "wpm": 134.85166317051244,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-27T05:27:04Z",
+    "asin": "B08VRP55V1",
+    "wpm": 312.26580064951287,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-27T21:45:33Z",
+    "asin": "B08VRP55V1",
+    "wpm": 101.48849797023004,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-27T21:58:58Z",
+    "asin": "B08VRP55V1",
+    "wpm": 265.6714529698273,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-28T05:29:15Z",
+    "asin": "B08VRP55V1",
+    "wpm": 269.389800776845,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-29T03:54:25Z",
+    "asin": "B08VRP55V1",
+    "wpm": 437.485058570404,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-29T10:14:21Z",
+    "asin": "B08VRP55V1",
+    "wpm": 328.6717793387897,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-29T20:57:52Z",
+    "asin": "B08VRP55V1",
+    "wpm": 117.34028683181225,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-29T21:27:43Z",
+    "asin": "B08VRP55V1",
+    "wpm": 1100.9174311926606,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-30T16:55:40Z",
+    "asin": "B093B4BGRK",
+    "wpm": 8333.333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-30T16:55:46Z",
+    "asin": "B08VRP55V1",
+    "wpm": 925.9259259259259,
+    "period": "evening"
+  },
+  {
+    "start": "2022-01-31T04:13:20Z",
+    "asin": "B08VRP55V1",
+    "wpm": 423.8784881667255,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-31T04:23:51Z",
+    "asin": "B087PL8YVQ",
+    "wpm": 5272.564789991064,
+    "period": "morning"
+  },
+  {
+    "start": "2022-01-31T04:30:57Z",
+    "asin": "B08PF965W9",
+    "wpm": 394.3323085149044,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-01T23:45:11Z",
+    "asin": "B08PF965W9",
+    "wpm": 406.1371841155235,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-02T05:58:15Z",
+    "asin": "B08PF965W9",
+    "wpm": 454.0295119182747,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-02T17:07:07Z",
+    "asin": "B08PF965W9",
+    "wpm": 1430.517711171662,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-02T18:44:15Z",
+    "asin": "B08VRP55V1",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-03T01:42:32Z",
+    "asin": "B08PF965W9",
+    "wpm": 831.8605643244562,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-03T04:57:15Z",
+    "asin": "B08PF965W9",
+    "wpm": 880.3801006148688,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-03T05:03:27Z",
+    "asin": "B08VRP55V1",
+    "wpm": 581.3148788927336,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-04T04:50:05Z",
+    "asin": "B08B38JVKY",
+    "wpm": 1608.832807570978,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-04T04:54:55Z",
+    "asin": "B08VRP55V1",
+    "wpm": 930.3561935140883,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-04T05:06:16Z",
+    "asin": "B08VRP55V1",
+    "wpm": 2131.1475409836066,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-04T05:31:47Z",
+    "asin": "B0814JSV96",
+    "wpm": 5339.805825242718,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-04T05:34:50Z",
+    "asin": "B001NXK1XO",
+    "wpm": 1188.118811881188,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-04T18:19:12Z",
+    "asin": "B08B38JVKY",
+    "wpm": 61.73686376732062,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T18:49:11Z",
+    "asin": "B08B38JVKY",
+    "wpm": 64.76683937823834,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T18:54:09Z",
+    "asin": "B08B38JVKY",
+    "wpm": 230.65094823167607,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T19:10:05Z",
+    "asin": "B08B38JVKY",
+    "wpm": 59.39025999736043,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T19:23:49Z",
+    "asin": "B08B38JVKY",
+    "wpm": 324.0109140518417,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T19:38:55Z",
+    "asin": "B08B38JVKY",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T19:51:36Z",
+    "asin": "B08B38JVKY",
+    "wpm": 127.4968125796855,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T20:16:50Z",
+    "asin": "B08B38JVKY",
+    "wpm": 283.43480999370144,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-04T20:35:34Z",
+    "asin": "B08B38JVKY",
+    "wpm": 455.3668232743043,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-05T02:28:45Z",
+    "asin": "B08B38JVKY",
+    "wpm": 218.87159533073932,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-05T02:54:34Z",
+    "asin": "B08B38JVKY",
+    "wpm": 6000,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-05T04:21:19Z",
+    "asin": "B08B38JVKY",
+    "wpm": 299.43265391889054,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-05T22:06:12Z",
+    "asin": "B08B38JVKY",
+    "wpm": 316.4556962025316,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-05T22:08:37Z",
+    "asin": "B08B38JVKY",
+    "wpm": 67.65899864682002,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-05T22:14:11Z",
+    "asin": "B08B38JVKY",
+    "wpm": 373.3200597312096,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-06T00:08:13Z",
+    "asin": "B08B38JVKY",
+    "wpm": 1293.103448275862,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-06T00:43:35Z",
+    "asin": "B08B38JVKY",
+    "wpm": 12500,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-06T05:57:04Z",
+    "asin": "B001NXK1XO",
+    "wpm": 2036.1990950226243,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-06T06:00:37Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1034.2598577892695,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-06T21:39:34Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 3336.4226135310473,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-06T21:42:14Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 2443.146896127843,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-06T21:53:34Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 404.3126684636119,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-07T04:49:39Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 991.1894273127754,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-07T04:54:31Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1079.136690647482,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-07T04:54:54Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 583.6919992924945,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-08T05:30:02Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 755.939524838013,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-08T05:49:44Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 877.1929824561404,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-08T06:09:09Z",
+    "asin": "B08WRH53MY",
+    "wpm": 519.0311418685121,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-08T22:53:50Z",
+    "asin": "B08WRH53MY",
+    "wpm": 215.7928388746803,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-09T05:25:48Z",
+    "asin": "B08WRH53MY",
+    "wpm": 1401.8691588785045,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-09T05:26:23Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 1219.0116565424396,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-09T05:51:31Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 1704.5454545454545,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-09T05:53:04Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 180.50541516245488,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-09T19:40:58Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 1909.3449239366657,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-09T19:47:18Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 220.82638139169694,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-09T20:03:09Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 200.80321285140562,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-09T20:13:12Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 3579.9522673031024,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-09T20:22:14Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 705.6202030205496,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-09T20:30:08Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 32.223415682062296,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-10T05:22:16Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 590.5511811023622,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-10T05:23:04Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 1132.0754716981132,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-10T05:27:22Z",
+    "asin": "B000FC0R7O",
+    "wpm": 498.33887043189367,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-10T22:20:26Z",
+    "asin": "B000FC0R7O",
+    "wpm": 294.3410558298519,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-10T22:47:26Z",
+    "asin": "B000FC0R7O",
+    "wpm": 510.98620337250895,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-11T04:12:33Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1260.5042016806722,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-11T04:13:00Z",
+    "asin": "B000FC0R7O",
+    "wpm": 601.3926988816206,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-11T04:21:17Z",
+    "asin": "B000FC0R7O",
+    "wpm": 482.28211793679026,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-11T05:47:11Z",
+    "asin": "B000FC0R7O",
+    "wpm": 1909.9792715427895,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-11T05:58:50Z",
+    "asin": "B08WRH53MY",
+    "wpm": 579.6479175611851,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-11T06:02:55Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 104.90733185685977,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-11T22:13:58Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 831.9112627986348,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-11T22:18:05Z",
+    "asin": "B08WRH53MY",
+    "wpm": 229.53328232593725,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-12T04:59:26Z",
+    "asin": "B08WRH53MY",
+    "wpm": 461.5209298792069,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-13T03:12:54Z",
+    "asin": "B08WRH53MY",
+    "wpm": 413.7931034482758,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-13T23:05:42Z",
+    "asin": "B08WRH53MY",
+    "wpm": 1282.051282051282,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-14T00:19:00Z",
+    "asin": "B08WRH53MY",
+    "wpm": 110.3888139335214,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-14T00:45:30Z",
+    "asin": "B08WRH53MY",
+    "wpm": 779.896013864818,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-14T00:48:37Z",
+    "asin": "B08WRH53MY",
+    "wpm": 270.08951538224096,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-14T05:04:43Z",
+    "asin": "B08WRH53MY",
+    "wpm": 825.593395252838,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-14T05:11:51Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 1860.7442977190876,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-16T06:05:25Z",
+    "asin": "B08478YC6V",
+    "wpm": 2581.7555938037867,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-16T22:47:01Z",
+    "asin": "B07LGLF1JG",
+    "wpm": 955.4140127388536,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-16T22:47:21Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 183.7270341207349,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-17T06:31:51Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 457.0669583561216,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-17T22:44:01Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 564.2954856361149,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-17T22:51:08Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 167.8165206041395,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-18T21:06:37Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 239.1757635226297,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-19T06:04:21Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 249.70867321458297,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-22T01:21:12Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 232.90161326971145,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-22T05:45:07Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 361.01083032490976,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-22T05:48:51Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 280.01572018078207,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-22T19:23:51Z",
+    "asin": "B07N2X3ST6",
+    "wpm": 5153.203342618384,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T19:25:44Z",
+    "asin": "B07N2X3ST6",
+    "wpm": 2941.176470588235,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T19:26:05Z",
+    "asin": "B07PK5RMPM",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T19:26:42Z",
+    "asin": "B07PK5RMPM",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T19:28:04Z",
+    "asin": "B07PK5RMPM",
+    "wpm": 2456.331877729258,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T19:29:41Z",
+    "asin": "B07PK5RMPM",
+    "wpm": 5769.230769230769,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:14:09Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 1056.338028169014,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:15:30Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 372.20843672456573,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:22:35Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 5769.230769230769,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:24:10Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 205.17496865382424,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:41:21Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 179.61681745609366,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:54:07Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 25000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T20:54:09Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 940.2121504339441,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T21:15:31Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 199.40915805022158,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T21:28:44Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 4545.454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T21:30:00Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 8823.529411764706,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T21:30:08Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 360.57692307692304,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T21:36:13Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 192.6163723916533,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T21:48:58Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 230.57216054654143,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T22:22:53Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 842.6966292134831,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-22T22:24:20Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 125.0189422639794,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-23T03:45:10Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 281.14396509936984,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-24T02:33:17Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 342.81361097003554,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-24T04:25:06Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 111.1385527290689,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-24T04:56:15Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 287.69312733084706,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-24T22:53:46Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 57.833183395450455,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-25T00:53:58Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 555.5555555555555,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-25T00:57:40Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 1048.951048951049,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-25T00:58:04Z",
+    "asin": "B093ZQCS29",
+    "wpm": 578.1584582441113,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-25T05:24:44Z",
+    "asin": "B093ZQCS29",
+    "wpm": 318.00029581422865,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-25T21:27:49Z",
+    "asin": "B093ZQCS29",
+    "wpm": 256.8768061650433,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-26T00:23:04Z",
+    "asin": "B093ZQCS29",
+    "wpm": 903.6144578313252,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-26T01:31:38Z",
+    "asin": "B093ZQCS29",
+    "wpm": 462.40794656619283,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-26T01:48:56Z",
+    "asin": "B093ZQCS29",
+    "wpm": 510.8991825613079,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-26T06:24:58Z",
+    "asin": "B093ZQCS29",
+    "wpm": 427.6211593284764,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-26T06:30:16Z",
+    "asin": "B093ZQCS29",
+    "wpm": 435.0190320826536,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-26T06:39:36Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 463.5653871177619,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-27T05:10:34Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 540.8351500922355,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-28T01:55:24Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 144.60928712977346,
+    "period": "morning"
+  },
+  {
+    "start": "2022-02-28T22:24:56Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 1011.4107883817427,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-28T22:28:16Z",
+    "asin": "B09LM328XY",
+    "wpm": 798.2583454281568,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-28T22:36:17Z",
+    "asin": "B093ZQCS29",
+    "wpm": 490.19607843137254,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-28T22:40:59Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 614.9832277301529,
+    "period": "evening"
+  },
+  {
+    "start": "2022-02-28T22:45:34Z",
+    "asin": "B093ZQCS29",
+    "wpm": 106.24483532050525,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T05:50:51Z",
+    "asin": "B093ZQCS29",
+    "wpm": 426.10076029743504,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-01T06:10:57Z",
+    "asin": "B093ZQCS29",
+    "wpm": 83.93956351426972,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-01T06:14:03Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 1442.3076923076922,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-01T06:18:22Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 322.0213029477335,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-01T17:56:55Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 187.32438339057134,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T18:28:48Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 15000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T20:49:17Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 378.78787878787875,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T20:51:05Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 11538.461538461537,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T20:54:19Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 49.91680532445923,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T21:02:10Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 46.670815183571875,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T21:17:19Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 50.30181086519115,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T21:24:48Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 5357.142857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T21:27:06Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 1063.8297872340427,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T21:27:22Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 119.01613329806929,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-01T22:50:39Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 271.0333145115754,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-02T04:44:56Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 320.1189937269611,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-02T22:13:34Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 336.6463610131452,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-03T02:22:38Z",
+    "asin": "B09T9H87RB",
+    "wpm": 7880.5970149253735,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-03T05:48:23Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 607.5365290951038,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-03T06:46:00Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 485.47823865088156,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-03T22:26:06Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 151.73809085892955,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-04T04:43:45Z",
+    "asin": "B09T9H87RB",
+    "wpm": 6589.255735870173,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T04:50:15Z",
+    "asin": "B08RZ4PTSF",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T04:52:07Z",
+    "asin": "B08L3P3VGQ",
+    "wpm": 481.69556840077075,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T05:45:58Z",
+    "asin": "B08SBMCSQQ",
+    "wpm": 470.95761381475666,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T05:50:12Z",
+    "asin": "B00HYQEJAK",
+    "wpm": 1816.8947616800376,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T06:01:47Z",
+    "asin": "B0108VD2L4",
+    "wpm": 3473.5950296526407,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T06:07:48Z",
+    "asin": "B0108VD2L4",
+    "wpm": 3248.031496062992,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T06:15:11Z",
+    "asin": "B094GQBBPQ",
+    "wpm": 399.03264812575577,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-04T22:03:58Z",
+    "asin": "B094GQBBPQ",
+    "wpm": 359.8971722365039,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-04T22:13:46Z",
+    "asin": "B098TZ17NC",
+    "wpm": 171.76509079011944,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-05T05:10:33Z",
+    "asin": "B098TZ17NC",
+    "wpm": 735.2941176470588,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-05T05:11:46Z",
+    "asin": "B07TZYFR71",
+    "wpm": 124.58471760797342,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-05T05:27:53Z",
+    "asin": "B07TZYFR71",
+    "wpm": 293.2615023678151,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-06T02:37:39Z",
+    "asin": "B07TZYFR71",
+    "wpm": 292.16984807167904,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-06T04:53:35Z",
+    "asin": "B07TZYFR71",
+    "wpm": 363.19612590799034,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-06T05:36:10Z",
+    "asin": "B07TZYFR71",
+    "wpm": 80.46131151937777,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-06T05:51:28Z",
+    "asin": "B07TZYFR71",
+    "wpm": 193.50157220027413,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-06T06:26:13Z",
+    "asin": "B07TZYFR71",
+    "wpm": 321.4744963566224,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-07T03:08:05Z",
+    "asin": "B07TZYFR71",
+    "wpm": 94.90667510281557,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-08T05:45:50Z",
+    "asin": "B07TZYFR71",
+    "wpm": 297.24832974748045,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-08T22:06:42Z",
+    "asin": "B07TZYFR71",
+    "wpm": 338.2045929018789,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-09T01:33:14Z",
+    "asin": "B07TZYFR71",
+    "wpm": 447.90652385589095,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-09T04:46:48Z",
+    "asin": "B07TZYFR71",
+    "wpm": 347.43668931439163,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-09T05:08:30Z",
+    "asin": "B07TZYFR71",
+    "wpm": 369.71830985915494,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-11T01:39:08Z",
+    "asin": "B07TZYFR71",
+    "wpm": 309.3580819798917,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-11T04:55:20Z",
+    "asin": "B07TZYFR71",
+    "wpm": 543.7597099948214,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-11T04:58:53Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 2311.248073959938,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-11T05:00:27Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 831.5502820462945,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-11T05:18:45Z",
+    "asin": "B07TZYFR71",
+    "wpm": 413.6438844342625,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-11T06:31:56Z",
+    "asin": "B07TZYFR71",
+    "wpm": 420.21711217462354,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-12T05:47:29Z",
+    "asin": "B07TZYFR71",
+    "wpm": 392.83083722072183,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-12T06:07:54Z",
+    "asin": "B07TZYFR71",
+    "wpm": 1724.1379310344828,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-12T06:08:06Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 189.3939393939394,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-12T19:31:37Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 155.77672003461706,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-12T23:55:40Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 299.58058717795086,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-13T05:23:05Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 377.22908093278465,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-13T21:39:36Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 144.75659446708127,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-14T02:26:22Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 295.0432730133753,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-14T03:46:24Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 411.635565312843,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-14T03:57:43Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 491.76297024834025,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-14T04:20:39Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 545.4545454545455,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-14T04:22:35Z",
+    "asin": "B07TZYFR71",
+    "wpm": 67.58786422349054,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-14T04:35:59Z",
+    "asin": "B07TZYFR71",
+    "wpm": 343.3967663471169,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-14T19:37:44Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 100,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-14T21:13:19Z",
+    "asin": "B07TZYFR71",
+    "wpm": 682.5938566552901,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-14T21:19:18Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 211.90181882394492,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-15T03:32:25Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 627.6150627615062,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-15T03:35:00Z",
+    "asin": "B07TZYFR71",
+    "wpm": 891.3412563667233,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-15T04:10:15Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 425.77560878442307,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-16T00:55:25Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 275.22935779816515,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-16T03:04:15Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 784.0018179752301,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-16T03:19:12Z",
+    "asin": "B08QM8VHRT",
+    "wpm": 2307.6923076923076,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-16T04:08:11Z",
+    "asin": "B07TZYFR71",
+    "wpm": 697.7769072568798,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-16T18:51:15Z",
+    "asin": "B07TVRR6GR",
+    "wpm": 601.9261637239165,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-16T21:44:13Z",
+    "asin": "B07TZYFR71",
+    "wpm": 389.89602772593975,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-16T23:14:21Z",
+    "asin": "B07TZYFR71",
+    "wpm": 179.84071251177528,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-17T05:12:34Z",
+    "asin": "B07TZYFR71",
+    "wpm": 948.0170643071575,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-18T05:26:10Z",
+    "asin": "B07TZYFR71",
+    "wpm": 1074.856046065259,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-18T05:39:17Z",
+    "asin": "B07TVRR6GR",
+    "wpm": 305.45750746673906,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-18T17:33:53Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 4166.666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-21T23:52:42Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 13.600507752289419,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-22T03:09:02Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1456.3106796116506,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-22T03:10:36Z",
+    "asin": "",
+    "wpm": 717.7033492822967,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-22T03:11:45Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 267.64804282368686,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-22T21:36:35Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 228.52368783172793,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-22T22:30:55Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 209.04175260605385,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-23T02:47:22Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 296.2829951517328,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-23T02:59:38Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 263.94200314384256,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-23T04:34:07Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 903.6144578313252,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-23T04:35:52Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 311.2808168008633,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-23T21:41:24Z",
+    "asin": "B094GQBBPQ",
+    "wpm": 4137.931034482758,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-23T21:42:58Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1875,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-23T21:43:11Z",
+    "asin": "B094GQBBPQ",
+    "wpm": 126.90355329949239,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-26T03:13:47Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 539.3864479154961,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-26T03:28:43Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1973.6842105263156,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-26T03:28:53Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 448.8218426630096,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-26T21:06:08Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 352.0713531275672,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-27T04:03:07Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 308.3841953099904,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-27T04:29:32Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 263.1771328313473,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-27T04:53:07Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 303.9027511196417,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-27T19:18:25Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 251.25628140703517,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-27T20:25:36Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 162.1767726822236,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-27T21:42:43Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 155.9251559251559,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-27T23:01:19Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 236.82429892489287,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-28T04:04:33Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 334.2516813872458,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-28T21:09:42Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 24.330900243309003,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-28T21:23:46Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 259.61538461538464,
+    "period": "evening"
+  },
+  {
+    "start": "2022-03-29T03:24:54Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 289.319960321834,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-29T05:08:43Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 313.8580395943988,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-31T01:33:01Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 24.822108224391858,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-31T01:48:03Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 287.19684777179646,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-31T04:05:55Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 110.7965037547704,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-31T04:20:54Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 190.58375097056538,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-31T04:53:57Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 371.57012195121956,
+    "period": "morning"
+  },
+  {
+    "start": "2022-03-31T05:02:44Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 100.49129075480126,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-01T15:50:04Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 2000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-01T18:18:06Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 181.83917335334527,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-02T02:56:17Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 293.78598136387916,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-02T21:17:55Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 24.80568877129155,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-02T21:41:21Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 206.3476466542203,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-02T22:14:23Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 205.19835841313267,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-03T00:16:01Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 124.06947890818859,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-03T05:46:29Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 203.72010628875108,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-03T20:25:44Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 139.76602132725955,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-04T03:11:14Z",
+    "asin": "B08FH9BV7N",
+    "wpm": 1158.4068105807235,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-04T03:44:50Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 305.2740971680956,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-05T03:56:58Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 357.2846367606193,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-06T03:50:07Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 332.99417260197947,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-07T02:53:16Z",
+    "asin": "B09T9H87RB",
+    "wpm": 3015.075376884422,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-07T03:41:26Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 394.3476832073612,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-08T03:49:02Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 366.84257948255885,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-09T03:50:25Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 240.1921537229784,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-09T03:55:14Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 1505.0167224080267,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-09T03:56:38Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 212.56495040151157,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-09T15:31:18Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 578.4991161819058,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T16:04:44Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 2036.1990950226243,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T16:50:56Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 655.5944055944055,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T16:58:13Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 471.4510214772132,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T20:05:48Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 5232.558139534884,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T20:06:10Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 173.44686218858405,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T20:24:35Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 575.8157389635317,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-09T20:52:23Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 472.21461812209145,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-10T05:13:29Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 575.2636625119846,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-10T14:54:47Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 710.8028294759974,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-10T15:25:52Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 662.6092078138805,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-10T23:12:25Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 460.82949308755764,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-10T23:14:10Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 189.4442967295932,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-11T00:53:17Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 51.76578856551248,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-11T01:34:05Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 532.6844666578982,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-11T03:13:57Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 484.12083656080557,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-12T03:32:14Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 467.44574290484144,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-12T22:06:25Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 813.74321880651,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-13T03:02:15Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 331.73186913749714,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-13T21:02:39Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 296.38943775821804,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-14T02:03:35Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 493.370858906107,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-14T02:44:58Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 1724.1379310344828,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-14T02:45:17Z",
+    "asin": "B098PXP11K",
+    "wpm": 1170.7317073170732,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-14T02:55:39Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 1764.7058823529412,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-14T02:56:24Z",
+    "asin": "B098PXP11K",
+    "wpm": 396.14855570839063,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-14T03:59:34Z",
+    "asin": "B098PXP11K",
+    "wpm": 503.0743432084964,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-14T21:29:22Z",
+    "asin": "B098PXP11K",
+    "wpm": 504.2581801882564,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-14T21:36:55Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 194.4361352078971,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-14T23:27:57Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 808.8070096607504,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-14T23:35:38Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 541.871921182266,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-15T02:14:58Z",
+    "asin": "B08G1NJK2R",
+    "wpm": 1265.2179332696223,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-15T03:03:02Z",
+    "asin": "B098PXP11K",
+    "wpm": 753.7688442211055,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-16T04:02:52Z",
+    "asin": "B098PXP11K",
+    "wpm": 175.54125219426564,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-16T21:55:36Z",
+    "asin": "B098PXP11K",
+    "wpm": 318.64046733935214,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-16T22:22:04Z",
+    "asin": "B098PXP11K",
+    "wpm": 337.68572714993246,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-17T03:54:00Z",
+    "asin": "B098PXP11K",
+    "wpm": 248.53639677454987,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-17T17:31:23Z",
+    "asin": "B098PXP11K",
+    "wpm": 1437.6996805111824,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-17T17:35:37Z",
+    "asin": "B098PXP11K",
+    "wpm": 1829.268292682927,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-17T23:42:47Z",
+    "asin": "B098PXP11K",
+    "wpm": 416.07127847356475,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-18T00:23:17Z",
+    "asin": "B098PXP11K",
+    "wpm": 351.8681854861411,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-18T01:54:34Z",
+    "asin": "B098PXP11K",
+    "wpm": 362.45707745135445,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-18T03:29:37Z",
+    "asin": "B098PXP11K",
+    "wpm": 306.73937525932075,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-18T05:02:32Z",
+    "asin": "B098PXP11K",
+    "wpm": 324.9097472924188,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-18T22:32:40Z",
+    "asin": "B098PXP11K",
+    "wpm": 460.8389316729477,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-19T05:03:20Z",
+    "asin": "B08JKC299M",
+    "wpm": 424.2965609647164,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-19T23:06:52Z",
+    "asin": "B08JKC299M",
+    "wpm": 215.119852489244,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-20T02:06:11Z",
+    "asin": "B08JKC299M",
+    "wpm": 3260.869565217391,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T02:06:28Z",
+    "asin": "B08JKC299M",
+    "wpm": 1711.0266159695816,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T02:06:59Z",
+    "asin": "B08JKC299M",
+    "wpm": 12500,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T03:25:54Z",
+    "asin": "B08JKC299M",
+    "wpm": 101.51139183397248,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T03:30:45Z",
+    "asin": "B09T9H87RB",
+    "wpm": 11111.111111111111,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T03:33:27Z",
+    "asin": "B08JKC299M",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T03:34:16Z",
+    "asin": "B08FLLBBP9",
+    "wpm": 509.9660022665156,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-20T04:03:45Z",
+    "asin": "B08JKC299M",
+    "wpm": 277.623542476402,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-21T03:40:53Z",
+    "asin": "B08JKC299M",
+    "wpm": 415.38461538461536,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-21T03:49:14Z",
+    "asin": "B08JKC299M",
+    "wpm": 311.5264797507788,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-21T04:27:40Z",
+    "asin": "B08JKC299M",
+    "wpm": 265.15821106593603,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-21T19:14:15Z",
+    "asin": "B08JKC299M",
+    "wpm": 585.6832971800434,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-21T19:25:12Z",
+    "asin": "B08JKC299M",
+    "wpm": 5172.413793103448,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-22T03:04:39Z",
+    "asin": "B08JKC299M",
+    "wpm": 292.40568886936467,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-22T20:14:31Z",
+    "asin": "B08JKC299M",
+    "wpm": 282.43752139678196,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-22T22:46:42Z",
+    "asin": "B08JKC299M",
+    "wpm": 386.59793814432993,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-22T22:47:43Z",
+    "asin": "B08JKC299M",
+    "wpm": 338.67846281448715,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-22T23:34:44Z",
+    "asin": "B08JKC299M",
+    "wpm": 321.2440057730807,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T04:23:17Z",
+    "asin": "B08JKC299M",
+    "wpm": 327.76580459770116,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-23T15:17:33Z",
+    "asin": "B08JKC299M",
+    "wpm": 364.8747263439553,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T17:38:57Z",
+    "asin": "B08JKC299M",
+    "wpm": 440.73300858269545,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T18:37:52Z",
+    "asin": "B08JKC299M",
+    "wpm": 7222.609909281228,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T18:40:37Z",
+    "asin": "B08JKC299M",
+    "wpm": 401.33779264214047,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T19:04:34Z",
+    "asin": "B08JKC299M",
+    "wpm": 266.4298401420959,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T19:05:48Z",
+    "asin": "B08JKC299M",
+    "wpm": 410.7338444687842,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T19:25:38Z",
+    "asin": "B08JKC299M",
+    "wpm": 1494.0239043824702,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T20:14:18Z",
+    "asin": "B08JKC299M",
+    "wpm": 424.92917847025495,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-23T20:21:33Z",
+    "asin": "B08JKC299M",
+    "wpm": 238.2573179033356,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-24T04:02:16Z",
+    "asin": "B08JKC299M",
+    "wpm": 352.69221725840583,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-24T12:25:09Z",
+    "asin": "B08JKC299M",
+    "wpm": 3658.536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-24T20:09:35Z",
+    "asin": "B08JKC299M",
+    "wpm": 566.0377358490566,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-24T20:16:02Z",
+    "asin": "B0018ND8B6",
+    "wpm": 245.08202078295537,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-25T02:04:34Z",
+    "asin": "B0018ND8B6",
+    "wpm": 274.3598270701696,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T02:20:13Z",
+    "asin": "B0018ND8B6",
+    "wpm": 135.56258472661546,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T02:41:55Z",
+    "asin": "B0018ND8B6",
+    "wpm": 346.02076124567475,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T02:43:28Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 77.46733460724062,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T02:44:53Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 588.2352941176471,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T02:45:22Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T03:31:10Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 413.1186240620521,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T04:46:42Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 412.80539174389213,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T05:18:30Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 358.3580684862086,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-25T20:29:36Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 302.0957895399333,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-25T22:02:50Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 341.5430154453341,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-25T22:46:51Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 361.39135672338506,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-26T01:53:42Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 255.5878520597374,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-26T03:03:48Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 308.2543669368649,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-26T14:40:31Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 1851.8518518518517,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-26T20:51:36Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 189.8133502056311,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-26T21:37:23Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 292.151392325104,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-27T03:13:54Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 322.0896414884075,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-27T04:18:26Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 276.7527675276753,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-27T23:35:09Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 362.3703282648856,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-28T01:06:57Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 321.8327161989134,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T01:55:11Z",
+    "asin": "B01LWWK7WR",
+    "wpm": 1648.3516483516482,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T03:47:42Z",
+    "asin": "B098TZ17NC",
+    "wpm": 496.68874172185434,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T03:49:18Z",
+    "asin": "B098TZ17NC",
+    "wpm": 225.9436469962786,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T04:08:57Z",
+    "asin": "B0018ND8B6",
+    "wpm": 361.35870874488074,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T04:30:27Z",
+    "asin": "B099DRHTLX",
+    "wpm": 1578.9473684210527,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T04:31:23Z",
+    "asin": "B099DRHTLX",
+    "wpm": 117.00468018720748,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-28T20:37:56Z",
+    "asin": "B099DRHTLX",
+    "wpm": 183.61581920903956,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-29T03:10:27Z",
+    "asin": "B099DRHTLX",
+    "wpm": 322.2888160126654,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-29T03:25:19Z",
+    "asin": "B098TZ17NC",
+    "wpm": 444.57617071724957,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-29T03:32:46Z",
+    "asin": "B098TZ17NC",
+    "wpm": 309.76676384839647,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-29T08:14:07Z",
+    "asin": "B098TZ17NC",
+    "wpm": 362.7569528415961,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-29T08:15:38Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 377.05160431761055,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-30T03:24:34Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 212.0606444693609,
+    "period": "morning"
+  },
+  {
+    "start": "2022-04-30T14:02:03Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 12952.646239554317,
+    "period": "evening"
+  },
+  {
+    "start": "2022-04-30T18:18:31Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 709.2198581560284,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-01T01:07:09Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 43.49507055867002,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-01T01:33:48Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 66.3716814159292,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-01T02:21:15Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 267.786590184085,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-01T05:25:42Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 211.09417145537705,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-02T02:49:41Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 264.0203932993445,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-02T22:19:57Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 389.2733564013841,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-02T22:39:31Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 254.02853330596326,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-03T03:51:36Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 418.79944160074456,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-03T03:58:54Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 450.25728987993136,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-03T04:03:27Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 123.54576340986307,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-04T03:54:02Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 229.8733142623621,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-04T20:45:57Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 783.289817232376,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-04T20:48:41Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 1277.5551102204408,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-04T22:52:01Z",
+    "asin": "B00JV2H5I8",
+    "wpm": 1162.7906976744187,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-04T22:52:20Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 290.5041457362464,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-05T03:33:28Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 303.83091149273446,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-05T22:31:28Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 292.7038218076246,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-06T03:11:19Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 341.3482181193645,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-06T20:07:33Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 148.2479784366577,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-07T03:17:48Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 369.09448818897636,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-07T03:21:20Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 915.9069608929027,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-07T17:23:40Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 494.7526236881559,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-07T21:41:34Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 2586.206896551724,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-07T21:42:16Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1077.414205905826,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-07T22:13:27Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 3448.2758620689656,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-08T05:29:38Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1363.6363636363637,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-08T05:30:11Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 976.3454516589935,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-08T18:29:31Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1563.3571036752605,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-08T18:34:58Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1083.5540573079702,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-08T18:42:11Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1350.2454991816694,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-08T18:54:13Z",
+    "asin": "B08PY1XTB8",
+    "wpm": 1521.7391304347825,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-08T21:07:58Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 292.772186642269,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-09T01:52:23Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 381.39763779527556,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-09T02:34:16Z",
+    "asin": "B091Y4KGFH",
+    "wpm": 242.91497975708504,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-09T02:39:58Z",
+    "asin": "B099DRHTLX",
+    "wpm": 1056.338028169014,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-09T02:40:36Z",
+    "asin": "B099DRHTLX",
+    "wpm": 311.9584055459272,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-09T19:21:06Z",
+    "asin": "B09Z1Y1MG9",
+    "wpm": 5460.46287367406,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-09T19:37:48Z",
+    "asin": "B099DRHTLX",
+    "wpm": 639.3180607352158,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-09T20:05:07Z",
+    "asin": "B099DRHTLX",
+    "wpm": 4761.904761904762,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-10T01:51:07Z",
+    "asin": "B099DRHTLX",
+    "wpm": 318.8682011435273,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-10T20:41:08Z",
+    "asin": "B099DRHTLX",
+    "wpm": 1415.0943396226414,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-10T21:37:31Z",
+    "asin": "B099DRHTLX",
+    "wpm": 167.93551276309896,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-10T21:52:29Z",
+    "asin": "B099DRHTLX",
+    "wpm": 84.90165558228385,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-10T23:10:02Z",
+    "asin": "B099DRHTLX",
+    "wpm": 254.4529262086514,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-11T03:11:48Z",
+    "asin": "B099DRHTLX",
+    "wpm": 418.4333854050435,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-11T22:01:59Z",
+    "asin": "B099DRHTLX",
+    "wpm": 275.0085940185631,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-11T23:13:44Z",
+    "asin": "B099DRHTLX",
+    "wpm": 729.5719844357976,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-12T00:13:52Z",
+    "asin": "B099DRHTLX",
+    "wpm": 591.2269548633185,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-12T00:28:11Z",
+    "asin": "B099DRHTLX",
+    "wpm": 262.2458056007116,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-12T02:50:43Z",
+    "asin": "B099DRHTLX",
+    "wpm": 455.3868937430581,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-13T01:22:05Z",
+    "asin": "B099DRHTLX",
+    "wpm": 528.8135593220339,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-13T01:35:00Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 2000,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-13T04:28:35Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 370.60445874511606,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-13T17:23:45Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 205.09499136442142,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T00:05:25Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 1020.4081632653061,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:06:25Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 705.5503292568203,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:11:04Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 334.82142857142856,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:12:42Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 227.82503037667072,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:22:49Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 221.23893805309737,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:24:39Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 199.66722129783693,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:33:52Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 383.6317135549872,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T00:39:01Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 415.80041580041586,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T01:24:25Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 245.1982018798529,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T01:34:43Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 3191.4893617021276,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T02:59:16Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 372.51655629139077,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T03:20:56Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 220.96131812973977,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-14T14:40:12Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 476.7959313413859,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T15:51:12Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 239.57632817753864,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T16:46:36Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 1160.5415860735009,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T17:02:29Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 7500,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T17:23:03Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 164.73172262315657,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T18:13:03Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 82.91873963515754,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T18:25:41Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 258.8996763754045,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T19:51:53Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 449.00577293136627,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T20:17:26Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 113.44299489506524,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T20:35:08Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 388.2238757683598,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-14T23:01:47Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 307.1606834325206,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T00:19:31Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 273.46598604021256,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-15T02:45:45Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 379.5207620181574,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-15T02:57:05Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 1003.3444816053511,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-15T02:58:30Z",
+    "asin": "B0756J4NRG",
+    "wpm": 2036.1990950226243,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-15T14:46:35Z",
+    "asin": "B01NBJMMRR",
+    "wpm": 1401.8691588785045,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T14:46:53Z",
+    "asin": "B0756J4NRG",
+    "wpm": 5000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T16:02:07Z",
+    "asin": "B0756J4NRG",
+    "wpm": 31.27606338615513,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T16:12:51Z",
+    "asin": "B0756J4NRG",
+    "wpm": 541.5162454873646,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T16:18:02Z",
+    "asin": "B0756J4NRG",
+    "wpm": 598.1201936770151,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T16:30:25Z",
+    "asin": "B0756J4NRG",
+    "wpm": 711.7437722419928,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T17:43:21Z",
+    "asin": "B0756J4NRG",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T20:05:50Z",
+    "asin": "B0756J4NRG",
+    "wpm": 471.737151369693,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T21:28:00Z",
+    "asin": "B0756J4NRG",
+    "wpm": 379.0724677276142,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T22:09:16Z",
+    "asin": "B0756J4NRG",
+    "wpm": 6040.268456375839,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T22:41:55Z",
+    "asin": "B0756J4NRG",
+    "wpm": 543.970988213962,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-15T23:04:22Z",
+    "asin": "B0756J4NRG",
+    "wpm": 128.75536480686696,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T02:58:31Z",
+    "asin": "B0756J4NRG",
+    "wpm": 183.36357558972398,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-16T16:17:37Z",
+    "asin": "B0756J4NRG",
+    "wpm": 522.8836734080596,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T17:44:28Z",
+    "asin": "B0756J4NRG",
+    "wpm": 458.8100349989706,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T20:00:57Z",
+    "asin": "B0756J4NRG",
+    "wpm": 225.01933759932493,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T21:14:13Z",
+    "asin": "B0756J4NRG",
+    "wpm": 251.10782865583457,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T23:19:51Z",
+    "asin": "B0756J4NRG",
+    "wpm": 1363.3185737590306,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T23:37:09Z",
+    "asin": "B0756J4NRG",
+    "wpm": 177.9551337359793,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T23:53:12Z",
+    "asin": "B0756J4NRG",
+    "wpm": 88.57395925597875,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-16T23:59:53Z",
+    "asin": "B0756J4NRG",
+    "wpm": 278.8104089219331,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-17T00:19:25Z",
+    "asin": "B0756J4NRG",
+    "wpm": 70.9891150023663,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-17T00:24:17Z",
+    "asin": "B0756J4NRG",
+    "wpm": 139.37282229965157,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-17T00:31:31Z",
+    "asin": "B0756J4NRG",
+    "wpm": 79.07221929362152,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-17T00:42:53Z",
+    "asin": "B0756J4NRG",
+    "wpm": 229.3577981651376,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-17T01:41:52Z",
+    "asin": "B07GVCBVYC",
+    "wpm": 1485.148514851485,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-18T02:23:44Z",
+    "asin": "B07GVCBVYC",
+    "wpm": 3370.7865168539324,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-20T02:25:07Z",
+    "asin": "B07WYSF921",
+    "wpm": 3658.536585365854,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-20T02:27:28Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 1985.2941176470588,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-20T17:08:51Z",
+    "asin": "B0756J4NRG",
+    "wpm": 568.1818181818181,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-20T17:09:44Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 719.7696737044146,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-20T17:13:55Z",
+    "asin": "",
+    "wpm": 942.2110552763819,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-21T04:23:01Z",
+    "asin": "B095MMJYSR",
+    "wpm": 354.36353529738744,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-21T15:54:56Z",
+    "asin": "B095MMJYSR",
+    "wpm": 191.17135905457073,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-22T02:40:36Z",
+    "asin": "B095MMJYSR",
+    "wpm": 29.889409186011758,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-22T04:02:15Z",
+    "asin": "B095MMJYSR",
+    "wpm": 182.5557809330629,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-22T15:00:28Z",
+    "asin": "B095MMJYSR",
+    "wpm": 624.1331484049931,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-22T15:12:45Z",
+    "asin": "B095MMJYSR",
+    "wpm": 605.57125555107,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-22T17:04:07Z",
+    "asin": "B095MMJYSR",
+    "wpm": 469.8144233027954,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-22T17:25:42Z",
+    "asin": "B095MMJYSR",
+    "wpm": 1094.890510948905,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-22T21:25:47Z",
+    "asin": "B095MMJYSR",
+    "wpm": 258.7017873941674,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-22T21:47:35Z",
+    "asin": "B095MMJYSR",
+    "wpm": 168.1479702137881,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-23T00:32:06Z",
+    "asin": "B095MMJYSR",
+    "wpm": 621.5096379030806,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-23T03:07:26Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 775.4342431761786,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-23T03:16:38Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 296.70713260675643,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-23T19:31:44Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 623.9600665557404,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-23T20:12:33Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 1079.136690647482,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-23T20:13:10Z",
+    "asin": "B07WYSF921",
+    "wpm": 5123.825789923143,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-24T17:13:51Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 272.2323049001815,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-24T17:14:51Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 621.9991270187691,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-24T18:24:02Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 903.6144578313252,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-24T19:07:19Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 1401.8691588785045,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-26T00:21:42Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 153.30891746869943,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-26T00:41:46Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 436.5904365904365,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-27T02:51:52Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 408.95813047711783,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-27T03:00:38Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 299.04306220095697,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-27T20:30:53Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 909.090909090909,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-27T20:31:18Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 260.2133749674733,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-27T23:19:02Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 318.21148825065274,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-27T23:47:28Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 516.7068549776094,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-28T03:50:48Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 228.75030098723815,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-28T04:16:40Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 220.35676810073454,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-28T15:53:40Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 619.0269331016508,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-28T17:26:17Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 2912.621359223301,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T04:15:03Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 493.09664694280076,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-29T16:36:33Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 337.70262157294377,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T16:40:09Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 1351.3513513513515,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T17:48:27Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 461.53846153846155,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T18:00:00Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 350.81857667891745,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T18:22:40Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 303.42037513791837,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T18:45:14Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 591.9383632434464,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T19:04:46Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 541.2077478161792,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-29T19:26:04Z",
+    "asin": "B07D2C6J4K",
+    "wpm": 808.9272380320251,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-30T23:11:21Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 987.5640087783468,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-31T02:45:49Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 311.85031185031187,
+    "period": "morning"
+  },
+  {
+    "start": "2022-05-31T21:26:08Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 151.6513143113907,
+    "period": "evening"
+  },
+  {
+    "start": "2022-05-31T23:39:28Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 151.47689977278466,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-01T02:37:53Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 301.8660812294182,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-01T20:33:52Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 511.22694466720134,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-01T20:48:21Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 99.70752459452272,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-01T22:09:38Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 404.58530006743086,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-02T02:33:57Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 356.82729558893493,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-02T21:19:51Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 176.05633802816902,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-03T18:56:04Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 146.74232048522796,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-03T20:33:32Z",
+    "asin": "B09Q1SQ567",
+    "wpm": 2400,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-03T20:33:45Z",
+    "asin": "B09QCX4JK7",
+    "wpm": 4545.454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-04T03:05:40Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 112.45220781168004,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-04T19:06:32Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 104.94402985074628,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-05T04:29:35Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 209.41364180295173,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-05T05:07:34Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 98.86633271816504,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-05T05:28:34Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 258.4721424468696,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-06T02:51:59Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 300.6012024048096,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-06T02:57:16Z",
+    "asin": "B08XTNHRR5",
+    "wpm": 2343.75,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-06T02:59:19Z",
+    "asin": "B09Z1Y1MG9",
+    "wpm": 2278.481012658228,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-06T03:00:48Z",
+    "asin": "B093ZQCS29",
+    "wpm": 385.2504127682994,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-06T03:11:36Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 140.7525570047856,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-07T03:38:12Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 853.3267375711106,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-07T04:14:33Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 841.1214953271027,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-07T04:32:02Z",
+    "asin": "B00JX43A0G",
+    "wpm": 295.6081081081081,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-07T04:47:33Z",
+    "asin": "B00JX43A0G",
+    "wpm": 330.0935264991748,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-08T03:02:20Z",
+    "asin": "B00JX43A0G",
+    "wpm": 396.7149220489978,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-08T03:15:06Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 2500,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-08T03:15:27Z",
+    "asin": "B096DH95W8",
+    "wpm": 1125,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-08T03:32:53Z",
+    "asin": "B098QS47D3",
+    "wpm": 476.5687053216839,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-08T19:04:21Z",
+    "asin": "B098QS47D3",
+    "wpm": 190.3807615230461,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-09T01:44:02Z",
+    "asin": "B09P37M6P3",
+    "wpm": 867.0520231213873,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-09T02:41:16Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 785.3403141361256,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-09T03:57:52Z",
+    "asin": "B098QS47D3",
+    "wpm": 366.1141055629005,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-09T14:44:18Z",
+    "asin": "B096DH95W8",
+    "wpm": 704.2253521126761,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-09T14:45:14Z",
+    "asin": "B098QS47D3",
+    "wpm": 204.55578564573966,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-09T17:54:27Z",
+    "asin": "B098QS47D3",
+    "wpm": 241.54589371980677,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-09T17:55:40Z",
+    "asin": "B098QS47D3",
+    "wpm": 821.9178082191781,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-09T19:58:16Z",
+    "asin": "B098QS47D3",
+    "wpm": 289.5179649609027,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-09T20:32:02Z",
+    "asin": "B098QS47D3",
+    "wpm": 47.528517110266165,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-10T03:56:38Z",
+    "asin": "B098QS47D3",
+    "wpm": 210.12607564538723,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-10T04:21:41Z",
+    "asin": "B098QS47D3",
+    "wpm": 325.003611151235,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-10T21:13:19Z",
+    "asin": "B098QS47D3",
+    "wpm": 171.30271637164532,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-11T04:56:03Z",
+    "asin": "B098QS47D3",
+    "wpm": 341.53005464480873,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-11T18:04:18Z",
+    "asin": "B098QS47D3",
+    "wpm": 237.96303640834458,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-11T18:46:23Z",
+    "asin": "B098QS47D3",
+    "wpm": 197.8891820580475,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-12T01:00:44Z",
+    "asin": "B098QS47D3",
+    "wpm": 24.80568877129155,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-12T01:13:02Z",
+    "asin": "B098QS47D3",
+    "wpm": 223.2775730082223,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-12T03:07:51Z",
+    "asin": "B098QS47D3",
+    "wpm": 250.70653660315435,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-12T04:17:19Z",
+    "asin": "B098QS47D3",
+    "wpm": 324.73389861086054,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-12T17:17:48Z",
+    "asin": "B098QS47D3",
+    "wpm": 278.67897845437153,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-12T18:46:05Z",
+    "asin": "B098QS47D3",
+    "wpm": 324.5067497403946,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-12T19:09:27Z",
+    "asin": "B098QS47D3",
+    "wpm": 560.1765404854864,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-12T19:24:34Z",
+    "asin": "B098QS47D3",
+    "wpm": 546.7196819085486,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-12T21:03:57Z",
+    "asin": "B098QS47D3",
+    "wpm": 3308.823529411765,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-17T04:49:12Z",
+    "asin": "B098TZ17NC",
+    "wpm": 1384.6153846153848,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-17T04:49:59Z",
+    "asin": "B098TZ17NC",
+    "wpm": 286.07755880483154,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-18T02:59:34Z",
+    "asin": "B098TZ17NC",
+    "wpm": 194.5525291828794,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-18T21:28:48Z",
+    "asin": "B098TZ17NC",
+    "wpm": 188.8329383886256,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-19T04:17:05Z",
+    "asin": "B098TZ17NC",
+    "wpm": 345.3004848900426,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-19T04:51:33Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 3620.689655172414,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-19T04:52:05Z",
+    "asin": "B09BTJNJCX",
+    "wpm": 1948.051948051948,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-19T04:54:41Z",
+    "asin": "B098TZ17NC",
+    "wpm": 2631.578947368421,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-19T05:06:44Z",
+    "asin": "B08KL58Q4X",
+    "wpm": 411.3924050632911,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-19T05:14:53Z",
+    "asin": "B08KL58Q4X",
+    "wpm": 442.31478068558795,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-20T04:23:06Z",
+    "asin": "B08KL58Q4X",
+    "wpm": 2045.614860098754,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-20T04:30:34Z",
+    "asin": "B098TZ17NC",
+    "wpm": 3580.901856763926,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-21T01:10:22Z",
+    "asin": "B098TZ17NC",
+    "wpm": 1276.595744680851,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-21T01:38:15Z",
+    "asin": "B09QBBMXCR",
+    "wpm": 13701.923076923076,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-21T01:46:55Z",
+    "asin": "B08J3YYP2M",
+    "wpm": 6864.06460296097,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-21T01:50:57Z",
+    "asin": "B08J3YYP2M",
+    "wpm": 8040.131940626718,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-22T04:46:44Z",
+    "asin": "B08P98PVY2",
+    "wpm": 1079.136690647482,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-22T04:47:16Z",
+    "asin": "B08P98PVY2",
+    "wpm": 314.2557851633178,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-22T17:50:43Z",
+    "asin": "B08P98PVY2",
+    "wpm": 234.31132844335778,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-22T19:29:20Z",
+    "asin": "B08P98PVY2",
+    "wpm": 418.64005412719894,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-22T21:41:49Z",
+    "asin": "B08P98PVY2",
+    "wpm": 68.64360241625481,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-23T03:38:49Z",
+    "asin": "B08P98PVY2",
+    "wpm": 381.27667737758384,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-23T15:54:58Z",
+    "asin": "B08J3YYP2M",
+    "wpm": 1293.103448275862,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-23T16:38:08Z",
+    "asin": "B08J3YYP2M",
+    "wpm": 2838.8746803069052,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-23T21:06:42Z",
+    "asin": "B08P98PVY2",
+    "wpm": 253.52112676056336,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-23T21:27:05Z",
+    "asin": "B08P98PVY2",
+    "wpm": 98.96091044037605,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-23T21:49:43Z",
+    "asin": "B08P98PVY2",
+    "wpm": 637.3745592622729,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-23T22:37:46Z",
+    "asin": "B08P98PVY2",
+    "wpm": 248.02498622083408,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-24T02:25:55Z",
+    "asin": "B08P98PVY2",
+    "wpm": 300.6463897379366,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-24T03:54:58Z",
+    "asin": "B08P98PVY2",
+    "wpm": 496.2002682163612,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-24T17:57:08Z",
+    "asin": "B08P98PVY2",
+    "wpm": 261.00096158249005,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-24T21:18:30Z",
+    "asin": "B08P98PVY2",
+    "wpm": 24.84266313348791,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-24T22:52:29Z",
+    "asin": "B08P98PVY2",
+    "wpm": 413.22314049586777,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-25T03:08:12Z",
+    "asin": "B08P98PVY2",
+    "wpm": 438.0372640151359,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-25T18:11:46Z",
+    "asin": "B08P98PVY2",
+    "wpm": 235.09129378575346,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-25T20:47:45Z",
+    "asin": "B08P98PVY2",
+    "wpm": 244.59845087647778,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-25T21:14:04Z",
+    "asin": "B08P98PVY2",
+    "wpm": 184.20446695832374,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-26T00:33:54Z",
+    "asin": "B0151YQYYU",
+    "wpm": 47.86979415988511,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-26T01:08:32Z",
+    "asin": "B0151YQYYU",
+    "wpm": 317.71394597004945,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-26T02:50:38Z",
+    "asin": "B0151YQYYU",
+    "wpm": 294.306156884802,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-26T19:48:55Z",
+    "asin": "B0151YQYYU",
+    "wpm": 302.3050762060713,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-27T02:58:33Z",
+    "asin": "B0151YQYYU",
+    "wpm": 307.1322943919918,
+    "period": "morning"
+  },
+  {
+    "start": "2022-06-27T20:33:20Z",
+    "asin": "B0151YQYYU",
+    "wpm": 233.29338874582493,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-27T21:41:37Z",
+    "asin": "B0151YQYYU",
+    "wpm": 218.49963583394026,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-27T22:01:18Z",
+    "asin": "B0151YQYYU",
+    "wpm": 451.64780880242756,
+    "period": "evening"
+  },
+  {
+    "start": "2022-06-29T01:26:48Z",
+    "asin": "B00AEBETU2",
+    "wpm": 171.46420035332017,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-03T03:51:10Z",
+    "asin": "B00AEBETU2",
+    "wpm": 676.6917293233082,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-05T04:12:18Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 711.1893795719318,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-06T02:09:08Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 189.65735238336072,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-06T20:58:20Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 177.82344108116652,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-07T04:23:47Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 373.7906772207564,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-07T04:42:52Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 324.2509551578524,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-09T03:54:21Z",
+    "asin": "B0B5GC1ZR5",
+    "wpm": 1240.8088235294117,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-09T04:08:45Z",
+    "asin": "B0B5GC1ZR5",
+    "wpm": 1269.5624401149792,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-09T04:23:38Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 282.6826170674751,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-09T17:55:55Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 152.184292193841,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-10T04:15:31Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 324.3593902043464,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-11T04:09:41Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 305.83873957367933,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-11T21:50:55Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 376.7173880927759,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-11T22:02:30Z",
+    "asin": "B095MPSYWY",
+    "wpm": 187.64073054791095,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-12T03:34:20Z",
+    "asin": "B095MPSYWY",
+    "wpm": 282.87330704611696,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-12T21:05:23Z",
+    "asin": "B095MPSYWY",
+    "wpm": 675.6756756756757,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-12T21:12:10Z",
+    "asin": "B095MPSYWY",
+    "wpm": 387.0967741935484,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-12T21:18:50Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 190.99316445516686,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-12T23:16:42Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 144.6480231436837,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-13T03:17:48Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 393.99624765478427,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-13T03:22:27Z",
+    "asin": "B095MPSYWY",
+    "wpm": 180.01440115209218,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-13T21:14:50Z",
+    "asin": "B095MPSYWY",
+    "wpm": 302.07134637514383,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-14T03:47:41Z",
+    "asin": "B095MPSYWY",
+    "wpm": 308.641975308642,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-14T04:09:03Z",
+    "asin": "B095MPSYWY",
+    "wpm": 431.55663234403397,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-14T19:26:34Z",
+    "asin": "B095MPSYWY",
+    "wpm": 120.02743484224966,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-14T21:57:56Z",
+    "asin": "B095MPSYWY",
+    "wpm": 480.4270462633452,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-14T22:02:44Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 494.6236559139785,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-14T22:14:29Z",
+    "asin": "B095MPSYWY",
+    "wpm": 320.62700391877445,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-15T03:51:43Z",
+    "asin": "B095MPSYWY",
+    "wpm": 381.21546961325964,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-16T03:38:16Z",
+    "asin": "B095MPSYWY",
+    "wpm": 299.5606443882306,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-17T05:15:47Z",
+    "asin": "B095MPSYWY",
+    "wpm": 260.44896440530823,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T00:26:54Z",
+    "asin": "B095MPSYWY",
+    "wpm": 643.7768240343348,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T00:29:29Z",
+    "asin": "B095MPSYWY",
+    "wpm": 493.9084622983207,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T02:55:35Z",
+    "asin": "B095MPSYWY",
+    "wpm": 556.9306930693069,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T03:00:36Z",
+    "asin": "B095MPSYWY",
+    "wpm": 568.7203791469194,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T03:02:30Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 371.8180951472972,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T03:20:06Z",
+    "asin": "B095MPSYWY",
+    "wpm": 298.4846165620695,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-18T18:46:51Z",
+    "asin": "B095MPSYWY",
+    "wpm": 175.4572522330923,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-18T19:20:36Z",
+    "asin": "B095MPSYWY",
+    "wpm": 547.4452554744526,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-18T20:44:27Z",
+    "asin": "B095MPSYWY",
+    "wpm": 45.90899816364008,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-19T03:22:45Z",
+    "asin": "B095MPSYWY",
+    "wpm": 279.5378307864331,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-19T16:58:24Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1546.3917525773197,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-19T19:40:16Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 10520.361990950227,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-19T19:41:55Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1991.1504424778761,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-19T20:51:05Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 10144.927536231884,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T15:53:44Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1525.4237288135594,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T16:45:36Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 1485.148514851485,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T22:27:56Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 2367.879203843514,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T22:40:30Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 2127.6595744680853,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T22:42:03Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 831.0249307479224,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T22:53:15Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 3839.590443686007,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-20T23:34:49Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 16564.41717791411,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-21T02:50:11Z",
+    "asin": "B095MPSYWY",
+    "wpm": 438.21209465381247,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-21T16:15:27Z",
+    "asin": "B095MPSYWY",
+    "wpm": 1578.9473684210527,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-21T16:16:07Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 167.57101819342483,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-21T16:30:13Z",
+    "asin": "B08N8Z99MK",
+    "wpm": 12923.923006416131,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-22T04:17:50Z",
+    "asin": "B095MPSYWY",
+    "wpm": 266.7259390975772,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-23T03:14:20Z",
+    "asin": "B095MPSYWY",
+    "wpm": 507.61421319796955,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-23T03:16:53Z",
+    "asin": "B095MPSYWY",
+    "wpm": 167.60946993505135,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-23T18:19:47Z",
+    "asin": "B095MPSYWY",
+    "wpm": 136.10071452875127,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-24T18:41:15Z",
+    "asin": "B095MPSYWY",
+    "wpm": 141.53371075656202,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-25T03:34:45Z",
+    "asin": "B095MPSYWY",
+    "wpm": 366.7481662591687,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-25T03:42:12Z",
+    "asin": "B097T5JR84",
+    "wpm": 429.7994269340974,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-25T16:19:02Z",
+    "asin": "B097T5JR84",
+    "wpm": 376.88442211055275,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-25T16:24:33Z",
+    "asin": "B095MPSYWY",
+    "wpm": 110.33468186833394,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-26T03:12:47Z",
+    "asin": "B095MPSYWY",
+    "wpm": 291.0109937486527,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-27T03:05:53Z",
+    "asin": "B095MPSYWY",
+    "wpm": 532.9324952172725,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-27T03:13:11Z",
+    "asin": "B095MPSYWY",
+    "wpm": 400.35587188612095,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-29T03:17:10Z",
+    "asin": "B095MPSYWY",
+    "wpm": 1359.9731363331096,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-29T03:25:32Z",
+    "asin": "B09HCD24DJ",
+    "wpm": 266.7922159447583,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-29T17:24:13Z",
+    "asin": "B09HCD24DJ",
+    "wpm": 243.23798404358826,
+    "period": "evening"
+  },
+  {
+    "start": "2022-07-31T03:16:56Z",
+    "asin": "B09HCD24DJ",
+    "wpm": 1048.951048951049,
+    "period": "morning"
+  },
+  {
+    "start": "2022-07-31T03:17:29Z",
+    "asin": "B08HL86V91",
+    "wpm": 256.4102564102564,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-02T02:49:00Z",
+    "asin": "B08HL86V91",
+    "wpm": 291.8287937743191,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-02T02:50:10Z",
+    "asin": "B084M663VB",
+    "wpm": 367.3835125448029,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-02T20:09:32Z",
+    "asin": "B084M663VB",
+    "wpm": 311.08038712225954,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-03T03:42:10Z",
+    "asin": "B084M663VB",
+    "wpm": 500.43247250710493,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-04T03:45:24Z",
+    "asin": "B084M663VB",
+    "wpm": 395.7187005351624,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-04T14:36:36Z",
+    "asin": "B084M663VB",
+    "wpm": 1145.0381679389313,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-05T04:06:53Z",
+    "asin": "B084M663VB",
+    "wpm": 338.1424706943192,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-06T04:17:12Z",
+    "asin": "B084M663VB",
+    "wpm": 267.0856245090338,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-06T19:39:55Z",
+    "asin": "B084M663VB",
+    "wpm": 500.20842017507294,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-07T03:26:47Z",
+    "asin": "B084M663VB",
+    "wpm": 19.692792437967704,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-07T03:43:18Z",
+    "asin": "B084M663VB",
+    "wpm": 381.8181818181818,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-07T22:45:21Z",
+    "asin": "B084M663VB",
+    "wpm": 253.3783783783784,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-07T23:38:56Z",
+    "asin": "B084M663VB",
+    "wpm": 86.71773377655731,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-08T00:05:55Z",
+    "asin": "B084M663VB",
+    "wpm": 574.9574105621806,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-08T00:15:46Z",
+    "asin": "B084M663VB",
+    "wpm": 520.2191856835681,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-08T01:59:06Z",
+    "asin": "B084M663VB",
+    "wpm": 440.64799498032056,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-08T19:35:53Z",
+    "asin": "B084M663VB",
+    "wpm": 188.75229890620463,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-09T03:37:10Z",
+    "asin": "B084M663VB",
+    "wpm": 436.70048522276136,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-09T20:58:33Z",
+    "asin": "B084M663VB",
+    "wpm": 243.50649350649348,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-10T02:02:16Z",
+    "asin": "B084M663VB",
+    "wpm": 362.0226556113512,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-10T19:09:59Z",
+    "asin": "B084M663VB",
+    "wpm": 212.89807504657145,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-10T19:32:14Z",
+    "asin": "B084M663VB",
+    "wpm": 550.05500550055,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-11T02:43:40Z",
+    "asin": "B084M663VB",
+    "wpm": 366.60082359637084,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-11T20:23:51Z",
+    "asin": "B084M663VB",
+    "wpm": 195.83949865088346,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-12T03:07:48Z",
+    "asin": "B084M663VB",
+    "wpm": 626.6180277712402,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-12T03:36:34Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 459.0425085939465,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-12T19:43:11Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 112.24744325268146,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-12T20:21:14Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 378.5046728971963,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-13T03:11:47Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 493.42105263157896,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-13T15:16:47Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 178.65322950068713,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-14T17:17:19Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 125.69832402234638,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-15T02:51:57Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 221.09400589584018,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-15T03:12:27Z",
+    "asin": "B01MSICPW3",
+    "wpm": 314.520356456404,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-15T03:22:13Z",
+    "asin": "B00OICLVBI",
+    "wpm": 2788.4089666484415,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-15T03:44:10Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 239.31926963304377,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-16T04:10:48Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 530.6408224932749,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-16T20:59:30Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 216.85517475975848,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-17T02:21:09Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 175.91059602649005,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-17T03:06:24Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 349.4014881915238,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-18T02:33:28Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 457.3170731707317,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-18T02:51:42Z",
+    "asin": "B098TZ17NC",
+    "wpm": 376.93703755409746,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-22T03:02:24Z",
+    "asin": "B098TZ17NC",
+    "wpm": 688.0733944954128,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-22T03:03:24Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 430.91065785693763,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-23T03:51:08Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 691.2442396313363,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-23T04:31:04Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 385.2612861799862,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-23T04:48:31Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 161.29032258064515,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-23T11:33:26Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 1522.8426395939086,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-23T21:20:19Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 131.75873511614287,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-24T00:52:41Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 275.21357720314205,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-25T02:29:07Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 152.12981744421907,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-26T02:49:39Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 411.0489970404472,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-26T19:02:43Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 223.65805168986086,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-26T21:50:15Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 277.33118971061094,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-26T22:25:54Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 24.81389578163772,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-26T22:51:20Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 47.86979415988511,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-27T03:09:01Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 21.894613924974458,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-27T03:26:50Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 282.54693675889325,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-27T19:25:08Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 503.2853348245491,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-27T21:02:21Z",
+    "asin": "B08YRM9NBM",
+    "wpm": 606.8245778611632,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-29T03:04:11Z",
+    "asin": "B098TZ17NC",
+    "wpm": 902.2556390977443,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-29T03:07:27Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 408.0351537978657,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-30T03:30:57Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 318.74203144921375,
+    "period": "morning"
+  },
+  {
+    "start": "2022-08-30T21:06:28Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 126.9726101940867,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-30T23:34:02Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 371.19041417035686,
+    "period": "evening"
+  },
+  {
+    "start": "2022-08-31T03:03:42Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 421.47426316733424,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-01T03:37:50Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 410.67041067041066,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-01T22:18:40Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 225.50739163117015,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-02T03:26:55Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 39.784280788612854,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-02T03:46:09Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 1456.3106796116506,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-02T03:46:30Z",
+    "asin": "B08THH7R49",
+    "wpm": 401.7701176196576,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-02T18:08:51Z",
+    "asin": "B08THH7R49",
+    "wpm": 195.17565809228304,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-04T04:07:36Z",
+    "asin": "B08THH7R49",
+    "wpm": 293.0880078156802,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-04T20:45:16Z",
+    "asin": "B08THH7R49",
+    "wpm": 231.1629698937751,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-05T03:45:22Z",
+    "asin": "B08THH7R49",
+    "wpm": 346.8547912992357,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-05T19:00:23Z",
+    "asin": "B08THH7R49",
+    "wpm": 265.2583281556182,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-06T02:19:03Z",
+    "asin": "B08THH7R49",
+    "wpm": 373.1343283582089,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-06T02:23:51Z",
+    "asin": "B08PF965W9",
+    "wpm": 663.2472585779979,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-06T02:42:56Z",
+    "asin": "B08THH7R49",
+    "wpm": 24.991669443518827,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-06T02:53:00Z",
+    "asin": "B08THH7R49",
+    "wpm": 358.8516746411483,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-06T21:06:39Z",
+    "asin": "B08THH7R49",
+    "wpm": 368.8524590163935,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-06T21:09:08Z",
+    "asin": "B08THH7R49",
+    "wpm": 709.2198581560284,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-07T04:14:00Z",
+    "asin": "B08THH7R49",
+    "wpm": 112.75369581558508,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-07T04:57:43Z",
+    "asin": "B08THH7R49",
+    "wpm": 359.8298985933922,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-07T18:49:27Z",
+    "asin": "B08THH7R49",
+    "wpm": 223.61359570661898,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-08T03:16:36Z",
+    "asin": "B08THH7R49",
+    "wpm": 388.2430357534547,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-08T05:06:49Z",
+    "asin": "B08THH7R49",
+    "wpm": 326.2719878948364,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-08T20:23:56Z",
+    "asin": "B08THH7R49",
+    "wpm": 217.49637506041566,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-10T01:18:40Z",
+    "asin": "B08THH7R49",
+    "wpm": 216.65864227250844,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-11T02:44:09Z",
+    "asin": "B08THH7R49",
+    "wpm": 157.91740441211658,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-12T02:45:44Z",
+    "asin": "B08THH7R49",
+    "wpm": 284.05926255987526,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-13T03:29:16Z",
+    "asin": "B08THH7R49",
+    "wpm": 390.8660769389015,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-13T04:18:02Z",
+    "asin": "B09841WSGD",
+    "wpm": 834.8794063079778,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-15T04:07:24Z",
+    "asin": "B09841WSGD",
+    "wpm": 516.2352237019303,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-16T02:35:21Z",
+    "asin": "B08PF965W9",
+    "wpm": 1643.945469125902,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-16T02:47:44Z",
+    "asin": "B09G9C2WRT",
+    "wpm": 599.4005994005994,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-16T18:47:03Z",
+    "asin": "B09G9C2WRT",
+    "wpm": 402.1447721179624,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-16T18:47:44Z",
+    "asin": "B09JPFYQY2",
+    "wpm": 301.0033444816053,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-16T18:50:19Z",
+    "asin": "B09HCD24DJ",
+    "wpm": 70.52186177715092,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-18T02:48:24Z",
+    "asin": "B0BCPF7HGJ",
+    "wpm": 6190.47619047619,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-20T02:46:14Z",
+    "asin": "B0BCPF7HGJ",
+    "wpm": 5714.285714285714,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-20T03:19:38Z",
+    "asin": "B08PC3SZHX",
+    "wpm": 1518.987341772152,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-20T03:20:25Z",
+    "asin": "B08PC3SZHX",
+    "wpm": 476.63881369895256,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-20T17:01:21Z",
+    "asin": "B08PC3SZHX",
+    "wpm": 1351.3513513513515,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-20T22:27:46Z",
+    "asin": "B08PC3SZHX",
+    "wpm": 1630.4347826086957,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-20T22:29:46Z",
+    "asin": "B09NTJPTKN",
+    "wpm": 90.53415149381351,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-21T01:29:41Z",
+    "asin": "B09NTJPTKN",
+    "wpm": 251.2142019762184,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-22T02:42:02Z",
+    "asin": "B09NTJPTKN",
+    "wpm": 394.1267387944358,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-23T02:42:57Z",
+    "asin": "B09NTJPTKN",
+    "wpm": 649.9535747446611,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-23T19:14:03Z",
+    "asin": "B09NLPTNQ2",
+    "wpm": 25000,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-25T03:32:57Z",
+    "asin": "B09QKTFZGR",
+    "wpm": 330.2377711952606,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-26T01:57:22Z",
+    "asin": "B098TZ17NC",
+    "wpm": 822.481151473612,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-26T02:04:35Z",
+    "asin": "B08PF965W9",
+    "wpm": 825.7858284496538,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-26T02:25:09Z",
+    "asin": "B097769VDM",
+    "wpm": 527.7362764470578,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-26T20:19:06Z",
+    "asin": "B097769VDM",
+    "wpm": 475.9514007430465,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-27T04:18:59Z",
+    "asin": "B097769VDM",
+    "wpm": 511.1524163568773,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-27T22:30:18Z",
+    "asin": "B097769VDM",
+    "wpm": 1515.151515151515,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-28T00:47:00Z",
+    "asin": "B097769VDM",
+    "wpm": 470.11729659281326,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-28T01:48:43Z",
+    "asin": "B097769VDM",
+    "wpm": 419.9418542048024,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-28T02:35:30Z",
+    "asin": "B097769VDM",
+    "wpm": 422.41401788740836,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-28T09:44:19Z",
+    "asin": "B097769VDM",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-28T10:25:01Z",
+    "asin": "B097769VDM",
+    "wpm": 302.2269353128314,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-28T19:40:42Z",
+    "asin": "B097769VDM",
+    "wpm": 694.8733786287833,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-28T19:46:22Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 149.2624678061344,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-28T20:30:51Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 214.7539748323412,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-29T03:56:40Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 718.2459677419355,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-29T20:18:17Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 525.5781359495445,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-29T20:30:33Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 308.5805295640056,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-30T02:46:30Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 436.94690265486724,
+    "period": "morning"
+  },
+  {
+    "start": "2022-09-30T19:30:30Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 244.140625,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-30T21:29:11Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 341.4483583471585,
+    "period": "evening"
+  },
+  {
+    "start": "2022-09-30T22:33:34Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 157.45965096444036,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-01T00:58:41Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 410.958904109589,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-01T01:08:31Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 516.6475315729047,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-01T01:10:17Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 278.0352177942539,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-01T01:27:35Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 430.1075268817204,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-01T02:18:15Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 297.2495463661541,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-01T22:19:41Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 227.39801543550163,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-02T03:18:48Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 355.672032946462,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-03T02:50:37Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 260.26604973973394,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-04T03:32:09Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 316.50143075989246,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T02:16:31Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 1515.151515151515,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T02:17:23Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 2008.9285714285713,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T02:18:20Z",
+    "asin": "B09NLPTNQ2",
+    "wpm": 746.2686567164179,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T02:19:18Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 379.746835443038,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T02:20:16Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 341.2825482430269,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T10:10:42Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 784.167289021658,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-05T17:12:58Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 368.55036855036855,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-05T19:29:03Z",
+    "asin": "B000FC0QBQ",
+    "wpm": 520.8333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-05T19:31:19Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 1437.6996805111824,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-05T19:31:53Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 1835.6643356643358,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-06T03:54:28Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 494.61420092327984,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-06T04:02:28Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 1087.5706214689267,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-07T03:29:18Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 734.8752421100604,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-08T02:13:41Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 1038.9730328777243,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-09T03:34:14Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 1123.7312711454808,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-10T02:33:18Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 319.5889209174082,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-11T02:56:33Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 488.84432188518423,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-13T03:37:07Z",
+    "asin": "2WHQ4RDHHZSUUDZRQBG52I7KS37FTVCT",
+    "wpm": 572.7829350187635,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-13T04:06:45Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 284.3144267219798,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-14T04:00:10Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 287.0044390019899,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-15T03:43:29Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 321.6123499142367,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-16T04:03:09Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 433.52601156069363,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-16T04:05:05Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 367.1221700999388,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-17T00:37:53Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 189.19624217118997,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-17T22:55:29Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 308.9598352214212,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-17T23:06:48Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 3260.8695652173915,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-18T01:56:49Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 68.24385805277525,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-18T02:15:24Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 1013.5135135135135,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-18T02:16:19Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 212.38387954553303,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-18T21:03:45Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 238.08070325376963,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-19T20:49:40Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 212.26415094339623,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-20T03:21:23Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 407.70503427085794,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-20T14:32:15Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 176.22180451127818,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-20T17:35:22Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 214.01703489126206,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-20T19:25:27Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 310.3612923762534,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-21T01:50:40Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 242.00539395106915,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-22T22:39:37Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 401.7408771342484,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-22T23:48:05Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 172.05534446913757,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-23T00:16:08Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 128.61184943839493,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-23T03:00:35Z",
+    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
+    "wpm": 545.8799064205875,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-23T03:23:30Z",
+    "asin": "B0B193DJYK",
+    "wpm": 460.24034773715164,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-23T03:44:17Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 231.85205630692795,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-25T04:46:37Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 300.6012024048096,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-27T03:30:15Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 386.3987635239567,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-27T03:46:45Z",
+    "asin": "B003BRBCFG",
+    "wpm": 247.7291494632535,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-27T03:54:54Z",
+    "asin": "B003BRBCFG",
+    "wpm": 241.31274131274134,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-28T04:16:37Z",
+    "asin": "B003BRBCFG",
+    "wpm": 348.81640927792023,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-28T04:45:39Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 648.8490653483701,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-29T05:15:55Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 204.42394380962364,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-31T02:36:58Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 731.7073170731708,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-31T02:41:50Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 226.43062988884316,
+    "period": "morning"
+  },
+  {
+    "start": "2022-10-31T23:01:02Z",
+    "asin": "B0BKPPPQNV",
+    "wpm": 2015.1133501259444,
+    "period": "evening"
+  },
+  {
+    "start": "2022-10-31T23:06:14Z",
+    "asin": "B0BKPPPQNV",
+    "wpm": 1500,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-01T00:18:40Z",
+    "asin": "B0BKPPPQNV",
+    "wpm": 4613.445378151261,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-01T01:29:06Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 850.5670446964642,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-01T01:34:14Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 349.359507569456,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-01T01:44:24Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 125.979843225084,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-01T02:53:41Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 331.7724419647305,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-02T02:43:48Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 697.6744186046511,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-02T03:07:22Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 1666.6666666666667,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-02T03:30:34Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 160.57808109193095,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-02T03:55:41Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 319.7320341047503,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-03T03:10:45Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 334.6177245994727,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-03T03:27:19Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 356.41547861507127,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-03T03:36:35Z",
+    "asin": "B09QPJKSXM",
+    "wpm": 269.62252846015576,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T01:46:51Z",
+    "asin": "B09QPJKSXM",
+    "wpm": 403.22580645161287,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T01:48:57Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 386.129618413083,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T02:11:04Z",
+    "asin": "B09QPJKSXM",
+    "wpm": 378.1909864481563,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T02:16:32Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 423.728813559322,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T04:09:17Z",
+    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
+    "wpm": 597.5351674343334,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T04:25:04Z",
+    "asin": "QSKJSE7YJTJXN5WGZEBZAJ3ZZEBKDEAX",
+    "wpm": 526.3157894736843,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-04T04:31:47Z",
+    "asin": "B09QPJKSXM",
+    "wpm": 3825.1366120218577,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-05T02:42:41Z",
+    "asin": "B09QPJKSXM",
+    "wpm": 1127.8195488721803,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-11T05:38:56Z",
+    "asin": "B09285Y1V4",
+    "wpm": 505.050505050505,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-11T05:45:07Z",
+    "asin": "B09285Y1V4",
+    "wpm": 973.5396904643035,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-13T06:18:23Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 1293.103448275862,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-13T06:19:20Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 299.61340206185565,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-13T06:45:43Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 309.02348578491967,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-13T20:38:14Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 2255.6390977443607,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-13T21:55:51Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 243.92046714465224,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-14T03:52:44Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 351.410627056126,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-14T23:26:19Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 2727.2727272727275,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-14T23:29:30Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 412.26674381599884,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-15T04:11:36Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 377.32376219399964,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-15T22:07:20Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 789.4736842105264,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-15T22:07:46Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 2500,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-15T22:08:22Z",
+    "asin": "N4LRBDHXLHWB6GQCAL74CNNNWOIWTPMJ",
+    "wpm": 1229.5081967213114,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-16T04:34:42Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 370.31736376972344,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-16T21:59:44Z",
+    "asin": "B0BH8GTQYX",
+    "wpm": 245.3385672227674,
+    "period": "evening"
+  },
+  {
+    "start": "2022-11-17T04:10:21Z",
+    "asin": "N4LRBDHXLHWB6GQCAL74CNNNWOIWTPMJ",
+    "wpm": 467.37060758178984,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-17T04:37:00Z",
+    "asin": "N4LRBDHXLHWB6GQCAL74CNNNWOIWTPMJ",
+    "wpm": 490.00768639508067,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-17T04:54:49Z",
+    "asin": "B07WK8JZ9N",
+    "wpm": 732.7743346700693,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-18T03:38:57Z",
+    "asin": "B07WK8JZ9N",
+    "wpm": 1061.2119347892956,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-18T03:46:03Z",
+    "asin": "N4LRBDHXLHWB6GQCAL74CNNNWOIWTPMJ",
+    "wpm": 509.12176495545185,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-18T04:05:56Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 308.50091407678246,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-22T04:02:07Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 157.89473684210526,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-27T04:44:27Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 264.4984326018809,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-28T03:15:47Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 331.0910237544671,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-28T05:05:25Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 225.84239212261735,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-29T03:31:06Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 265.3972533490606,
+    "period": "morning"
+  },
+  {
+    "start": "2022-11-30T05:41:15Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 317.5145100716968,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-01T04:34:02Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 342.01026030780923,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-01T06:03:31Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 119.74454497072912,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-02T14:31:27Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 802.1390374331552,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-02T20:55:16Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 3409.090909090909,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-02T20:56:25Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 1587.3015873015872,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-02T21:10:44Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 1408.4507042253522,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-02T21:11:55Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 171.6961498439126,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-02T21:30:24Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 365.8536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-02T21:35:18Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 336.03707995365005,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-03T04:36:30Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 351.34291068082445,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-03T10:33:43Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 259.69029527748387,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-04T04:49:07Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 182.4279501732144,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-05T00:44:34Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 1764.7058823529412,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-05T04:14:03Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 271.6551084411855,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-05T19:21:16Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 110.07827788649706,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-06T05:50:58Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 468.75,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-06T05:51:47Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 422.1596800474004,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-07T04:06:53Z",
+    "asin": "B08KH4LZDM",
+    "wpm": 414.73125414731254,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-07T04:22:11Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 553.5055350553506,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-07T04:29:36Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 382.46721709567754,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-08T04:33:19Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 387.2263122669471,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-09T03:33:01Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 197.09288001970927,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-13T03:50:44Z",
+    "asin": "B0B33PJZJT",
+    "wpm": 2842.9602888086642,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-13T04:25:08Z",
+    "asin": "B09NH4DJBP",
+    "wpm": 1471.9626168224297,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-13T04:30:26Z",
+    "asin": "B0B33PJZJT",
+    "wpm": 676.4943457189014,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-14T04:13:16Z",
+    "asin": "B0B33PJZJT",
+    "wpm": 2236.1240516438174,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-14T17:44:27Z",
+    "asin": "B0B33PJZJT",
+    "wpm": 3703.7037037037035,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-15T03:28:13Z",
+    "asin": "B0B33PJZJT",
+    "wpm": 3947.3684210526317,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-15T03:29:00Z",
+    "asin": "B0B33PJZJT",
+    "wpm": 2701.644479248238,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-15T04:11:35Z",
+    "asin": "B09RX45W14",
+    "wpm": 377.4178329926089,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-15T23:18:38Z",
+    "asin": "B09RX45W14",
+    "wpm": 764.0067911714771,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-16T04:01:07Z",
+    "asin": "B09RX45W14",
+    "wpm": 105.67632850241547,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-16T04:21:26Z",
+    "asin": "B09RX2WQ3M",
+    "wpm": 3000,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-16T04:24:31Z",
+    "asin": "B09RX45W14",
+    "wpm": 1239.6694214876034,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-16T04:25:24Z",
+    "asin": "B09RX2WQ3M",
+    "wpm": 332.9105897273304,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-16T05:09:28Z",
+    "asin": "B09RX2WQ3M",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-16T05:17:24Z",
+    "asin": "B097XBXQ1T",
+    "wpm": 523.3111322549953,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-18T22:26:47Z",
+    "asin": "B09RX45W14",
+    "wpm": 769.2307692307692,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-18T22:33:20Z",
+    "asin": "B097XBXQ1T",
+    "wpm": 1127.8195488721803,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-18T22:33:49Z",
+    "asin": "B09RX45W14",
+    "wpm": 906.344410876133,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-20T03:41:48Z",
+    "asin": "B09RX45W14",
+    "wpm": 1515.151515151515,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-20T03:42:33Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 1662.0498614958449,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-20T03:43:21Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 1315.7894736842104,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-20T03:44:53Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 549.6262049970491,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-20T05:29:22Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 426.6750948166877,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-20T18:59:58Z",
+    "asin": "B0BKPPPQNV",
+    "wpm": 3448.2758620689656,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-20T23:18:48Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 318.30238726790446,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-22T00:54:28Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 280.45941923913455,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-22T06:00:45Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 394.3272224143895,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-22T21:10:38Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 307.7024880889359,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-23T04:23:44Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 281.8943298969072,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-23T04:58:09Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 302.59709316178225,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-23T18:25:53Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 495.36770246908105,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-24T02:16:40Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 360.16853169030037,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-24T04:36:49Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 66.69630947087595,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-24T17:09:43Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 534.0939545924423,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-24T19:22:51Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 556.7729529090828,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-24T21:34:55Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 100.20040080160321,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-25T04:20:30Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 223.16684378320937,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-25T19:31:21Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-25T23:34:11Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 437.4088731514268,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-26T02:40:30Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 549.326340537119,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-26T03:59:58Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 610.0867678958786,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-26T09:52:45Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 680.3811967378357,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-26T13:35:34Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 909.090909090909,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-26T23:25:09Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 990.8838684106223,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-27T00:34:13Z",
+    "asin": "B08BYBNGMW",
+    "wpm": 1132.9463598853067,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-27T04:21:07Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 394.23018152924635,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-27T09:21:21Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 425.7001954033684,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-27T17:56:15Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 225.57485204230133,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-27T18:53:57Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 195.92476489028215,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-27T19:06:49Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 504.86163051608077,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-27T19:56:31Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 259.85663082437276,
+    "period": "evening"
+  },
+  {
+    "start": "2022-12-28T05:13:49Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 363.6363636363636,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-29T05:26:24Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 261.2265207115313,
+    "period": "morning"
+  },
+  {
+    "start": "2022-12-31T02:29:50Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 273.3568217713522,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-01T04:30:42Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 769.6574677575926,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-01T04:42:59Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 86.50519031141869,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-02T03:39:18Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 530.035335689046,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-02T04:23:15Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 463.0005685971895,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-02T05:45:04Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 436.8546465448769,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-02T05:51:51Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 285.2098329485264,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-02T23:21:10Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 161.79887155658813,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-03T04:28:53Z",
+    "asin": "B01HNJIJ3U",
+    "wpm": 476.43109795712115,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-03T04:52:20Z",
+    "asin": "B09T9D8QY7",
+    "wpm": 717.6234979973298,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-03T05:08:22Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 576.9230769230769,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-03T05:09:44Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 1265.8227848101264,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-03T06:42:34Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 367.4713193116635,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-04T04:20:43Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 414.51399735672237,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-07T06:14:31Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 254.85436893203885,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-08T04:41:38Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 256.45010879701584,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-09T04:37:04Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 365.8239167547354,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-10T08:39:31Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 322.061191626409,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-11T04:14:07Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 131.11888111888112,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-11T04:30:24Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 294.7863280798428,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-11T21:31:52Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 129.15724895059736,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-12T04:26:46Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 354.44562850391515,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-12T05:31:47Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 937.5,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-12T05:35:47Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 2830.188679245283,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-12T05:37:12Z",
+    "asin": "B0BQVLNL73",
+    "wpm": 4486.42266824085,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-12T05:50:04Z",
+    "asin": "B0BQVLNL73",
+    "wpm": 12500,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-13T04:35:19Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 426.1741987037201,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-15T04:55:26Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 347.8596965890424,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-16T04:04:49Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 356.6867761680391,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-17T04:27:56Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 359.18792295679333,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-17T04:44:15Z",
+    "asin": "B003L77UKC",
+    "wpm": 286.15032430370087,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-18T03:47:54Z",
+    "asin": "B003L77UKC",
+    "wpm": 672.645739910314,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-18T04:04:32Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 283.3298990315269,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-18T20:40:03Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 1282.051282051282,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-19T05:31:59Z",
+    "asin": "B003L77UKC",
+    "wpm": 509.62627406568515,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-19T05:35:02Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 328.1557646029315,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-24T22:50:38Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 800,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-25T00:55:25Z",
+    "asin": "B09R21YVLM",
+    "wpm": 229.00763358778627,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-25T05:16:36Z",
+    "asin": "B09R21YVLM",
+    "wpm": 310.97290093291866,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-25T21:53:59Z",
+    "asin": "B09R21YVLM",
+    "wpm": 147.2121695393486,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-26T04:42:52Z",
+    "asin": "B09R21YVLM",
+    "wpm": 317.8350889938249,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-26T20:58:41Z",
+    "asin": "B09R21YVLM",
+    "wpm": 177.65495459928937,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-27T00:13:18Z",
+    "asin": "B09R21YVLM",
+    "wpm": 657.8947368421052,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-27T00:16:07Z",
+    "asin": "B003L77UKC",
+    "wpm": 1221.166892808684,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-27T00:21:11Z",
+    "asin": "B09R21YVLM",
+    "wpm": 480.3268430932313,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-27T04:30:56Z",
+    "asin": "B09R21YVLM",
+    "wpm": 432.1996138422694,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-27T20:29:05Z",
+    "asin": "B09R21YVLM",
+    "wpm": 372.99158377964807,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-27T22:16:49Z",
+    "asin": "B09R21YVLM",
+    "wpm": 828.3132530120482,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-28T04:26:47Z",
+    "asin": "B09R21YVLM",
+    "wpm": 606.0810128287147,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-28T05:16:24Z",
+    "asin": "B09R21YVLM",
+    "wpm": 2586.206896551724,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-28T05:28:13Z",
+    "asin": "B003L77UKC",
+    "wpm": 971.9222462203024,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-30T21:30:37Z",
+    "asin": "B003L77UKC",
+    "wpm": 1530.6122448979593,
+    "period": "evening"
+  },
+  {
+    "start": "2023-01-31T04:34:25Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 429.07871375024655,
+    "period": "morning"
+  },
+  {
+    "start": "2023-01-31T22:20:23Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 183.286057167794,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-01T04:49:24Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 253.94424032850657,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-01T19:31:25Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1107.8286558345642,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-01T19:36:35Z",
+    "asin": "B003L77UKC",
+    "wpm": 1036.2694300518135,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-01T19:37:36Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 24.98750624687656,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-01T19:48:12Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 388.39979285344384,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-01T19:51:51Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 175.76163374623368,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-02T03:22:02Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 390.1395832731266,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-02T21:55:00Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 215.67217828900073,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-03T03:57:00Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 459.30909561392156,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-05T04:24:47Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 525.2918287937744,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-05T04:29:15Z",
+    "asin": "B003L77UKC",
+    "wpm": 1176.4705882352941,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-05T04:31:26Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 452.0795660036166,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-05T17:09:41Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1047.1204188481677,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-05T17:10:48Z",
+    "asin": "B003L77UKC",
+    "wpm": 2272.7272727272725,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-05T17:13:23Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 127.80790085205268,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-05T20:51:10Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 546.7800729040098,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-05T20:54:56Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1797.3856209150326,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-05T20:59:44Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 636.9426751592356,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-06T23:56:50Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1500,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-06T23:58:44Z",
+    "asin": "B09RX2WQ3M",
+    "wpm": 65.03360069369174,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-08T22:13:16Z",
+    "asin": "B003L77UKC",
+    "wpm": 629.8449612403101,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-09T04:16:53Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1125.5323463800446,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-09T04:25:13Z",
+    "asin": "B00PSSG4MM",
+    "wpm": 577.8120184899846,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-09T04:47:07Z",
+    "asin": "B00PSSG4MM",
+    "wpm": 148.397309062129,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-10T04:47:38Z",
+    "asin": "B00PSSG4MM",
+    "wpm": 374.1250301713734,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-12T06:27:12Z",
+    "asin": "B00PSSG4MM",
+    "wpm": 254.52488687782807,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-13T04:37:52Z",
+    "asin": "B00PSSG4MM",
+    "wpm": 443.97463002114165,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-13T04:42:21Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 853.1409168081494,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-13T19:13:07Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1282.051282051282,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-13T19:13:44Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 336.4389233954451,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-13T19:23:36Z",
+    "asin": "B003L77UKC",
+    "wpm": 846.6603951081843,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-13T19:29:01Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 392.82440748985204,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-13T20:38:30Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 1875,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-14T04:15:33Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 334.556944379908,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-14T21:35:54Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 64.81161424127204,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-14T22:11:07Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 340.3821488473049,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-14T23:54:21Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 446.5592972181552,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-15T05:00:28Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 292.8105661004278,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-15T05:42:37Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 400.2511379689216,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-15T05:53:28Z",
+    "asin": "B09QMHZ53K",
+    "wpm": 3016.8946098149636,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-15T06:07:01Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 1607.5845012366035,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-15T06:11:32Z",
+    "asin": "B00PSSG4MM",
+    "wpm": 1875,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-15T22:06:48Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 166.56795972756885,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-16T04:50:58Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 388.085766954497,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-16T05:43:22Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 269.8608086355459,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-17T04:03:34Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 251.91560827122913,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-18T04:02:52Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 360.3348994948246,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T02:26:43Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 925.9259259259259,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T02:27:03Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 255.53662691652468,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T02:29:04Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 656.4551422319474,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T02:45:20Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 142.04545454545453,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T03:04:42Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 1704.5454545454545,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T03:08:06Z",
+    "asin": "B01COJUEZ0",
+    "wpm": 330.188679245283,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T03:14:08Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 24.50980392156863,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T04:18:23Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 230.88763468445356,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-20T19:12:18Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 911.854103343465,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T19:14:09Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 399.57378795950984,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T19:19:41Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 578.108941418294,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T19:29:32Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 575.6578947368421,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T21:39:22Z",
+    "asin": "B07VDJBKNJ",
+    "wpm": 1612.9032258064517,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T21:40:26Z",
+    "asin": "B003L77UKC",
+    "wpm": 435.3715170278638,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T21:50:56Z",
+    "asin": "B09NTK9WDQ",
+    "wpm": 600.4945249028613,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-20T22:36:59Z",
+    "asin": "B0B2F5J32D",
+    "wpm": 284.04843773359244,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-21T04:47:59Z",
+    "asin": "B0B2F5J32D",
+    "wpm": 556.2422744128554,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-21T05:09:08Z",
+    "asin": "B003L77UKC",
+    "wpm": 2307.6923076923076,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-21T05:09:36Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 402.226672550151,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-21T15:38:55Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 202.252538071066,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-21T16:56:46Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 273.01747311827955,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-21T22:02:58Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 277.4352651048089,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-22T00:33:26Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 231.97770564096282,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-22T03:05:15Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 39.17812989726624,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-22T03:41:58Z",
+    "asin": "B08NT2VSWF",
+    "wpm": 393.0211363875355,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-23T19:38:14Z",
+    "asin": "B003L77UKC",
+    "wpm": 1119.402985074627,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-23T19:38:52Z",
+    "asin": "B08KQ4W18H",
+    "wpm": 263.21747990490206,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-24T03:56:59Z",
+    "asin": "B08KQ4W18H",
+    "wpm": 742.5742574257425,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-24T03:57:36Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 313.4141245298788,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-25T04:27:14Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 329.8006373675239,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-27T03:34:43Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 269.2872630621809,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-27T21:57:12Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 176.1006289308176,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-27T23:51:19Z",
+    "asin": "B0BWMMN631",
+    "wpm": 3171.1555169417898,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T04:27:09Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 307.5114804286027,
+    "period": "morning"
+  },
+  {
+    "start": "2023-02-28T19:24:49Z",
+    "asin": "B003L77UKC",
+    "wpm": 1048.951048951049,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T19:33:16Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 53.495007132667624,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T19:37:59Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 56.158742044178204,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T19:57:17Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 129.52507472600465,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T20:22:25Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 87.4024006526046,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T20:51:32Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 88.28722778104769,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:03:31Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 8333.333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:05:09Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 595.2380952380953,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:06:06Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 198.93899204244033,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:10:12Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 185.72018159306646,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:16:43Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 481.7987152034261,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:18:42Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 329.6703296703297,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:23:23Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 330.2925448254168,
+    "period": "evening"
+  },
+  {
+    "start": "2023-02-28T21:31:04Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 193.6554776835116,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-01T03:42:11Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 296.2811606048222,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-01T18:51:11Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 174.44758265492607,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-01T19:53:00Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 260.3601648947711,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-01T22:27:02Z",
+    "asin": "B08QXTPXPH",
+    "wpm": 320.35825008611783,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-02T04:42:47Z",
+    "asin": "B01HLY0Z0W",
+    "wpm": 223.8538681948424,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-02T22:47:37Z",
+    "asin": "B01HLY0Z0W",
+    "wpm": 24.683231857824584,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-02T23:14:08Z",
+    "asin": "B01HLY0Z0W",
+    "wpm": 44.75607936744741,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-03T03:51:21Z",
+    "asin": "B01HLY0Z0W",
+    "wpm": 275.78865879620673,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-03T04:17:47Z",
+    "asin": "B09NW4FN2R",
+    "wpm": 1315.7894736842104,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-03T04:18:40Z",
+    "asin": "B09NW4FN2R",
+    "wpm": 178.91932726332948,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-03T20:24:15Z",
+    "asin": "B09NW4FN2R",
+    "wpm": 139.86945517516983,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-04T03:24:03Z",
+    "asin": "B09NW4FN2R",
+    "wpm": 227.7029179707266,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-05T04:29:13Z",
+    "asin": "B09NW4FN2R",
+    "wpm": 230.16517736257785,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-07T03:33:07Z",
+    "asin": "B09NW4FN2R",
+    "wpm": 669.6428571428571,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-07T03:36:13Z",
+    "asin": "B003L77UKC",
+    "wpm": 568.1818181818181,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-07T03:36:55Z",
+    "asin": "B003L77UKC",
+    "wpm": 2371.5415019762845,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-07T03:39:34Z",
+    "asin": "B07TYBQJBM",
+    "wpm": 688.4681583476764,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-07T04:03:23Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 132.46628131021194,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-08T06:25:41Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 622.4066390041494,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-08T06:26:27Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 243.47826086956522,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-08T19:51:31Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 354.6698192872825,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-08T20:24:44Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 7500,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-08T22:10:15Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 974.025974025974,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-08T22:11:14Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 150.41782729805013,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-09T03:35:20Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 156.14649380145735,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-09T04:12:03Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 260.4514491785762,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-09T04:49:40Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 226.97181766597313,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-09T17:47:46Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 332.22591362126246,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-09T17:55:27Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 1190.4761904761906,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-09T17:55:45Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 63.051702395964696,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-09T19:22:29Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 211.42245024525005,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-09T23:08:30Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 283.14708547266684,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-10T05:03:01Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 364.4567858382506,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-10T05:12:54Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 309.80603448275866,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-10T22:22:43Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 375.26804860614726,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-10T22:32:14Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 110.06481594716888,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-10T23:42:18Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 404.1146216017634,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T04:56:50Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 375.4489063010121,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-11T05:12:23Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 232.73367719209966,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-11T05:56:45Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 190.95538312318138,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-11T17:02:45Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 246.59464537341475,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T17:12:19Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 231.80219545987424,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T21:33:01Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 279.4597112249651,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T21:58:14Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 429.2206699208887,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T22:08:16Z",
+    "asin": "B007D1TKAU",
+    "wpm": 604.4905008635578,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T22:14:20Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 211.34698478301712,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T22:50:25Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 152.8932099733417,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T23:13:36Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 714.2857142857143,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-11T23:15:32Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 501.07638631133545,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-12T05:29:43Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 329.5316443862765,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-12T20:26:58Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 472.05438066465257,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-12T20:40:29Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 207.6986984214899,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-13T03:50:54Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 351.99614910195857,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-13T04:46:32Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 236.35760490960357,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-13T05:06:48Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 248.93617021276597,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-13T21:44:53Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 295.45363186879445,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-14T01:08:17Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 157.39769150052464,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T01:21:38Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 292.35695391897536,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T02:42:38Z",
+    "asin": "B09N6VX4K7",
+    "wpm": 385.9942375789034,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T04:01:28Z",
+    "asin": "B003L77UKC",
+    "wpm": 374.0648379052369,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T04:02:15Z",
+    "asin": "B003L77UKC",
+    "wpm": 1692.7083333333335,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T04:04:18Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 377.8644563627499,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T04:43:22Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 472.2481343283582,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T05:40:27Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 627.6150627615064,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T05:45:06Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 298.1639378563582,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-14T22:08:47Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 387.0391504986851,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-14T23:42:24Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 263.8780297107115,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-15T00:58:13Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 512.656199935918,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-15T01:53:02Z",
+    "asin": "B09JBCGQB8",
+    "wpm": 601.0819475055099,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-15T02:19:40Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 329.36010037641154,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-15T02:30:27Z",
+    "asin": "B007D1TKAU",
+    "wpm": 430.2103250478011,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-16T02:33:47Z",
+    "asin": "B007D1TKAU",
+    "wpm": 303.4180977542932,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T02:55:15Z",
+    "asin": "B007D1TKAU",
+    "wpm": 416.6666666666667,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T02:58:53Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 419.5804195804196,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T03:00:38Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 2777.777777777778,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T03:01:14Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 401.5296367112811,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T03:14:44Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 361.34683821516563,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T06:39:56Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 549.4505494505495,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T06:40:31Z",
+    "asin": "B003L77UKC",
+    "wpm": 1202.6239067055394,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T06:43:03Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 296.26253418413853,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T06:54:06Z",
+    "asin": "B007D1TKAU",
+    "wpm": 700.7007007007007,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-17T20:16:12Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 182.82392649540597,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-17T23:25:15Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 24.654832347140037,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-18T04:11:46Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 270.80700487452606,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-18T04:21:50Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 372.36243276789406,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-18T04:26:09Z",
+    "asin": "B006CUDDUG",
+    "wpm": 254.3053448737396,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-18T04:52:10Z",
+    "asin": "B006CUDDUG",
+    "wpm": 234.30178069353326,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-19T04:48:25Z",
+    "asin": "B006CUDDUG",
+    "wpm": 572.5190839694657,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-19T04:49:21Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 243.192980782986,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T01:56:26Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 592.8853754940712,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T02:00:14Z",
+    "asin": "B003L77UKC",
+    "wpm": 416.6666666666667,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T02:01:44Z",
+    "asin": "B007D1TKAU",
+    "wpm": 666.8783740870118,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T02:08:12Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 71.62468664199595,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T02:24:58Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 122.8888328711873,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T02:52:16Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 314.4654088050314,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T03:22:50Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 250.29200734189888,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-20T20:42:20Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 287.66630708378284,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-20T20:56:38Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 101.82311869666408,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-21T04:20:09Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 305.1261187957689,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-21T04:28:30Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 400.85515766969536,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-21T04:41:51Z",
+    "asin": "B003L77UKC",
+    "wpm": 728.1553398058253,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-21T04:44:36Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 217.1008684034736,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-22T03:52:15Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 299.543552681628,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-22T20:07:32Z",
+    "asin": "B003L77UKC",
+    "wpm": 365.4970760233918,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-22T20:11:11Z",
+    "asin": "B007D1TKAU",
+    "wpm": 365.8708194568226,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-23T21:16:27Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 443.0379746835443,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-23T21:22:58Z",
+    "asin": "B007D1TKAU",
+    "wpm": 552.4861878453039,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-23T21:24:11Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 231.69999141851883,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-24T04:36:21Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 567.199654278306,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-24T04:52:12Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 367.2316384180791,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-24T20:33:55Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 1401.8691588785045,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-24T20:38:22Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 187.52604528406724,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-24T20:56:11Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 208.33333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-24T22:23:38Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 1020.4081632653061,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-24T22:24:15Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 534.9500713266763,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-25T05:49:08Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 396.25360230547545,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-25T15:07:55Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 937.5,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-25T18:14:28Z",
+    "asin": "B07MXCRB2F",
+    "wpm": 4245.2830188679245,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-25T18:29:08Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 1219.5121951219512,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-25T18:29:52Z",
+    "asin": "B007D1TKAU",
+    "wpm": 2059.6711307001187,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-25T21:27:27Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 429.18454935622316,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-26T03:14:00Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 512.5701732975348,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-26T03:42:04Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 525.164113785558,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-27T03:59:09Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 400.5696991276482,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-29T02:35:39Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 862.0689655172414,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-29T02:38:32Z",
+    "asin": "B0B3989NDF",
+    "wpm": 345.05534551086413,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-29T04:08:24Z",
+    "asin": "B0B3989NDF",
+    "wpm": 481.77156702541276,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-29T11:05:14Z",
+    "asin": "B0B3989NDF",
+    "wpm": 376.15410919867776,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-29T16:14:26Z",
+    "asin": "B0B3989NDF",
+    "wpm": 296.0656169130225,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-29T17:55:09Z",
+    "asin": "B0B3989NDF",
+    "wpm": 166.0126773317235,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-29T18:13:14Z",
+    "asin": "B0B3989NDF",
+    "wpm": 419.40923679486485,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-29T21:13:40Z",
+    "asin": "B0B3989NDF",
+    "wpm": 530.035335689046,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-30T03:46:52Z",
+    "asin": "B07MXCRB2F",
+    "wpm": 5555.555555555556,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-30T03:47:26Z",
+    "asin": "B0BWMMN631",
+    "wpm": 8260.869565217392,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-30T05:08:15Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 319.55688112484023,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-31T04:18:18Z",
+    "asin": "B0B3Y8DJFJ",
+    "wpm": 600,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-31T04:20:11Z",
+    "asin": "B003L77UKC",
+    "wpm": 783.289817232376,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-31T04:29:37Z",
+    "asin": "B0B1Y1ZKFX",
+    "wpm": 882.3529411764706,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-31T04:30:52Z",
+    "asin": "B0B1Y1ZKFX",
+    "wpm": 208.00316957210777,
+    "period": "morning"
+  },
+  {
+    "start": "2023-03-31T16:16:32Z",
+    "asin": "B075SPBQDV",
+    "wpm": 3296.7032967032965,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-31T20:09:27Z",
+    "asin": "B075SPBQDV",
+    "wpm": 75000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-31T20:09:28Z",
+    "asin": "B075SPBQDV",
+    "wpm": 10489.510489510489,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-31T20:58:10Z",
+    "asin": "B0B1Y1ZKFX",
+    "wpm": 597.609561752988,
+    "period": "evening"
+  },
+  {
+    "start": "2023-03-31T20:59:03Z",
+    "asin": "B075SPBQDV",
+    "wpm": 166.179877127606,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-01T04:55:21Z",
+    "asin": "B075SPBQDV",
+    "wpm": 309.44241424024517,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-01T19:43:35Z",
+    "asin": "B075SPBQDV",
+    "wpm": 215.1238591916558,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-01T22:16:55Z",
+    "asin": "B075SPBQDV",
+    "wpm": 301.8108651911469,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-01T23:29:17Z",
+    "asin": "B075SPBQDV",
+    "wpm": 290.89901648427764,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-02T03:33:54Z",
+    "asin": "B075SPBQDV",
+    "wpm": 245.34859946841138,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-02T18:43:15Z",
+    "asin": "B075SPBQDV",
+    "wpm": 60.24096385542168,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-02T22:38:53Z",
+    "asin": "B075SPBQDV",
+    "wpm": 186.61068346162818,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-03T02:24:28Z",
+    "asin": "B075SPBQDV",
+    "wpm": 7317.073170731708,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-03T02:25:13Z",
+    "asin": "B075SPBQDV",
+    "wpm": 21428.571428571428,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-03T04:02:25Z",
+    "asin": "B075SPBQDV",
+    "wpm": 272.2213260203259,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-03T21:10:19Z",
+    "asin": "B075SPBQDV",
+    "wpm": 245.80569644947326,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-04T00:41:38Z",
+    "asin": "B075SPBQDV",
+    "wpm": 382.1826877947388,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-04T02:03:48Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 3257.6505429417575,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-04T03:01:16Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 237.33021761355337,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-04T23:11:49Z",
+    "asin": "B075SPBQDV",
+    "wpm": 2884.6153846153843,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-04T23:12:27Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 670.3078450844092,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-04T23:16:42Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 358.85167464114835,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-05T00:15:04Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 5555.555555555556,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-05T03:24:18Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 737.1007371007371,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-05T04:28:15Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 330.6739449926517,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-05T21:51:17Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 313.0550621669627,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-05T23:11:13Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 799.5735607675907,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-07T03:54:36Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 384.0484133757468,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-07T18:30:26Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 94.52788572628926,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-08T04:22:37Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 268.53776853776856,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-09T03:59:08Z",
+    "asin": "B07HB5DKQX",
+    "wpm": 541.5162454873646,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-09T04:09:48Z",
+    "asin": "B004HW7DZ2",
+    "wpm": 233.16062176165804,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-09T18:52:12Z",
+    "asin": "B004HW7DZ2",
+    "wpm": 156.4265229860085,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-09T23:05:46Z",
+    "asin": "B004HW7DZ2",
+    "wpm": 833.3333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-09T23:14:17Z",
+    "asin": "B000U913EI",
+    "wpm": 411.52263374485597,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T02:50:41Z",
+    "asin": "B000U913EI",
+    "wpm": 898.2035928143713,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-10T02:51:20Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 279.38296957829886,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-10T04:05:15Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 296.1865975564605,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-10T20:01:21Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 118.49511207662684,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T20:20:38Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 136.54984069185252,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T20:24:22Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 184.95684340320594,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T20:35:07Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 192.51925192519252,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T21:45:08Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 643.6104218362283,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T23:43:46Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T23:44:25Z",
+    "asin": "B087BQ7GK3",
+    "wpm": 4277.524621490519,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-10T23:55:50Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 309.2352695361471,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-11T01:59:23Z",
+    "asin": "B0B3HPSFJ7",
+    "wpm": 334.1984134756635,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-11T03:08:10Z",
+    "asin": "B000U913EI",
+    "wpm": 4285.714285714285,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-11T03:22:47Z",
+    "asin": "B000U913EI",
+    "wpm": 210.87680355160933,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T00:28:27Z",
+    "asin": "B000U913EI",
+    "wpm": 349.65034965034965,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T00:30:07Z",
+    "asin": "B000U913EI",
+    "wpm": 242.19380713039402,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T03:46:16Z",
+    "asin": "B000U913EI",
+    "wpm": 1190.4761904761906,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T03:46:39Z",
+    "asin": "B003L77UKC",
+    "wpm": 949.9136442141623,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T03:52:32Z",
+    "asin": "B000U913EI",
+    "wpm": 24.98750624687656,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T04:02:35Z",
+    "asin": "B000U913EI",
+    "wpm": 296.4539546197408,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-12T13:22:50Z",
+    "asin": "B000U913EI",
+    "wpm": 1351.3513513513515,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T04:09:35Z",
+    "asin": "B000U913EI",
+    "wpm": 298.2588134135856,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-13T17:05:59Z",
+    "asin": "B000U913EI",
+    "wpm": 2027.027027027027,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T18:08:06Z",
+    "asin": "B000U913EI",
+    "wpm": 24.958402662229616,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T18:18:13Z",
+    "asin": "B000U913EI",
+    "wpm": 364.3134715025907,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T18:28:39Z",
+    "asin": "B003L77UKC",
+    "wpm": 763.3587786259542,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T18:30:05Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 202.2192263818314,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T22:09:12Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 1086.0755389852488,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T22:46:45Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 153.2416502946955,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-13T23:38:10Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 613.9154160982265,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T00:49:47Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 221.8369116222143,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-14T02:03:58Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 7317.073170731707,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-14T02:39:09Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 360.082304526749,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-14T03:43:14Z",
+    "asin": "B000U913EI",
+    "wpm": 250.55679287305125,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-14T17:57:19Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 2672.8439059158945,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T18:00:28Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 112.26344488399444,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T18:22:27Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 4838.709677419355,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T18:24:11Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 337.07865168539325,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T18:49:28Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 9375,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T18:51:09Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 161.67277430480706,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T19:11:25Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 354.7389485173731,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T19:23:04Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 492.842055855433,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T19:51:26Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T19:52:04Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 879.7054009819967,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T20:04:56Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 302.4955886059995,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T20:12:40Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 719.355457510071,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T20:22:36Z",
+    "asin": "B0B1BTJLJN",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T21:12:39Z",
+    "asin": "B000U913EI",
+    "wpm": 964.0102827763496,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T21:14:34Z",
+    "asin": "B000U913EI",
+    "wpm": 78.125,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T21:29:08Z",
+    "asin": "B000U913EI",
+    "wpm": 167.713768501757,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-14T22:49:50Z",
+    "asin": "B000U913EI",
+    "wpm": 397.20068091545295,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-15T04:40:24Z",
+    "asin": "B000U913EI",
+    "wpm": 206.08925038469994,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-16T03:19:53Z",
+    "asin": "B000U913EI",
+    "wpm": 282.16704288939053,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-16T18:22:46Z",
+    "asin": "B000U913EI",
+    "wpm": 148.45973029815664,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-17T04:07:43Z",
+    "asin": "B000U913EI",
+    "wpm": 394.14140431122576,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-17T20:37:21Z",
+    "asin": "B000U913EI",
+    "wpm": 258.3979328165375,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-18T21:23:07Z",
+    "asin": "B000U913EI",
+    "wpm": 367.6470588235294,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-19T03:55:17Z",
+    "asin": "B000U913EI",
+    "wpm": 240.44241404183697,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-19T19:06:34Z",
+    "asin": "B000U913EI",
+    "wpm": 1351.3513513513515,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-19T19:07:29Z",
+    "asin": "B000U913EI",
+    "wpm": 574.7126436781609,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-19T19:08:52Z",
+    "asin": "B000U913EI",
+    "wpm": 100,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-19T19:17:50Z",
+    "asin": "B000U913EI",
+    "wpm": 98.1140303063338,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-19T19:58:14Z",
+    "asin": "B000U913EI",
+    "wpm": 161.81229773462783,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-19T21:32:20Z",
+    "asin": "B000U913EI",
+    "wpm": 229.10412387422974,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-20T03:43:32Z",
+    "asin": "B000U913EI",
+    "wpm": 309.83733539891557,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-20T19:25:51Z",
+    "asin": "B000U913EI",
+    "wpm": 193.6039007600746,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-21T03:28:06Z",
+    "asin": "B000U913EI",
+    "wpm": 572.7619855748833,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-21T03:44:09Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 168.4131736526946,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-21T16:34:17Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 356.2005277044855,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-22T03:55:09Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 543.4782608695652,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-22T03:56:35Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 588.2352941176471,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-23T04:47:09Z",
+    "asin": "B000U913EI",
+    "wpm": 1875,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-23T04:47:27Z",
+    "asin": "B003L77UKC",
+    "wpm": 1474.7191011235955,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-23T04:51:12Z",
+    "asin": "B000U913EI",
+    "wpm": 144.81305950500266,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-24T03:08:04Z",
+    "asin": "B000U913EI",
+    "wpm": 420.1680672268908,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-24T03:09:40Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 943.3962264150942,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-24T03:10:02Z",
+    "asin": "B000U913EI",
+    "wpm": 379.3733314598848,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-24T03:22:01Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 343.69271788035326,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-24T16:01:35Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 1546.3917525773197,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-24T22:33:18Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 343.75511540350305,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-24T22:46:03Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 639.5870736086176,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-25T03:07:14Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 361.5819209039548,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-25T23:23:01Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 141.0153102336825,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-26T00:04:08Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 180.3607214428858,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-26T02:42:49Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 351.9124129105645,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-26T20:35:01Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 243.31839950563878,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-26T21:47:27Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 219.16630855178343,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-27T02:50:18Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 229.73756105637884,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-27T19:59:09Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 191.7741145748327,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-27T21:12:58Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 185.35160638058863,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-27T21:28:15Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 204.5268611944369,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-27T22:14:49Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 903.6144578313252,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-27T22:15:36Z",
+    "asin": "B0B6Z3LN2D",
+    "wpm": 520.8333333333333,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-28T03:38:29Z",
+    "asin": "B0B6Z4SVTH",
+    "wpm": 2406.4171122994653,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-28T03:39:39Z",
+    "asin": "B0B6Z4SVTH",
+    "wpm": 323.5082674335011,
+    "period": "morning"
+  },
+  {
+    "start": "2023-04-28T17:04:41Z",
+    "asin": "B0B6Z4SVTH",
+    "wpm": 155.3867403314917,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-28T19:53:44Z",
+    "asin": "B0B6Z4SVTH",
+    "wpm": 2479.3388429752067,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-28T19:54:15Z",
+    "asin": "B0C3QHMLGL",
+    "wpm": 8455.882352941177,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-28T19:58:05Z",
+    "asin": "B0B6Z4SVTH",
+    "wpm": 231.56394727467045,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-28T22:49:29Z",
+    "asin": "B0B6Z4SVTH",
+    "wpm": 241.35156878519712,
+    "period": "evening"
+  },
+  {
+    "start": "2023-04-30T21:03:41Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 1744.1860465116279,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-01T20:39:24Z",
+    "asin": "B003L77UKC",
+    "wpm": 1119.4029850746267,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-01T20:44:54Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 736.738703339882,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-01T20:46:45Z",
+    "asin": "B09CNFH5WG",
+    "wpm": 949.6834388537154,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-01T20:52:07Z",
+    "asin": "B000U913EI",
+    "wpm": 971.864737729653,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-02T01:20:28Z",
+    "asin": "B084357H23",
+    "wpm": 301.5729096858123,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-02T01:24:45Z",
+    "asin": "B084357H23",
+    "wpm": 8064.5161290322585,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-02T22:53:11Z",
+    "asin": "B084357H23",
+    "wpm": 255.4450121000269,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-02T23:20:41Z",
+    "asin": "B084357H23",
+    "wpm": 393.89353747552076,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-03T00:00:13Z",
+    "asin": "B084357H23",
+    "wpm": 552.0951302378256,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-03T00:54:15Z",
+    "asin": "B084357H23",
+    "wpm": 225.93764121102575,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-03T01:27:31Z",
+    "asin": "B084357H23",
+    "wpm": 196.5166461159063,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-03T02:21:15Z",
+    "asin": "B084357H23",
+    "wpm": 338.6004514672686,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-04T00:38:45Z",
+    "asin": "B084357H23",
+    "wpm": 229.95554192856048,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-04T03:10:24Z",
+    "asin": "B084357H23",
+    "wpm": 433.32473562032504,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-05T02:36:11Z",
+    "asin": "B084357H23",
+    "wpm": 334.34742010301517,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-06T05:10:22Z",
+    "asin": "B084357H23",
+    "wpm": 410.0557461406518,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-06T19:46:50Z",
+    "asin": "B084357H23",
+    "wpm": 224.87150199885778,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-07T04:09:29Z",
+    "asin": "B084357H23",
+    "wpm": 395.8426373269457,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-07T16:38:48Z",
+    "asin": "B084357H23",
+    "wpm": 242.60803639120545,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-08T03:24:28Z",
+    "asin": "B084357H23",
+    "wpm": 397.70216526734424,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-08T03:55:41Z",
+    "asin": "B084357H23",
+    "wpm": 221.77866489243732,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-08T17:26:42Z",
+    "asin": "B003L77UKC",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-08T17:26:59Z",
+    "asin": "B003L77UKC",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-08T17:27:31Z",
+    "asin": "B003L77UKC",
+    "wpm": 111.74016686531584,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-08T18:51:14Z",
+    "asin": "B084357H23",
+    "wpm": 270.682953914492,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-08T19:25:02Z",
+    "asin": "B084357H23",
+    "wpm": 311.4186851211072,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-08T20:09:01Z",
+    "asin": "B084357H23",
+    "wpm": 777.0435633871757,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-09T03:08:22Z",
+    "asin": "B09RTYQW2S",
+    "wpm": 977.7777777777778,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-09T03:14:09Z",
+    "asin": "B0BBCB6PFC",
+    "wpm": 284.3601895734597,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-09T21:50:18Z",
+    "asin": "B0BBCB6PFC",
+    "wpm": 209.4647013188518,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-11T02:50:28Z",
+    "asin": "B0BBCB6PFC",
+    "wpm": 1327.4336283185842,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-11T02:51:11Z",
+    "asin": "B09GW3P1KJ",
+    "wpm": 312.6085446335533,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-12T02:39:16Z",
+    "asin": "B09GW3P1KJ",
+    "wpm": 852.2727272727273,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-12T02:40:21Z",
+    "asin": "B003L77UKC",
+    "wpm": 935.5509355509356,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-12T02:43:51Z",
+    "asin": "B09XL59MJX",
+    "wpm": 177.3632004204165,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-12T15:46:42Z",
+    "asin": "B09XL59MJX",
+    "wpm": 491.80327868852464,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-12T15:47:15Z",
+    "asin": "B09XL59MJX",
+    "wpm": 23.633212541358123,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-12T21:05:17Z",
+    "asin": "B09XL59MJX",
+    "wpm": 273.07482250136536,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-12T21:42:01Z",
+    "asin": "B09XL59MJX",
+    "wpm": 519.780537106555,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-13T01:14:46Z",
+    "asin": "B09XL59MJX",
+    "wpm": 469.5652173913043,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-13T01:38:36Z",
+    "asin": "B09XL59MJX",
+    "wpm": 375.49965680138894,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-13T02:52:09Z",
+    "asin": "B09XL59MJX",
+    "wpm": 290.23242481427513,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-13T04:20:43Z",
+    "asin": "B09XL59MJX",
+    "wpm": 407.9412564590699,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-13T04:27:44Z",
+    "asin": "B09XL59MJX",
+    "wpm": 301.7501508750754,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-13T05:00:36Z",
+    "asin": "B09XL59MJX",
+    "wpm": 296.0172228202368,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-13T20:02:24Z",
+    "asin": "B09XL59MJX",
+    "wpm": 463.89124893797793,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T04:30:57Z",
+    "asin": "B09XL59MJX",
+    "wpm": 276.9961308476961,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-14T17:42:05Z",
+    "asin": "B09XL59MJX",
+    "wpm": 1304.3478260869565,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T18:00:33Z",
+    "asin": "B09XL59MJX",
+    "wpm": 542.968226303794,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T18:13:24Z",
+    "asin": "B09XL59MJX",
+    "wpm": 336.0716952949963,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T18:15:39Z",
+    "asin": "B09XL59MJX",
+    "wpm": 4687.5,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T18:20:53Z",
+    "asin": "B09XL59MJX",
+    "wpm": 354.735721887194,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T21:48:11Z",
+    "asin": "B09XL59MJX",
+    "wpm": 397.01636188642925,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-14T23:54:23Z",
+    "asin": "B09XL59MJX",
+    "wpm": 413.0453489372688,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-15T02:32:17Z",
+    "asin": "B09XL59MJX",
+    "wpm": 450.59753150917516,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-15T02:57:56Z",
+    "asin": "B003L77UKC",
+    "wpm": 1700.6802721088436,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-15T03:07:59Z",
+    "asin": "B09XL59MJX",
+    "wpm": 2884.6153846153843,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-15T03:09:13Z",
+    "asin": "B09GW3P1KJ",
+    "wpm": 3846.153846153846,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-15T03:25:17Z",
+    "asin": "B09GW3P1KJ",
+    "wpm": 169.19739696312365,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-15T03:48:42Z",
+    "asin": "B0C3QHMLGL",
+    "wpm": 480.7692307692308,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-15T20:35:22Z",
+    "asin": "B0C3QHMLGL",
+    "wpm": 671.1409395973154,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-15T20:37:01Z",
+    "asin": "B003L77UKC",
+    "wpm": 742.5742574257425,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-15T20:39:00Z",
+    "asin": "B09Y46DSD7",
+    "wpm": 188.45467169212458,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-16T04:27:15Z",
+    "asin": "B09Y46DSD7",
+    "wpm": 240.1921537229784,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-16T20:43:46Z",
+    "asin": "B003L77UKC",
+    "wpm": 2571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-16T20:44:17Z",
+    "asin": "B08D4QJRY2",
+    "wpm": 143.8710915020142,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-16T22:07:48Z",
+    "asin": "B08D4QJRY2",
+    "wpm": 173.4339930626403,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-17T03:44:00Z",
+    "asin": "B08D4QJRY2",
+    "wpm": 435.7931435212086,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-17T03:52:53Z",
+    "asin": "B00AG8GXVQ",
+    "wpm": 137.68836533312935,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-18T03:45:00Z",
+    "asin": "B00AG8GXVQ",
+    "wpm": 289.2030848329049,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-18T03:53:06Z",
+    "asin": "B003L77UKC",
+    "wpm": 668.4672518568535,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-18T04:17:33Z",
+    "asin": "B08D4QJRY2",
+    "wpm": 162.38159675236807,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-20T03:43:35Z",
+    "asin": "B08D4QJRY2",
+    "wpm": 678.7330316742082,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-20T03:44:31Z",
+    "asin": "B003L77UKC",
+    "wpm": 1401.8691588785045,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-20T03:56:26Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 303.0762236702531,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-20T04:44:05Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 251.2768130745659,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-21T16:55:53Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 207.4688796680498,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-21T20:24:54Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 217.15680708527307,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-21T22:41:48Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 62.674094707520894,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-22T02:43:35Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 238.7365328109696,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-22T03:39:14Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 74.81296758104737,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-23T03:24:25Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 252.38362310712282,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-23T20:48:12Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 251.7717269675494,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-23T21:30:07Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 350.7531676545761,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-23T22:08:13Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 121.26111560226354,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-23T23:09:25Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 42.80821917808219,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-24T03:19:21Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 98.73834339001645,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-24T03:36:34Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 127.55102040816327,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-24T04:11:06Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 147.53407334551076,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-24T21:34:10Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 168.7289088863892,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-25T04:04:41Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 193.7984496124031,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-25T18:04:38Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 152.03344735841887,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-26T03:27:01Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 175.2715627299087,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-26T19:56:29Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 173.52379036314255,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-27T04:22:50Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 173.98639742711023,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-27T17:58:58Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 421.5456674473068,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-27T18:04:31Z",
+    "asin": "B0B3Y4RYX6",
+    "wpm": 4952.830188679245,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-27T18:07:06Z",
+    "asin": "B098433CGQ",
+    "wpm": 200.09528346831823,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-27T19:44:07Z",
+    "asin": "B098433CGQ",
+    "wpm": 585.9375,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-27T22:34:02Z",
+    "asin": "B098433CGQ",
+    "wpm": 1546.3917525773197,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-28T04:07:35Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 207.0291319564253,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-28T20:45:43Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 105.43333099037042,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-28T21:17:08Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 300.97237227967275,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-28T22:21:54Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 24.838549428713364,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-28T22:33:25Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 155.7632398753894,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-28T22:49:35Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 94.64468806688224,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-28T23:37:30Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 65.34727408513815,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-29T04:37:49Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 238.0952380952381,
+    "period": "morning"
+  },
+  {
+    "start": "2023-05-29T15:59:22Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 440.54794520547944,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-29T17:15:34Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 385.2739726027397,
+    "period": "evening"
+  },
+  {
+    "start": "2023-05-29T17:17:56Z",
+    "asin": "B08PG6CKZJ",
+    "wpm": 2083.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-03T03:25:42Z",
+    "asin": "B0B5SR4KBR",
+    "wpm": 300.2001334222815,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-03T03:45:52Z",
+    "asin": "B0B6JSJQLH",
+    "wpm": 129.75778546712803,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-03T17:18:58Z",
+    "asin": "B0B6JSJQLH",
+    "wpm": 106.30758327427357,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-07T02:55:54Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 112.78195488721803,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-07T02:58:22Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 236.50912531041823,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-07T19:05:10Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 50000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-07T19:05:19Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 198.22541060977912,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-08T01:09:32Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 669.6428571428571,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-08T03:33:45Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 164.37882108663052,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-08T21:27:15Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 2267.002518891688,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-08T21:37:46Z",
+    "asin": "B000GCFX6S",
+    "wpm": 286.3961813842482,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-09T03:41:44Z",
+    "asin": "B000GCFX6S",
+    "wpm": 873.3624454148471,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-09T03:44:09Z",
+    "asin": "B000GCFX6S",
+    "wpm": 346.97234501901926,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-10T02:12:37Z",
+    "asin": "B000GCFX6S",
+    "wpm": 231.17569352708057,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-12T02:17:22Z",
+    "asin": "B000GCFX6S",
+    "wpm": 374.71896077941545,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-12T02:26:00Z",
+    "asin": "B000GCFX6S",
+    "wpm": 350.9592887225082,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-12T02:37:47Z",
+    "asin": "B000GCFX6S",
+    "wpm": 257.62129669386,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-12T03:22:50Z",
+    "asin": "B09XBGYWSR",
+    "wpm": 1321.5859030837003,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-12T03:23:26Z",
+    "asin": "B000GCFX6S",
+    "wpm": 105.94521557548212,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-12T18:48:24Z",
+    "asin": "B000GCFX6S",
+    "wpm": 21428.571428571428,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-12T18:49:44Z",
+    "asin": "B000GCFX6S",
+    "wpm": 147.32965009208104,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-12T19:03:21Z",
+    "asin": "B000GCFX6S",
+    "wpm": 34.94874184529357,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-12T19:11:13Z",
+    "asin": "B000GCFX6S",
+    "wpm": 731.7073170731708,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-12T19:34:13Z",
+    "asin": "B000GCFX6S",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-12T19:52:36Z",
+    "asin": "B000GCFX6S",
+    "wpm": 7500,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-13T01:23:22Z",
+    "asin": "B000GCFX6S",
+    "wpm": 170.33840563252326,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-13T02:04:47Z",
+    "asin": "B000GCFX6S",
+    "wpm": 66.3643402278509,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-13T22:15:02Z",
+    "asin": "B000GCFX6S",
+    "wpm": 368.55036855036855,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-13T22:22:40Z",
+    "asin": "B0BBCB6PFC",
+    "wpm": 32.36944324557618,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T03:43:14Z",
+    "asin": "B0BBCB6PFC",
+    "wpm": 882.3529411764706,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-14T03:45:09Z",
+    "asin": "B000GCFX6S",
+    "wpm": 239.32987634623055,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-14T19:54:47Z",
+    "asin": "B000GCFX6S",
+    "wpm": 253.54969574036514,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T20:07:14Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 156.3957635954563,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T20:38:45Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 298.804780876494,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T20:40:33Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 4166.666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T20:40:38Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 167.41071428571428,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T20:43:13Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 515.4639175257732,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T20:52:22Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 377.0739064856712,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T22:23:21Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 426.8639726807058,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T22:26:42Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 868.7258687258687,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T23:01:56Z",
+    "asin": "B000GCFX6S",
+    "wpm": 1006.7114093959732,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-14T23:02:41Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 200,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-15T00:19:53Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 147.9555236728838,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-15T01:49:50Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 310.24891234576705,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-15T02:23:33Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 220.54769343870612,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-15T19:24:18Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 304.4998308334273,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-15T20:25:14Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 69.08728026406693,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-15T20:50:14Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 476.1904761904762,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-15T23:18:17Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 368.7315634218289,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-16T18:54:47Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 130.8796700245895,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-16T19:51:11Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 233.20089825531178,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-19T00:18:54Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 49.22874958976042,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-19T00:29:55Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 147.2121695393486,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-19T20:56:12Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 296.0665444804737,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-19T21:08:12Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 289.4914600019299,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-20T03:05:00Z",
+    "asin": "B0BHCXVWGT",
+    "wpm": 1102.9411764705883,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-20T03:05:48Z",
+    "asin": "B000GCFX6S",
+    "wpm": 264.6085997794928,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-21T03:50:34Z",
+    "asin": "B000GCFX6S",
+    "wpm": 321.37118371719333,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-21T17:27:26Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 6428.571428571428,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-21T17:28:04Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 424.3119266055046,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-21T17:49:57Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 236.2204724409449,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-21T17:55:55Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 167.53536857781089,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-21T19:11:24Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-21T19:50:34Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 223.7136465324385,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-21T20:30:24Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 184.6078109616016,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-22T02:57:33Z",
+    "asin": "B000GCFX6S",
+    "wpm": 1136.3636363636363,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-22T02:58:26Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 288.2709747162333,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-22T20:37:59Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 1515.151515151515,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-22T22:39:06Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 1530.6122448979593,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-22T22:40:09Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 242.80439071273207,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-23T03:26:10Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 290.11604641856746,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-23T03:52:18Z",
+    "asin": "B000GCFX6S",
+    "wpm": 270.5953096812989,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-23T19:24:07Z",
+    "asin": "B000GCFX6S",
+    "wpm": 130.74484944532486,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-23T21:21:52Z",
+    "asin": "B000GCFX6S",
+    "wpm": 420.75736325385697,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-23T21:26:42Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 78.1725006514375,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-24T02:24:40Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 198.7130961392884,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-24T13:07:23Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 1764.7058823529412,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-25T03:30:01Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 229.31572188589251,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-26T03:04:22Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 158.3157426952561,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-26T19:58:03Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 274.66937945066127,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-26T19:58:11Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 0,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-26T20:36:22Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 1515.151515151515,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-26T21:35:02Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 70.6880301602262,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-27T02:51:59Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 238.75114784205692,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-27T20:11:27Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 200.4764948573421,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-27T23:45:27Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 273.22404371584696,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-28T02:34:11Z",
+    "asin": "B0BHTN6TL6",
+    "wpm": 408.0167123645384,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-28T03:56:50Z",
+    "asin": "B000GCFX6S",
+    "wpm": 403.91676866585067,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-28T04:03:45Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 263.2898696088265,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-28T20:31:05Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 209.76353928299008,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-28T21:54:56Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 155.71913929784824,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-28T22:12:41Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 229.88234739348786,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-28T23:48:50Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 185.3601802718616,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-29T02:44:57Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 206.9121187800963,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-29T21:06:05Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 110.59228311624479,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-30T02:57:04Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 249.54569885592892,
+    "period": "morning"
+  },
+  {
+    "start": "2023-06-30T18:15:17Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 238.67465368775737,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-30T20:21:37Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 289.65683710825925,
+    "period": "evening"
+  },
+  {
+    "start": "2023-06-30T21:52:36Z",
+    "asin": "B0B7NDZNDV",
+    "wpm": 316.76034905748264,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-03T03:23:43Z",
+    "asin": "B000GCFX6S",
+    "wpm": 299.42333284045543,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-03T19:58:07Z",
+    "asin": "B000GCFX6S",
+    "wpm": 193.31557693959962,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-04T03:08:45Z",
+    "asin": "B000GCFX6S",
+    "wpm": 341.76698632932056,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-04T19:07:00Z",
+    "asin": "B000GCFX6S",
+    "wpm": 164.75550283379465,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-04T21:57:47Z",
+    "asin": "B000GCFX6S",
+    "wpm": 162.83992835043153,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-04T22:37:14Z",
+    "asin": "B000GCFX6S",
+    "wpm": 433.80912398544643,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-05T02:07:01Z",
+    "asin": "B016TG0SAK",
+    "wpm": 7563.0252100840335,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-05T02:14:43Z",
+    "asin": "B000GCFX6S",
+    "wpm": 1648.3516483516482,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-05T02:16:56Z",
+    "asin": "B09Y94K74X",
+    "wpm": 24.777006937561943,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-05T02:36:24Z",
+    "asin": "B09Y94K74X",
+    "wpm": 407.6640847941296,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-05T20:21:39Z",
+    "asin": "B09Y94K74X",
+    "wpm": 244.95677233429393,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-06T03:02:01Z",
+    "asin": "B09Y94K74X",
+    "wpm": 370.2837542874961,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-06T21:16:43Z",
+    "asin": "B09Y94K74X",
+    "wpm": 368.3652397164704,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-06T22:16:31Z",
+    "asin": "B09Y94K74X",
+    "wpm": 137.0399373531715,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-07T02:42:39Z",
+    "asin": "B09Y94K74X",
+    "wpm": 450.6008010680908,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-07T03:17:52Z",
+    "asin": "B09Y94K74X",
+    "wpm": 269.7841726618705,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-07T19:16:55Z",
+    "asin": "B09Y94K74X",
+    "wpm": 1086.9565217391305,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-07T19:20:22Z",
+    "asin": "B09Y94K74X",
+    "wpm": 275.11121517209085,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-09T04:12:14Z",
+    "asin": "B09Y94K74X",
+    "wpm": 166.12522150029534,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-10T03:25:09Z",
+    "asin": "B09Y94K74X",
+    "wpm": 211.22703706074378,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-11T03:27:40Z",
+    "asin": "B09Y94K74X",
+    "wpm": 385.3363882524474,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-12T03:01:27Z",
+    "asin": "B09Y94K74X",
+    "wpm": 328.5438934641668,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-13T02:30:01Z",
+    "asin": "B09Y94K74X",
+    "wpm": 332.76192396894226,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-14T02:49:10Z",
+    "asin": "B09Y94K74X",
+    "wpm": 4394.69320066335,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-14T02:54:26Z",
+    "asin": "B000GCFX6S",
+    "wpm": 372.1218699123963,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-15T03:35:09Z",
+    "asin": "B000GCFX6S",
+    "wpm": 318.3177389794541,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-16T03:12:59Z",
+    "asin": "B000GCFX6S",
+    "wpm": 442.04322200392926,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-16T03:20:01Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 222.3384776353649,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-16T21:15:24Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 276.97495183044316,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-17T03:40:41Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 376.1755485893417,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-17T20:46:22Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 323.1393089465236,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-18T02:57:51Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 506.9708491761724,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-18T03:01:54Z",
+    "asin": "B07GJBCLHN",
+    "wpm": 658.4197924980048,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-18T03:10:23Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 285.6140702510398,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-19T02:07:27Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 1116.0714285714284,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-19T02:08:55Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 143.12977099236642,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-19T03:08:46Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 298.69321717485997,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-20T02:25:58Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 309.84622446637593,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-20T02:33:27Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 255.04546462630293,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-21T03:16:04Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 411.5397406052544,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-21T20:41:38Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 24.342745861733203,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-21T21:14:44Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 492.45962898705454,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-21T22:18:39Z",
+    "asin": "B07GD51NCJ",
+    "wpm": 655.7688652347463,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-22T03:19:11Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 369.6236559139785,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-22T03:26:46Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 333.2345971563981,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-23T03:31:51Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 329.9120234604105,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-23T03:38:50Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 529.8570227081581,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-23T16:50:11Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 393.0332922318126,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-23T19:52:56Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 402.74463007159903,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-23T20:00:54Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 146.7318808359271,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-24T03:48:36Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 544.703948625817,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-25T02:38:00Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 244.11475285746724,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-26T03:08:08Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 332.3284785530091,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-26T03:54:16Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 1562.5,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-26T03:54:37Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 331.0344827586207,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-26T20:29:04Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 322.9278794402583,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-26T20:35:25Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 1351.3513513513515,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-26T20:35:38Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 1648.3516483516482,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-26T20:35:50Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 194.2872724793783,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-27T04:08:27Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 305.73956547922364,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-27T19:36:04Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 197.55747126436782,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-28T03:02:41Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 326.3734884304783,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-28T18:41:25Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 1704.5454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-29T01:21:20Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 274.5713325114871,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-29T22:21:26Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 266.42984014209594,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-30T00:15:37Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 431.15247741582266,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-30T07:32:48Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 486.1493303980921,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-30T09:42:25Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 589.7771952817824,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-30T09:45:07Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 303.58015213901876,
+    "period": "morning"
+  },
+  {
+    "start": "2023-07-30T12:12:49Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 356.6576086956522,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-30T12:17:46Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 231.62445954292772,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-30T12:50:48Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 344.3328550932568,
+    "period": "evening"
+  },
+  {
+    "start": "2023-07-31T02:22:20Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 532.0917858330562,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-03T04:20:02Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 473.728048865135,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-03T18:26:14Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 324.98796340876265,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-03T19:13:19Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 210.32951624211265,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-03T19:40:54Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 628.7095392522792,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-03T20:36:55Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 341.5559772296015,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-04T03:57:00Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 291.33284777858705,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-04T04:10:55Z",
+    "asin": "B084G9Z5C3",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-04T04:19:16Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 429.72480250021704,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-05T04:37:20Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 466.1487236403995,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-05T04:45:24Z",
+    "asin": "B0BG13PH57",
+    "wpm": 126.1962351456515,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-06T06:50:49Z",
+    "asin": "B0BG13PH57",
+    "wpm": 166.00652376514446,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-07T03:26:04Z",
+    "asin": "B0BG13PH57",
+    "wpm": 95.72431397574984,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-07T04:03:41Z",
+    "asin": "B0BG13PH57",
+    "wpm": 304.8780487804878,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-07T04:39:50Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 374.41497659906395,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-07T21:36:02Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 305.1881993896236,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-07T21:37:47Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 1162.7906976744187,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-07T21:38:19Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 148.16810344827587,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-08T02:46:33Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 439.5604395604396,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-08T02:49:11Z",
+    "asin": "B0BG13PH57",
+    "wpm": 282.228428634426,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-09T02:10:03Z",
+    "asin": "B0BG13PH57",
+    "wpm": 562.8517823639775,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-09T02:25:24Z",
+    "asin": "B0BL126WSH",
+    "wpm": 286.32784538296346,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-10T03:33:19Z",
+    "asin": "B0BL126WSH",
+    "wpm": 207.32550103662751,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-10T03:55:17Z",
+    "asin": "B0BL126WSH",
+    "wpm": 153.3457249070632,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-10T21:55:31Z",
+    "asin": "B0BL126WSH",
+    "wpm": 967.7419354838709,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-11T03:54:20Z",
+    "asin": "B0BL126WSH",
+    "wpm": 283.9643652561247,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-11T20:34:35Z",
+    "asin": "B0BL126WSH",
+    "wpm": 746.2686567164179,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-11T20:36:07Z",
+    "asin": "B08T6CL58V",
+    "wpm": 358.53566486350485,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-12T03:41:42Z",
+    "asin": "B08T6CL58V",
+    "wpm": 305.0330452465684,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-14T02:31:30Z",
+    "asin": "B08T6CL58V",
+    "wpm": 280.838771798438,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-14T22:27:43Z",
+    "asin": "B08T6CL58V",
+    "wpm": 463.28071379547015,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-15T03:53:44Z",
+    "asin": "B08T6CL58V",
+    "wpm": 347.2564279381342,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-16T01:43:32Z",
+    "asin": "B08T6CL58V",
+    "wpm": 278.22949486736456,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-17T22:32:05Z",
+    "asin": "B08T6CL58V",
+    "wpm": 192.89221416880991,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-18T00:22:23Z",
+    "asin": "B08T6CL58V",
+    "wpm": 330.74489502444635,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-18T03:00:23Z",
+    "asin": "B08T6CL58V",
+    "wpm": 319.72669936930623,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-18T18:24:28Z",
+    "asin": "B08T6CL58V",
+    "wpm": 136.68117849549458,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-19T01:27:29Z",
+    "asin": "B08T6CL58V",
+    "wpm": 480.3547234881143,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-19T03:31:11Z",
+    "asin": "B08T6CL58V",
+    "wpm": 491.0714285714286,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-19T03:37:38Z",
+    "asin": "B0BHY38ZPH",
+    "wpm": 572.5190839694657,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-19T04:18:31Z",
+    "asin": "B0BHY38ZPH",
+    "wpm": 418.8144329896907,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-19T04:27:48Z",
+    "asin": "B08T6CL58V",
+    "wpm": 180.5830251956316,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-22T03:41:13Z",
+    "asin": "B08T6CL58V",
+    "wpm": 309.5104108047271,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-22T21:53:46Z",
+    "asin": "B08T6CL58V",
+    "wpm": 81.74386920980928,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-23T03:09:18Z",
+    "asin": "B08T6CL58V",
+    "wpm": 306.53950953678475,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-23T03:14:53Z",
+    "asin": "B000GCFX6S",
+    "wpm": 1293.103448275862,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-23T03:15:38Z",
+    "asin": "B0BGJ3W5D3",
+    "wpm": 574.642748555792,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-23T03:43:11Z",
+    "asin": "B08T6CL58V",
+    "wpm": 211.8074233458849,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-23T20:41:21Z",
+    "asin": "B08T6CL58V",
+    "wpm": 360.7696419027258,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-23T21:18:50Z",
+    "asin": "B08T6CL58V",
+    "wpm": 156.95301872972692,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-23T23:19:15Z",
+    "asin": "B08T6CL58V",
+    "wpm": 24.77291494632535,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-24T03:48:53Z",
+    "asin": "B08T6CL58V",
+    "wpm": 360.1003425673671,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-25T02:29:18Z",
+    "asin": "B08T6CL58V",
+    "wpm": 276.04211247111186,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-25T20:39:16Z",
+    "asin": "B08T6CL58V",
+    "wpm": 223.48816827344436,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-26T02:46:09Z",
+    "asin": "B08T6CL58V",
+    "wpm": 1160.8767218227497,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-26T03:44:32Z",
+    "asin": "B000GCFX6S",
+    "wpm": 119.61722488038278,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-26T04:01:00Z",
+    "asin": "B000GCFX6S",
+    "wpm": 2164.5021645021643,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-26T04:03:36Z",
+    "asin": "B0B7NGCGHG",
+    "wpm": 118.08699074985239,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-27T03:12:01Z",
+    "asin": "B092T947PJ",
+    "wpm": 423.10206047263597,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-27T04:04:18Z",
+    "asin": "B092T947PJ",
+    "wpm": 369.3823106915658,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-28T02:12:20Z",
+    "asin": "B092T947PJ",
+    "wpm": 221.3719595517901,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-28T17:49:55Z",
+    "asin": "B093R2CP2V",
+    "wpm": 2678.5714285714284,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T17:50:04Z",
+    "asin": "B093R2CP2V",
+    "wpm": 13235.29411764706,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T17:50:43Z",
+    "asin": "B092T947PJ",
+    "wpm": 1515.151515151515,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T17:51:47Z",
+    "asin": "B0BHY38ZPH",
+    "wpm": 3797.4683544303803,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T17:52:22Z",
+    "asin": "B092T947PJ",
+    "wpm": 556.4715581203628,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T17:56:29Z",
+    "asin": "B093R2CP2V",
+    "wpm": 339.4877903513996,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T18:46:39Z",
+    "asin": "B093R2CP2V",
+    "wpm": 313.9169863969306,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-28T20:19:27Z",
+    "asin": "B093R2CP2V",
+    "wpm": 171.5658240878417,
+    "period": "evening"
+  },
+  {
+    "start": "2023-08-31T03:10:52Z",
+    "asin": "B093R2CP2V",
+    "wpm": 641.025641025641,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-31T03:11:40Z",
+    "asin": "B092T947PJ",
+    "wpm": 300.04478280340345,
+    "period": "morning"
+  },
+  {
+    "start": "2023-08-31T21:08:27Z",
+    "asin": "B092T947PJ",
+    "wpm": 222.36545278762486,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-01T02:51:05Z",
+    "asin": "B092T947PJ",
+    "wpm": 261.8416193897076,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-02T03:37:11Z",
+    "asin": "B092T947PJ",
+    "wpm": 309.4606542882405,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-02T03:43:03Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 1138.1789137380192,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-02T03:47:20Z",
+    "asin": "B0BBC769LV",
+    "wpm": 439.5691430381752,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-02T04:08:37Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 63.25555243182457,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-03T02:59:42Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 200.43169904409498,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-03T18:29:36Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 478.5276073619632,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-03T18:36:33Z",
+    "asin": "B092T947PJ",
+    "wpm": 327.7809845798631,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-03T21:17:21Z",
+    "asin": "B092T947PJ",
+    "wpm": 272.23230490018153,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-03T23:07:08Z",
+    "asin": "B092T947PJ",
+    "wpm": 393.32014941771035,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-04T01:03:45Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 5172.413793103448,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-04T02:57:42Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 372.0115075559671,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-04T16:15:41Z",
+    "asin": "B0BLY7J9DC",
+    "wpm": 655.0218340611353,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-04T16:16:42Z",
+    "asin": "B0BBC769LV",
+    "wpm": 49.00359359686377,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-04T16:22:06Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 257.1183696790782,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-04T19:53:15Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 250.89466313987865,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-04T21:37:50Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 126.09751541191855,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-05T02:31:40Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 242.2209800633501,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-06T02:46:36Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 255.31914893617022,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-06T16:52:19Z",
+    "asin": "B0BT82YGGF",
+    "wpm": 1405.3716427232978,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-06T20:55:22Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 143.2408236347359,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-07T03:39:30Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 334.43081948513213,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-07T04:43:54Z",
+    "asin": "B0BBC769LV",
+    "wpm": 229.09507445589918,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-07T17:59:14Z",
+    "asin": "B0BBC769LV",
+    "wpm": 506.7567567567568,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-07T19:23:13Z",
+    "asin": "B0BBC769LV",
+    "wpm": 24.626498111968477,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-08T03:28:08Z",
+    "asin": "B0BBC769LV",
+    "wpm": 308.67295723750254,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-09T02:48:02Z",
+    "asin": "B0BBC769LV",
+    "wpm": 346.6490590954111,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-09T02:53:16Z",
+    "asin": "B0BP2HWMP6",
+    "wpm": 1512.9682997118157,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-09T03:00:44Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 272.975432211101,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-09T14:25:38Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 46.61280298321939,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-14T03:27:49Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 1111.111111111111,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-14T03:28:34Z",
+    "asin": "B09721CTG1",
+    "wpm": 351.6174402250351,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-16T03:03:35Z",
+    "asin": "B09721CTG1",
+    "wpm": 1415.0943396226414,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-16T03:12:16Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 221.2138400453772,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-17T03:44:29Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 374.85582468281433,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-18T01:29:00Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 186.62519440124416,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-19T02:40:08Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 382.50294233032565,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-20T01:51:23Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 372.67080745341616,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-20T02:03:31Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 540.8653846153846,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-20T02:04:57Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 110.29411764705883,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-20T21:53:02Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 283.6396641706376,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-21T03:50:03Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 329.2217198542645,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-21T21:02:45Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 129.80590925948817,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-22T02:49:23Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 328.46715328467155,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-22T03:14:47Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 402.47678018575857,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-23T02:27:34Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 255.76730190571715,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-23T08:50:31Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 335.4340313071762,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-23T08:58:54Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 91.37055837563452,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-24T03:23:44Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 412.0879120879121,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-24T03:26:59Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 354.9753807397229,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-24T04:10:47Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 363.81008378656475,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T01:11:57Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 269.6937376199908,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T02:34:18Z",
+    "asin": "B0BTVBH6G3",
+    "wpm": 839.1608391608391,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T02:55:55Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 3185.3281853281856,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T02:57:04Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 24.979184013322232,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T03:08:38Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 24.699489543882763,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T03:32:41Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 375.85013721512945,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-25T03:46:55Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 284.9740932642487,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-26T00:55:18Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 376.44787644787647,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-26T01:05:01Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 261.5603203306639,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-26T03:27:56Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 316.3327598645874,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-26T22:29:12Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 366.42238507661557,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-27T02:35:27Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 435.47110055423593,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-27T02:42:04Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 320.6860962304025,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T01:24:36Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 551.4705882352941,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T03:54:25Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 482.3151125401929,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T03:58:21Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 358.60655737704917,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T04:08:17Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 660.7929515418501,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T04:09:22Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 1485.148514851485,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T04:09:39Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 300.90270812437313,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T04:16:34Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 123.39754575992322,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-28T12:58:02Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 694.4444444444445,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-28T21:23:13Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 144.7661469933185,
+    "period": "evening"
+  },
+  {
+    "start": "2023-09-29T02:58:32Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 409.8802718153382,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-29T03:45:06Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 364.0040444893832,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-30T02:50:30Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 487.9635653871178,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-30T02:53:16Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 346.77701363795313,
+    "period": "morning"
+  },
+  {
+    "start": "2023-09-30T19:42:44Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 204.31684828164293,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-01T00:01:19Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 216.34615384615387,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T00:31:55Z",
+    "asin": "B0BJNKTFGH",
+    "wpm": 594.0353996605512,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T00:52:48Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 25,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T01:32:52Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 967.7419354838709,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T01:36:44Z",
+    "asin": "B09721CTG1",
+    "wpm": 1020.4081632653061,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T01:37:13Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 130.05780346820808,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T01:58:18Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 236.07589402815424,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T02:43:21Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 177.32592505024235,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-01T04:11:50Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 392.67015706806285,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-02T03:21:26Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 558.2215258055038,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-02T23:15:06Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 647.7150053976251,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-02T23:21:13Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 604.2849295000916,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-03T01:51:50Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 113.15417256011315,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-03T02:12:22Z",
+    "asin": "B0BQLKNTYR",
+    "wpm": 1024.5183887915937,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-03T02:42:31Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 194.02634054562557,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-03T03:02:29Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 259.39746973696185,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-03T04:44:10Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 316.63252002235055,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-04T00:59:07Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 273.090119739514,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-05T03:59:19Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 1009.421265141319,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-05T04:17:11Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 341.1675511751327,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-05T21:36:42Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 310.53519398865205,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-06T03:24:07Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 402.80042198139444,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-06T03:41:40Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 145.16536228225195,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-06T20:17:29Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 176.9972929825779,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-07T01:15:45Z",
+    "asin": "B0BBC9K8C3",
+    "wpm": 2586.206896551724,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-07T03:33:45Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 317.79661016949154,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-07T03:35:48Z",
+    "asin": "B0BP66G6B7",
+    "wpm": 1807.2289156626505,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-07T03:36:09Z",
+    "asin": "B0BBC9K8C3",
+    "wpm": 283.0570157703194,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-07T03:39:37Z",
+    "asin": "B0BBC9K8C3",
+    "wpm": 3846.153846153846,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-10T03:38:37Z",
+    "asin": "B0BBC9K8C3",
+    "wpm": 457.31707317073176,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-10T03:43:24Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 360.7937462417318,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-11T00:37:23Z",
+    "asin": "B0BKKVQPLB",
+    "wpm": 1428.5714285714287,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-11T00:42:54Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 194.36997319034853,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-11T21:09:41Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 345.46292031321974,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-11T21:15:15Z",
+    "asin": "B09RMQJCZJ",
+    "wpm": 2941.1764705882356,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-11T21:16:13Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 176.19851699581528,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T03:54:23Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 417.1437919188615,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-12T04:14:53Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 281.57447058133397,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-12T05:50:57Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 321.19914346895075,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-12T05:51:46Z",
+    "asin": "B0CBW58P3J",
+    "wpm": 312.3140987507436,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-12T06:03:31Z",
+    "asin": "B09RMQJCZJ",
+    "wpm": 204.41935169862748,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-12T16:51:29Z",
+    "asin": "B09RMQJCZJ",
+    "wpm": 2027.027027027027,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T16:52:31Z",
+    "asin": "B004HW7DZ2",
+    "wpm": 6701.030927835051,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T16:53:35Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 1477.832512315271,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T16:54:02Z",
+    "asin": "B004HW7DZ2",
+    "wpm": 127.8772378516624,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T16:56:02Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 1785.7142857142856,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T19:00:54Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 194.42644199611146,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T19:06:05Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 3947.368421052631,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T19:54:33Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 334.5677973234576,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T22:31:21Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 349.69110618953255,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-12T22:45:41Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 71.62183670221232,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-14T04:25:56Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 216.932811087677,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-16T04:17:39Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 81.90455389319646,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-17T03:17:37Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 298.6237340950403,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-18T02:55:07Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 244.1929720071471,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-19T03:55:20Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 284.0012622278321,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-19T04:12:34Z",
+    "asin": "B09RMQJCZJ",
+    "wpm": 797.8723404255319,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-19T04:13:01Z",
+    "asin": "B08SMFSLVQ",
+    "wpm": 254.841997961264,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-20T02:24:17Z",
+    "asin": "B08SMFSLVQ",
+    "wpm": 390.8045977011494,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-20T02:35:37Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 368.9388615600843,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-20T21:45:17Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 241.12432829651402,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-21T04:16:37Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 311.6492334145293,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-22T03:47:45Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 636.9426751592357,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-22T03:50:53Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 398.30058417419013,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-22T03:57:32Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 471.96903483580974,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-23T03:17:06Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 266.1462029808375,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-23T21:21:54Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 326.35822614705313,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-23T21:51:52Z",
+    "asin": "B09BV2JNWV",
+    "wpm": 2000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-24T03:06:09Z",
+    "asin": "B0BP6S1S57",
+    "wpm": 5172.413793103448,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-24T03:06:13Z",
+    "asin": "B0BP6S1S57",
+    "wpm": 1333.3333333333333,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-24T03:21:39Z",
+    "asin": "B0BP6S1S57",
+    "wpm": 423.8143289606458,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-24T13:34:07Z",
+    "asin": "B0BP6S1S57",
+    "wpm": 1470.5882352941176,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-26T04:23:31Z",
+    "asin": "B0BP6S1S57",
+    "wpm": 649.2027334851937,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-26T04:31:34Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 398.72997120283543,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-27T02:55:58Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 342.3637987496279,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-28T03:37:15Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 243.96414630620208,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-29T03:42:53Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 154.2257865515114,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-30T03:53:58Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 209.66271649954422,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-30T21:08:56Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 220.48015678588925,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-31T04:12:23Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 359.93089326849247,
+    "period": "morning"
+  },
+  {
+    "start": "2023-10-31T20:36:27Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 169.68325791855204,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-31T22:56:43Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 356.67431944899965,
+    "period": "evening"
+  },
+  {
+    "start": "2023-10-31T23:34:35Z",
+    "asin": "B0BKH7G2X8",
+    "wpm": 392.55101266782975,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-01T00:21:48Z",
+    "asin": "B0B9KVXCQ6",
+    "wpm": 1181.1023622047244,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-01T00:22:08Z",
+    "asin": "B0CHWJCN94",
+    "wpm": 400.5340453938585,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-01T02:46:02Z",
+    "asin": "B0CHWJCN94",
+    "wpm": 420.75736325385697,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-01T03:05:53Z",
+    "asin": "B0BGJ3W5D3",
+    "wpm": 218.23472356935017,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-01T03:40:23Z",
+    "asin": "B0B9KVXCQ6",
+    "wpm": 404.82187837351563,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-01T03:59:16Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 360.53247873782817,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-01T17:38:58Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 178.1613746139837,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-02T03:14:22Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 290.0905082385704,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-03T03:18:17Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 395.77836411609496,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-03T03:19:46Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 3191.4893617021276,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-03T03:19:55Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 298.4846165620695,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-03T20:57:21Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 126.60364618501013,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-04T05:46:06Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 228.52789944772422,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-04T19:25:55Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 112.15552232428968,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-05T05:03:42Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 189.50028074115667,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-06T04:08:09Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 309.9173553719008,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-06T20:58:58Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 12078.651685393259,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-06T22:53:28Z",
+    "asin": "B0BPX7SF89",
+    "wpm": 1562.5,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-06T22:54:33Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 357.40695094897706,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-06T23:41:53Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 931.6770186335405,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-07T04:35:46Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 132.46982631733883,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-08T04:15:13Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 215.8990256864482,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-08T18:57:57Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 4377.4319066147855,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-08T19:05:34Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 6000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-08T20:21:40Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 2439.0243902439024,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-08T20:21:55Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 3529.4117647058824,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-09T04:35:10Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 193.12475859405174,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-11T03:46:59Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 1229.5081967213114,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-11T03:47:51Z",
+    "asin": "B0BR511292",
+    "wpm": 260.7046926844683,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-11T03:59:25Z",
+    "asin": "B0BR511292",
+    "wpm": 24.79748718796495,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-11T04:25:37Z",
+    "asin": "B0BR511292",
+    "wpm": 303.2187840149277,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-11T13:10:59Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 6521.739130434783,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-12T21:37:25Z",
+    "asin": "B0BR511292",
+    "wpm": 248.16694867456286,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-12T23:37:16Z",
+    "asin": "B0BR511292",
+    "wpm": 1235.5848434925865,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-12T23:39:22Z",
+    "asin": "B0BR511292",
+    "wpm": 411.1734760475134,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-13T01:26:16Z",
+    "asin": "B0BR511292",
+    "wpm": 421.27435492364407,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-13T01:38:09Z",
+    "asin": "B0BR511292",
+    "wpm": 334.2884431709646,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-13T03:37:32Z",
+    "asin": "B0BR511292",
+    "wpm": 320.7739307535642,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-14T02:18:05Z",
+    "asin": "B0BR511292",
+    "wpm": 418.83842144452717,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-14T02:27:36Z",
+    "asin": "B006CUDDUG",
+    "wpm": 454.90284173873977,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-14T13:26:14Z",
+    "asin": "B0BR511292",
+    "wpm": 1382.4884792626726,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-14T13:29:36Z",
+    "asin": "B0BR511292",
+    "wpm": 1111.111111111111,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-15T03:57:16Z",
+    "asin": "B006CUDDUG",
+    "wpm": 312.3915307185005,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-15T04:02:22Z",
+    "asin": "B0BR511292",
+    "wpm": 246.78077641028887,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-16T03:11:51Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 151.28084448329187,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-17T03:27:03Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 140.9540655574595,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-21T03:34:04Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 249.58402662229616,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-21T03:35:36Z",
+    "asin": "B0BR511292",
+    "wpm": 355.2097428958051,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-21T04:30:01Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 316.5298944900352,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-22T03:26:37Z",
+    "asin": "B07CWDMQ45",
+    "wpm": 73.71007371007371,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-22T03:26:49Z",
+    "asin": "B0BR511292",
+    "wpm": 5000,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-22T03:30:59Z",
+    "asin": "B09YRR8DB6",
+    "wpm": 262.9901179470832,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-22T17:59:50Z",
+    "asin": "B09YRR8DB6",
+    "wpm": 3000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-22T18:00:03Z",
+    "asin": "B09YRR8DB6",
+    "wpm": 5263.157894736842,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-22T21:59:36Z",
+    "asin": "B09YRR8DB6",
+    "wpm": 182.1833979539403,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-22T22:38:18Z",
+    "asin": "B09YRR8DB6",
+    "wpm": 130.38439250531195,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-22T23:24:34Z",
+    "asin": "B09YRR8DB6",
+    "wpm": 380.95238095238096,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-27T05:46:34Z",
+    "asin": "B0BR511292",
+    "wpm": 570.3422053231939,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-27T21:50:46Z",
+    "asin": "B0BR511292",
+    "wpm": 255.831105374758,
+    "period": "evening"
+  },
+  {
+    "start": "2023-11-28T04:24:39Z",
+    "asin": "B0BR511292",
+    "wpm": 460.2687546291398,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-28T04:57:03Z",
+    "asin": "B0BR511292",
+    "wpm": 657.8947368421052,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-28T05:17:37Z",
+    "asin": "B0BR511292",
+    "wpm": 418.7952952358322,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-28T06:13:02Z",
+    "asin": "B0BR511292",
+    "wpm": 5357.142857142857,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-28T06:17:17Z",
+    "asin": "B0BR511292",
+    "wpm": 331.2027890761185,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-29T04:33:36Z",
+    "asin": "B0BR511292",
+    "wpm": 399.7819371252044,
+    "period": "morning"
+  },
+  {
+    "start": "2023-11-30T04:17:44Z",
+    "asin": "B0BR511292",
+    "wpm": 482.68226012940727,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-01T03:07:23Z",
+    "asin": "B0BR511292",
+    "wpm": 469.4709008984702,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-01T04:09:33Z",
+    "asin": "B0B6B4WPSF",
+    "wpm": 466.9260700389105,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-01T04:18:55Z",
+    "asin": "B0BR511292",
+    "wpm": 579.3780687397709,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-01T21:27:55Z",
+    "asin": "B0BR511292",
+    "wpm": 1562.5,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-01T21:28:35Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 985.2216748768474,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-02T06:22:02Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 422.43173748010287,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-04T03:43:54Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 330.47391365490085,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-05T01:34:10Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 15.048154093097914,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-06T04:31:52Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 313.1887252058926,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-06T21:09:48Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 670.6408345752608,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-06T21:13:55Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 201.15535382710956,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-07T04:09:00Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 249.7769848349688,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-07T21:37:17Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 221.36720602962103,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-07T23:19:28Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 311.6531165311653,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-08T05:48:14Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 363.4777551613841,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-09T04:27:42Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 373.92837599562233,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-09T16:55:39Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 309.5620270580142,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-09T18:24:43Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 3468.208092485549,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-09T19:49:28Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 469.52679064628984,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-10T05:52:34Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 396.5429588205389,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-11T04:33:37Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 399.35810934023857,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-11T17:04:49Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 1456.3106796116506,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-11T17:06:23Z",
+    "asin": "B0BR511292",
+    "wpm": 361.37006389441706,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-11T17:25:35Z",
+    "asin": "B0BR511292",
+    "wpm": 4285.714285714286,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-11T19:24:41Z",
+    "asin": "B0BR511292",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-11T21:27:12Z",
+    "asin": "B0BR511292",
+    "wpm": 5583.501006036217,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-11T21:36:26Z",
+    "asin": "B0BR511292",
+    "wpm": 1226.158038147139,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-11T21:37:11Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 357.76753060899983,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-12T04:47:04Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 530.2885534110453,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-12T05:36:51Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 161.60310277957336,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-12T19:31:09Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-12T19:32:27Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 300.6012024048096,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-12T19:39:34Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 3750,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-12T19:42:40Z",
+    "asin": "B0B6B4WPSF",
+    "wpm": 333.3333333333333,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T05:21:59Z",
+    "asin": "B0C5LRCM2F",
+    "wpm": 1442.3076923076922,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-13T05:23:32Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 545.438550189144,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-13T06:50:41Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 324.02073732718895,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-13T20:24:28Z",
+    "asin": "B0BR511292",
+    "wpm": 193.7984496124031,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T20:37:44Z",
+    "asin": "B0BR511292",
+    "wpm": 247.99244213509684,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T20:46:26Z",
+    "asin": "B0BR511292",
+    "wpm": 335.3828954723309,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T20:56:05Z",
+    "asin": "B0BR511292",
+    "wpm": 2803.738317757009,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:00:51Z",
+    "asin": "B0BR511292",
+    "wpm": 3133.159268929504,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:03:03Z",
+    "asin": "B0BR511292",
+    "wpm": 186.56716417910448,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:07:42Z",
+    "asin": "B0BR511292",
+    "wpm": 182.26002430133659,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:09:32Z",
+    "asin": "B0BR511292",
+    "wpm": 13636.363636363636,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:12:20Z",
+    "asin": "B0BR511292",
+    "wpm": 588.4782159818294,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:53:58Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 1442.3076923076922,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:54:44Z",
+    "asin": "B0BR511292",
+    "wpm": 8861.671469740633,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T21:58:48Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 321.7615899838025,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-13T23:06:39Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 409.4058366575687,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-14T02:54:26Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 1685.3932584269662,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-14T02:54:44Z",
+    "asin": "B0BR511292",
+    "wpm": 11073.825503355705,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-14T03:04:10Z",
+    "asin": "B0BR511292",
+    "wpm": 10103.626943005182,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-14T03:14:11Z",
+    "asin": "B0BR511292",
+    "wpm": 9415.584415584415,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-14T03:22:56Z",
+    "asin": "B0BR511292",
+    "wpm": 9565.217391304348,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-14T03:38:56Z",
+    "asin": "B0BR511292",
+    "wpm": 3125,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-14T03:40:26Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 420.64276635664856,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-15T02:59:36Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 351.40200389245297,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-15T16:17:27Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 71.59050232669132,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T16:36:38Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 2631.5789473684213,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T16:39:04Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T16:52:46Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 154.87867836861125,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T16:56:02Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T16:57:11Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 3370.7865168539324,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:01:39Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 5769.230769230769,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:22:50Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 472.19307450157396,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:26:27Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 2777.777777777778,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:26:48Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:33:10Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 1162.7906976744187,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:35:58Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 1704.5454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:36:30Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 925.9259259259259,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:37:10Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 1327.4336283185842,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-15T17:47:10Z",
+    "asin": "B0B9SN8K6H",
+    "wpm": 4576.976421636616,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-17T04:44:55Z",
+    "asin": "B08FGV64B1",
+    "wpm": 643.7768240343347,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-17T05:34:51Z",
+    "asin": "B08FGV64B1",
+    "wpm": 204.19739081111743,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-18T01:47:31Z",
+    "asin": "B08FGV64B1",
+    "wpm": 446.42857142857144,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-18T01:52:39Z",
+    "asin": "B08FGV64B1",
+    "wpm": 955.4140127388536,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-19T04:28:46Z",
+    "asin": "B08FGV64B1",
+    "wpm": 1762.708913649025,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-19T04:48:09Z",
+    "asin": "B0B399L6KP",
+    "wpm": 1992.7479603638524,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-20T05:21:36Z",
+    "asin": "B0B399L6KP",
+    "wpm": 4637.3850868232885,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-20T05:48:21Z",
+    "asin": "B08FGV64B1",
+    "wpm": 8549.222797927461,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-20T05:51:38Z",
+    "asin": "B08FGV64B1",
+    "wpm": 9135.559921414539,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-20T05:52:43Z",
+    "asin": "B08FGV64B1",
+    "wpm": 4918.032786885246,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-20T05:54:32Z",
+    "asin": "B08FGV64B1",
+    "wpm": 3750,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-21T06:14:42Z",
+    "asin": "B09Y467GZY",
+    "wpm": 483.74271072627675,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-21T18:32:43Z",
+    "asin": "B09Y467GZY",
+    "wpm": 330.90262883755133,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T04:15:44Z",
+    "asin": "B09Y467GZY",
+    "wpm": 295.3143457146607,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-22T16:45:30Z",
+    "asin": "B09Y467GZY",
+    "wpm": 239.0438247011952,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T16:56:55Z",
+    "asin": "B09Y467GZY",
+    "wpm": 7894.736842105262,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T17:00:28Z",
+    "asin": "B09Y467GZY",
+    "wpm": 25000,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T17:09:47Z",
+    "asin": "B09Y467GZY",
+    "wpm": 2586.206896551724,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T17:10:12Z",
+    "asin": "B09Y467GZY",
+    "wpm": 165.71533787516114,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T17:19:23Z",
+    "asin": "B09Y467GZY",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T17:19:30Z",
+    "asin": "B09Y467GZY",
+    "wpm": 6818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T17:22:31Z",
+    "asin": "B09Y467GZY",
+    "wpm": 5769.230769230769,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T18:21:01Z",
+    "asin": "B09Y467GZY",
+    "wpm": 199.74353915959753,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-22T20:25:47Z",
+    "asin": "B09Y467GZY",
+    "wpm": 3125,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-23T05:11:25Z",
+    "asin": "B09Y467GZY",
+    "wpm": 1127.8195488721803,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-23T05:12:57Z",
+    "asin": "B09Y467GZY",
+    "wpm": 417.12646214963587,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-23T18:10:53Z",
+    "asin": "B09Y467GZY",
+    "wpm": 1056.338028169014,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-23T18:12:04Z",
+    "asin": "B0B7NGCGHG",
+    "wpm": 321.8884120171674,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-23T18:13:02Z",
+    "asin": "B09Y94K74X",
+    "wpm": 463.06504961411247,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-23T18:20:08Z",
+    "asin": "B09S3WWY98",
+    "wpm": 8418.367346938776,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-24T23:13:59Z",
+    "asin": "B09S3WWY98",
+    "wpm": 5625,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-24T23:14:22Z",
+    "asin": "B09Y467GZY",
+    "wpm": 738.9162561576355,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-24T23:14:51Z",
+    "asin": "B09Y467GZY",
+    "wpm": 626.1510128913444,
+    "period": "evening"
+  },
+  {
+    "start": "2023-12-25T04:48:00Z",
+    "asin": "B09Y467GZY",
+    "wpm": 145.08420573509332,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-26T03:34:05Z",
+    "asin": "B09Y467GZY",
+    "wpm": 342.2888142598812,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-26T07:54:49Z",
+    "asin": "B09Y467GZY",
+    "wpm": 489.19690175295557,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T00:52:05Z",
+    "asin": "B09Y467GZY",
+    "wpm": 4411.764705882353,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T00:54:35Z",
+    "asin": "B09Q2F1X14",
+    "wpm": 949.367088607595,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T02:40:08Z",
+    "asin": "B09Y467GZY",
+    "wpm": 352.46727089627393,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T02:45:27Z",
+    "asin": "B09Y467GZY",
+    "wpm": 320.5128205128205,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T03:09:03Z",
+    "asin": "B09Y467GZY",
+    "wpm": 2188.7159533073927,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T03:10:51Z",
+    "asin": "B09Y94K74X",
+    "wpm": 589.3909626719056,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-27T03:39:59Z",
+    "asin": "B09Y467GZY",
+    "wpm": 539.8749763212729,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-29T04:49:54Z",
+    "asin": "B09Y467GZY",
+    "wpm": 1282.051282051282,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-29T04:53:08Z",
+    "asin": "B003XT60E0",
+    "wpm": 276.08901779240335,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-30T05:22:53Z",
+    "asin": "B003XT60E0",
+    "wpm": 367.1834433647355,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-31T04:33:54Z",
+    "asin": "B003XT60E0",
+    "wpm": 418.1184668989547,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-31T04:49:13Z",
+    "asin": "B003XT60E0",
+    "wpm": 625,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-31T04:49:53Z",
+    "asin": "B09Y467GZY",
+    "wpm": 502.51256281407035,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-31T04:53:56Z",
+    "asin": "B09Y467GZY",
+    "wpm": 700.9345794392523,
+    "period": "morning"
+  },
+  {
+    "start": "2023-12-31T05:08:13Z",
+    "asin": "B09S3WWY98",
+    "wpm": 364.2191142191142,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-01T04:07:38Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 377.54624209786937,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-01T10:23:28Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 416.420555227407,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-01T18:36:32Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 199.1916859122402,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-02T03:45:10Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 366.35944700460834,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-02T04:36:07Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 322.38132337533244,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-02T22:34:45Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 198.65670229874186,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T04:01:57Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 484.5366991685111,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-03T18:49:32Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 1041.6666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T19:09:49Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 181.8181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T19:30:11Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 24375,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T19:30:22Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 3061.2244897959185,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T19:41:55Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 934.5794392523363,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:05:37Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 3488.3720930232557,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:08:51Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 115.38461538461539,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:16:55Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 3197.6744186046512,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:18:16Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 24.979184013322232,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:30:03Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 1293.103448275862,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:30:37Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 862.0689655172414,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T20:39:11Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 10169.49152542373,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T21:31:33Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 1041.6666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-03T21:32:45Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 240.43715846994536,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-04T03:06:24Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 1027.3972602739725,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-04T04:02:09Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 251.65865934568748,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-04T04:51:22Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 395.12238434900996,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-05T02:01:50Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 746.2686567164179,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-05T02:03:44Z",
+    "asin": "B07LF64DZ2",
+    "wpm": 262.77372262773724,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-05T10:07:01Z",
+    "asin": "B07LF64DZ2",
+    "wpm": 266.21968053638335,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-05T21:12:47Z",
+    "asin": "B07LF64DZ2",
+    "wpm": 925.9259259259259,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-05T21:13:23Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 125.33073388107506,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-06T05:37:55Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 233.45234825597365,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-06T17:18:06Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 248.32153039639473,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-06T18:05:09Z",
+    "asin": "B0B7R4Q5DJ",
+    "wpm": 478.3841247342311,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-07T21:09:52Z",
+    "asin": "B0BST5X6GS",
+    "wpm": 172.49310027598898,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-08T04:11:24Z",
+    "asin": "B0BST5X6GS",
+    "wpm": 1562.5,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-08T04:17:34Z",
+    "asin": "B000JMKNV0",
+    "wpm": 295.82262594872407,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-08T20:22:26Z",
+    "asin": "B000JMKNV0",
+    "wpm": 197.78770786023003,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-09T00:48:25Z",
+    "asin": "B000JMKNV0",
+    "wpm": 297.3414179104478,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-09T02:52:05Z",
+    "asin": "B000JMKNV0",
+    "wpm": 209.91147211828056,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-09T04:32:16Z",
+    "asin": "B000JMKNV0",
+    "wpm": 277.7015907844213,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-09T21:23:16Z",
+    "asin": "B000JMKNV0",
+    "wpm": 223.58026531524817,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-09T23:07:37Z",
+    "asin": "B000JMKNV0",
+    "wpm": 47.214353163361665,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-10T02:37:16Z",
+    "asin": "B000JMKNV0",
+    "wpm": 409.806906953911,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-10T05:02:02Z",
+    "asin": "B09S3WWY98",
+    "wpm": 964.6302250803859,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-10T17:04:47Z",
+    "asin": "B0927NRBFB",
+    "wpm": 125.58869701726844,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-10T18:32:55Z",
+    "asin": "B0927NRBFB",
+    "wpm": 349.37888198757764,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-11T03:53:03Z",
+    "asin": "B0927NRBFB",
+    "wpm": 298.3129886161021,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-12T05:31:06Z",
+    "asin": "B0927NRBFB",
+    "wpm": 372.2084367245658,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-12T05:33:59Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 238.4737678855326,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-12T05:38:26Z",
+    "asin": "B0927NRBFB",
+    "wpm": 366.44951140065143,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-12T05:57:01Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 156.9584931984653,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-12T19:59:08Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 97.2762645914397,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-12T20:25:30Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 113.223083785082,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-13T05:04:20Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 249.75984630163305,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-14T05:03:29Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 165.1073197578426,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-15T04:07:01Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 369.87860394537176,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-15T04:16:04Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 374.16305632138636,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-15T04:29:02Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 1388.888888888889,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-15T04:29:29Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 273.6074084467518,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-15T18:22:54Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 306.5917220235054,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-15T18:26:21Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 172.9628816165166,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-15T22:29:55Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 274.1896173531562,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-16T00:09:17Z",
+    "asin": "B08TF1VTGX",
+    "wpm": 260.0317144623324,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-16T02:16:43Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 1048.951048951049,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-16T02:18:11Z",
+    "asin": "B0BJSGV831",
+    "wpm": 879.7653958944281,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-16T02:19:23Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 486.2236628849271,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-16T02:24:47Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 291.71528588098016,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-16T04:22:47Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 409.42808516104174,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-16T19:41:57Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 177.62646634348516,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-16T21:38:02Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 121.06537530266344,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-16T21:40:11Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 194.8051948051948,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-16T21:56:30Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 249.5840266222962,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-16T21:56:56Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 2000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-17T02:05:25Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 1181.1023622047244,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-17T03:55:20Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 444.0174491067719,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-17T22:36:48Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 274.11863245260037,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-18T03:55:52Z",
+    "asin": "B07WG8L7WC",
+    "wpm": 706.0785767234988,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-18T04:43:15Z",
+    "asin": "B0927NRBFB",
+    "wpm": 1401.8691588785045,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-18T04:44:56Z",
+    "asin": "B0BJSGV831",
+    "wpm": 252.23331581713086,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-19T04:48:08Z",
+    "asin": "B0BJSGV831",
+    "wpm": 127.32245590870508,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-19T05:06:00Z",
+    "asin": "B0BL6271NP",
+    "wpm": 303.3244358165494,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-19T22:20:18Z",
+    "asin": "B0BL6271NP",
+    "wpm": 194.14334250121343,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-20T04:49:18Z",
+    "asin": "B0BL6271NP",
+    "wpm": 7500,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-20T04:50:34Z",
+    "asin": "B0BJSGV831",
+    "wpm": 288.8620180034932,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-21T06:07:27Z",
+    "asin": "B0BJSGV831",
+    "wpm": 135.44018058690745,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-22T04:06:16Z",
+    "asin": "B0BJSGV831",
+    "wpm": 315.39599719648004,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-22T20:52:53Z",
+    "asin": "B0BJSGV831",
+    "wpm": 179.58097771865647,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-22T21:26:25Z",
+    "asin": "B0BJSGV831",
+    "wpm": 295.11715256662495,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-23T04:07:12Z",
+    "asin": "B0BJSGV831",
+    "wpm": 340.2358968885094,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-23T21:03:09Z",
+    "asin": "B0BJSGV831",
+    "wpm": 192.2433968572384,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-24T04:47:04Z",
+    "asin": "B0BJSGV831",
+    "wpm": 294.07971107958207,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-25T01:42:40Z",
+    "asin": "B0BJSGV831",
+    "wpm": 166.22340425531917,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-25T05:13:30Z",
+    "asin": "B0BJSGV831",
+    "wpm": 218.14563453589832,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-25T20:32:30Z",
+    "asin": "B0BJSGV831",
+    "wpm": 1630.4347826086957,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-25T20:33:06Z",
+    "asin": "B0C3C886FY",
+    "wpm": 4740.406320541761,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-25T20:33:58Z",
+    "asin": "B0C7RK8P8K",
+    "wpm": 1535.8361774744028,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-25T20:34:53Z",
+    "asin": "B0BJSGV831",
+    "wpm": 89.44010494305647,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-25T21:03:53Z",
+    "asin": "B0BJSGV831",
+    "wpm": 179.45886250690228,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-25T21:28:42Z",
+    "asin": "B0BJSGV831",
+    "wpm": 212.6905352711804,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T04:35:21Z",
+    "asin": "B0BJSGV831",
+    "wpm": 342.2425032594524,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-26T05:02:57Z",
+    "asin": "B0BJSGV831",
+    "wpm": 233.9409299151964,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-26T19:05:31Z",
+    "asin": "B0C592RHNC",
+    "wpm": 297.029702970297,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T19:06:41Z",
+    "asin": "B0C592RHNC",
+    "wpm": 1056.338028169014,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T19:19:18Z",
+    "asin": "B0C3C886FY",
+    "wpm": 328.0839895013123,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T19:25:32Z",
+    "asin": "B0C3C886FY",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T19:25:34Z",
+    "asin": "B0C3C886FY",
+    "wpm": 144.27040395713107,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T19:43:06Z",
+    "asin": "B0C3C886FY",
+    "wpm": 179.7175866495507,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T20:14:03Z",
+    "asin": "B0C3C886FY",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T21:01:42Z",
+    "asin": "B0BJSGV831",
+    "wpm": 1083.0324909747292,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T21:03:09Z",
+    "asin": "B0C3C886FY",
+    "wpm": 350.55829654635164,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-26T21:09:41Z",
+    "asin": "B0C3C886FY",
+    "wpm": 144.74465558194774,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-27T02:51:50Z",
+    "asin": "B0C3C886FY",
+    "wpm": 387.5968992248062,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-27T02:58:44Z",
+    "asin": "B0C3C886FY",
+    "wpm": 310.4850527549824,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-27T09:37:03Z",
+    "asin": "B0C3C886FY",
+    "wpm": 278.68091035764047,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-27T15:16:17Z",
+    "asin": "B0C3C886FY",
+    "wpm": 198.80715705765408,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-27T17:58:10Z",
+    "asin": "B0C3C886FY",
+    "wpm": 433.8349331433123,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T00:31:05Z",
+    "asin": "B0C3C886FY",
+    "wpm": 249.704297542384,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-29T01:09:58Z",
+    "asin": "B0C3C886FY",
+    "wpm": 219.50029808682459,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-29T02:17:42Z",
+    "asin": "B0C3C886FY",
+    "wpm": 178.37929667591595,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-29T04:28:43Z",
+    "asin": "B0C3C886FY",
+    "wpm": 298.4170919470634,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-29T14:41:24Z",
+    "asin": "B0C3C886FY",
+    "wpm": 492.831541218638,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T14:47:06Z",
+    "asin": "B0C3C886FY",
+    "wpm": 2830.188679245283,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T14:47:56Z",
+    "asin": "B0C7RK8P8K",
+    "wpm": 617.283950617284,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T18:15:18Z",
+    "asin": "B0C592RHNC",
+    "wpm": 292.39766081871346,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T18:33:05Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 4085.9088528025145,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T21:12:35Z",
+    "asin": "B0C592RHNC",
+    "wpm": 735.2941176470588,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-29T21:13:01Z",
+    "asin": "B0BH4QWM85",
+    "wpm": 3890.2743142144636,
+    "period": "evening"
+  },
+  {
+    "start": "2024-01-30T03:57:07Z",
+    "asin": "B0BJSGV831",
+    "wpm": 355.1442100731812,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-30T04:04:56Z",
+    "asin": "B0C592RHNC",
+    "wpm": 297.12215965364044,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-31T05:21:06Z",
+    "asin": "B0C592RHNC",
+    "wpm": 230.6361714395541,
+    "period": "morning"
+  },
+  {
+    "start": "2024-01-31T21:39:17Z",
+    "asin": "B0C592RHNC",
+    "wpm": 190.50917907862834,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-01T04:24:16Z",
+    "asin": "B0C592RHNC",
+    "wpm": 248.31867563372995,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-01T22:10:26Z",
+    "asin": "B0C592RHNC",
+    "wpm": 212.28417775261818,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T04:14:44Z",
+    "asin": "B0C592RHNC",
+    "wpm": 214.35376309939664,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-02T05:13:32Z",
+    "asin": "B0C592RHNC",
+    "wpm": 162.33180621189712,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-02T17:47:34Z",
+    "asin": "B0C592RHNC",
+    "wpm": 2912.621359223301,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T17:47:47Z",
+    "asin": "B0C592RHNC",
+    "wpm": 71.01432122144632,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T18:02:15Z",
+    "asin": "B0C592RHNC",
+    "wpm": 233.82696804364772,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T18:04:26Z",
+    "asin": "B0C592RHNC",
+    "wpm": 6818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T18:04:36Z",
+    "asin": "B0C592RHNC",
+    "wpm": 8823.529411764706,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T18:04:43Z",
+    "asin": "B0C592RHNC",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-02T18:16:51Z",
+    "asin": "B0C592RHNC",
+    "wpm": 43.72667910447761,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-03T06:11:35Z",
+    "asin": "B0C592RHNC",
+    "wpm": 181.91102316971978,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-03T21:01:56Z",
+    "asin": "B0C592RHNC",
+    "wpm": 125.6164511026333,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-04T00:26:11Z",
+    "asin": "B0C592RHNC",
+    "wpm": 256.7613830879836,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-04T01:10:20Z",
+    "asin": "B0C592RHNC",
+    "wpm": 287.3938602220771,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-04T02:08:13Z",
+    "asin": "B0C592RHNC",
+    "wpm": 527.4650483509628,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-05T04:41:33Z",
+    "asin": "B0C7RK8P8K",
+    "wpm": 215.61017680034496,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-06T22:00:45Z",
+    "asin": "B0C7RK8P8K",
+    "wpm": 842.6966292134831,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-06T22:01:26Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 255.56150513556926,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T04:12:50Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 322.21379833206976,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-07T18:13:41Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 43.115837884449554,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T18:19:51Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 212.26415094339623,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T18:27:35Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 25000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T18:27:37Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 4285.714285714285,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T18:28:04Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 111.69024571854058,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T19:12:20Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 5357.142857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T19:16:12Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 1973.6842105263156,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T19:44:38Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 3125,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-07T21:04:53Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 165.45855657106839,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-08T04:18:12Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 351.1883646683221,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-08T05:40:52Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 48.92367906066536,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-08T20:35:07Z",
+    "asin": "B09LHBX5KV",
+    "wpm": 226.7106347897774,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-08T21:24:38Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 249.68789013732834,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-09T04:39:15Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 100.79290417954576,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-09T04:56:19Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 655.6291390728477,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-10T03:59:27Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 237.2948388372553,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-11T17:54:44Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 1500,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-11T17:55:11Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 1147.227533460803,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-11T21:10:38Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 201.91622456251486,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-12T04:34:20Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 293.6971655892591,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-12T18:07:07Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 235.40321717730143,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-12T20:25:40Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 288.7803486755321,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-12T21:38:57Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 352.76107647593903,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-13T01:38:57Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 299.3697478991597,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-13T02:29:27Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 491.5155061439438,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-13T02:51:21Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 264.70305130426414,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-13T03:48:07Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 358.85167464114835,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-13T19:41:35Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 673.5896716250351,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-13T21:39:01Z",
+    "asin": "B0BDMPQ2FC",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-13T21:40:42Z",
+    "asin": "B0044781ZQ",
+    "wpm": 563.9097744360902,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-13T21:41:15Z",
+    "asin": "B0BJSGV831",
+    "wpm": 1829.268292682927,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-13T21:41:29Z",
+    "asin": "B0044781ZQ",
+    "wpm": 268.76737720111214,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-14T04:41:51Z",
+    "asin": "B0044781ZQ",
+    "wpm": 332.4228212132145,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-14T21:16:38Z",
+    "asin": "B0044781ZQ",
+    "wpm": 175.67145534041222,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-15T02:33:34Z",
+    "asin": "B0044781ZQ",
+    "wpm": 463.3204633204633,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-15T02:36:01Z",
+    "asin": "B07HDT9JFX",
+    "wpm": 802.8492092237112,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-15T03:17:44Z",
+    "asin": "B0044781ZQ",
+    "wpm": 25.004167361226873,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-15T03:59:28Z",
+    "asin": "B0044781ZQ",
+    "wpm": 268.3619188473557,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-15T22:35:10Z",
+    "asin": "B0044781ZQ",
+    "wpm": 141.75014175014175,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-15T23:32:43Z",
+    "asin": "B0044781ZQ",
+    "wpm": 176.2829481224467,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-16T03:44:42Z",
+    "asin": "B0044781ZQ",
+    "wpm": 230.81821076090418,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-16T20:03:34Z",
+    "asin": "B0044781ZQ",
+    "wpm": 167.00299213694245,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-17T20:31:39Z",
+    "asin": "B0044781ZQ",
+    "wpm": 102.54073145721773,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-17T22:26:15Z",
+    "asin": "B0044781ZQ",
+    "wpm": 242.16984178237,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-17T22:31:37Z",
+    "asin": "B0BJSGV831",
+    "wpm": 395.873320537428,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-17T22:38:38Z",
+    "asin": "B0044781ZQ",
+    "wpm": 25.004167361226873,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-18T06:36:08Z",
+    "asin": "B0044781ZQ",
+    "wpm": 148.7357461576599,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-19T07:53:18Z",
+    "asin": "B0044781ZQ",
+    "wpm": 266.374177373864,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-20T04:47:41Z",
+    "asin": "B0044781ZQ",
+    "wpm": 290.09531703273933,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-20T04:59:58Z",
+    "asin": "B0CLQVQSVL",
+    "wpm": 232.6893244958398,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-20T22:52:28Z",
+    "asin": "B0CLQVQSVL",
+    "wpm": 423.7288135593221,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-21T04:35:08Z",
+    "asin": "B0CLQVQSVL",
+    "wpm": 299.56427015250546,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-21T04:44:31Z",
+    "asin": "B0044781ZQ",
+    "wpm": 229.16313019860806,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-21T21:46:52Z",
+    "asin": "B0044781ZQ",
+    "wpm": 195.41427826993225,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-22T00:37:18Z",
+    "asin": "B0044781ZQ",
+    "wpm": 405.8441558441558,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-22T03:09:31Z",
+    "asin": "B0044781ZQ",
+    "wpm": 329.0312707238688,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-22T03:48:01Z",
+    "asin": "B0044781ZQ",
+    "wpm": 156.59955257270693,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-22T18:05:11Z",
+    "asin": "B0CLQVQSVL",
+    "wpm": 1500,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-22T20:08:35Z",
+    "asin": "B0044781ZQ",
+    "wpm": 201.63831127914304,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-22T21:20:17Z",
+    "asin": "B0044781ZQ",
+    "wpm": 671.7850287907869,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-22T21:45:05Z",
+    "asin": "B0BJSGV831",
+    "wpm": 83.957181837263,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-23T05:19:53Z",
+    "asin": "B0BJSGV831",
+    "wpm": 311.4382785956965,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-23T05:29:16Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 188.9168765743073,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-27T22:27:47Z",
+    "asin": "B0B72HGHW8",
+    "wpm": 1388.888888888889,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-27T23:40:57Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 135.1497459184777,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-28T02:06:49Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 76.58270932607216,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-28T03:50:22Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 349.9222395023328,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-28T03:58:19Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 245.9016393442623,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-28T20:09:16Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 87.77062609713283,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-28T20:21:41Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 194.07426575236124,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-28T21:32:14Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 122.7621483375959,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-29T01:45:39Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 236.6035723806985,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-29T03:55:41Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 311.7185023422916,
+    "period": "morning"
+  },
+  {
+    "start": "2024-02-29T20:35:35Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 210.78517477604075,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-29T21:17:55Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 121.61223071577484,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-29T21:38:34Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 126.36899747262005,
+    "period": "evening"
+  },
+  {
+    "start": "2024-02-29T23:41:48Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 175.48524328636003,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-01T00:22:33Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 192.45847886520778,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T01:32:01Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 47.19207173194903,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T01:45:04Z",
+    "asin": "B0C1YCKNK1",
+    "wpm": 276.1506276150627,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T02:26:58Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 560.8974358974359,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T02:30:13Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 1084.9056603773586,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T04:19:14Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 3764.478764478765,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T04:20:23Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 380.46924540266326,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T04:25:44Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 408.0604534005038,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T04:42:25Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 190.2552204176334,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-01T22:17:24Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 63.00756090730887,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-01T23:07:41Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 207.64119601328906,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-02T04:48:41Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 197.20120365771714,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-02T20:13:23Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 152.51652262328417,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-03T05:13:17Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 245.740498034076,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-03T05:19:18Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 365.6307129798903,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-03T05:35:51Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 126.29451881788329,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-03T18:52:23Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 557.6208178438662,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-03T18:53:55Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 252.28681026851578,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-04T22:35:00Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 815.2173913043479,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-04T22:35:32Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 135.4679802955665,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-05T05:15:30Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 321.54340836012864,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-05T05:28:04Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 274.3960133728632,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-05T21:28:46Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 200.63310892148556,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-06T04:23:56Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 219.6577273621402,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-07T00:02:40Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 384.2869342442357,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-07T00:19:14Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 313.7710633352702,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-07T04:42:59Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 185.2150104686745,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-07T21:31:15Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 217.15526601520088,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-08T04:12:14Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 235.36105938340577,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-08T21:39:03Z",
+    "asin": "B0C7RPT9B3",
+    "wpm": 440.8831659610203,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-08T22:29:59Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 228.3633956644051,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-08T23:52:24Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 329.7911322828875,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-09T02:15:48Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 189.65050121918182,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-09T04:52:45Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 358.0585270975157,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-09T14:13:06Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 202.11093644733887,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-10T00:15:55Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 226.81451612903226,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-10T00:48:23Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 476.3795156808257,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-10T04:08:42Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 351.77424935604165,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-10T17:58:30Z",
+    "asin": "B0BJP5QFFM",
+    "wpm": 605.9122345308771,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-10T18:29:13Z",
+    "asin": "B0C6KMGND1",
+    "wpm": 1598.5790408525754,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-10T18:30:52Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 587.0841487279844,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-10T18:45:30Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 191.55206286836938,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-10T21:16:46Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 618.5567010309279,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-13T03:41:08Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 153.47409543298298,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-13T04:03:23Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 360.3800371300644,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-13T05:01:51Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 258.6994014406006,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-13T20:40:45Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 156.44555694618273,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-14T03:50:12Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 157.013258897418,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-15T02:50:04Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 358.3840139009557,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-15T02:58:28Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 210.5755732335049,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-16T03:10:38Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 238.79266428935304,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-17T03:59:50Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 143.48413234301148,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-18T03:46:25Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 365.55645816409424,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-18T03:52:49Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 504.8076923076923,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-18T04:10:16Z",
+    "asin": "B00BUP18U0",
+    "wpm": 439.0128144280968,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-19T03:43:07Z",
+    "asin": "B00BUP18U0",
+    "wpm": 323.9202657807309,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-19T03:53:21Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 198.72335300493796,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-19T19:54:50Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 12000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-19T19:56:39Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 646.551724137931,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-19T21:16:29Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 122.69938650306747,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-19T21:20:35Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 87.53501400560225,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-20T03:40:02Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 275.2924982794219,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-20T03:55:01Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 246.01254663987862,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-20T04:35:48Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 225.9036144578313,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-21T03:13:47Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 253.61330788110172,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-22T03:48:48Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 302.9223093371347,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-23T04:25:30Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 258.2563781499452,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-23T04:52:09Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 397.6670201484623,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-23T04:55:41Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 298.09220985691576,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-23T12:37:30Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 255.61827670678454,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-23T13:07:25Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 379.0489317711923,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-23T16:08:37Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 363.7465898757199,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-26T02:51:10Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 432.5883201153569,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-26T02:53:34Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 1181.1023622047244,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-26T02:53:52Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 299.07184599518735,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-28T03:51:26Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 362.82519888196083,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-28T16:31:57Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 267.9102996626315,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-28T16:33:20Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 1034.4827586206895,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-28T18:50:53Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 291.2100016522553,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-28T21:07:11Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 327.709673504066,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-28T23:41:16Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 278.1166138082459,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-29T04:25:59Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 296.198782293895,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-29T17:14:28Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 272.31467473524964,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-29T21:32:54Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 154.51970126191088,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-29T22:02:23Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 165.0346572780284,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-29T22:41:57Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 248.94128419365913,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-30T00:15:18Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 276.7983655715557,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T01:17:52Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 168.97488569345967,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T01:44:01Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 488.02530501581566,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T02:04:21Z",
+    "asin": "B0BTZRQHJM",
+    "wpm": 1674.4186046511627,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T02:07:12Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 402.1447721179624,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T02:08:08Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 1621.6216216216214,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T03:53:04Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 238.51076207097148,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-30T19:03:55Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 160.13198757763976,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-31T03:20:34Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 270.1557368365293,
+    "period": "morning"
+  },
+  {
+    "start": "2024-03-31T16:45:30Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 355.10133379525377,
+    "period": "evening"
+  },
+  {
+    "start": "2024-03-31T17:43:46Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 149.55134596211366,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-01T03:26:11Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 426.54028436018956,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-01T03:33:28Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 467.70601336302894,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-01T03:41:08Z",
+    "asin": "B007RMYE9M",
+    "wpm": 350.3777510128107,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-01T04:47:54Z",
+    "asin": "B007RMYE9M",
+    "wpm": 259.8246183825918,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-01T21:07:45Z",
+    "asin": "B007RMYE9M",
+    "wpm": 402.05104300198116,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-01T21:22:16Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 443.60801182954697,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-01T21:37:07Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 428.57142857142856,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T03:38:59Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 337.67250660663603,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-02T03:56:17Z",
+    "asin": "B007RMYE9M",
+    "wpm": 442.47787610619474,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-02T19:26:36Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 3529.4117647058824,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T19:27:15Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 3658.536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T19:35:01Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 14000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T19:42:48Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 12676.05633802817,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T20:57:43Z",
+    "asin": "B007RMYE9M",
+    "wpm": 1351.3513513513515,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T20:58:07Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 242.62784621127287,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T23:00:35Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 561.5640599001664,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T23:12:34Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 4345.917471466199,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T23:26:26Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 11980.830670926518,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-02T23:31:17Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 522.1023320570832,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-03T00:09:15Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 7614.213197969544,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-03T00:14:40Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 824.7089262613196,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-03T00:32:42Z",
+    "asin": "B008J2G5Y6",
+    "wpm": 8767.123287671233,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-03T03:17:48Z",
+    "asin": "B007RMYE9M",
+    "wpm": 1807.2289156626505,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-03T03:18:02Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 358.15891079048976,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-03T20:19:46Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 386.92312005831883,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-03T23:05:16Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 435.164565754796,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-04T03:22:03Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 420.5786142147075,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-04T19:13:53Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 25000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-04T19:13:56Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 4285.714285714285,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-04T19:14:13Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 684.931506849315,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-04T22:07:47Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 363.5788808093582,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-04T23:26:52Z",
+    "asin": "B0BXTB6HSN",
+    "wpm": 847.0894874022589,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-04T23:42:48Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 1074.6268656716418,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-05T03:38:37Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 234.4773683363601,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-05T21:13:39Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 185.6331214490634,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-06T14:07:10Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 1393.188854489164,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-07T04:29:25Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 200.66392508546795,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-07T17:05:38Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 250.2254283137962,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-08T03:47:40Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 338.3915825093851,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-08T05:32:55Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 284.11781418694954,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-08T06:14:50Z",
+    "asin": "B0BQGHJM5L",
+    "wpm": 903.2211259431225,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-08T06:40:58Z",
+    "asin": "B007RMYE9M",
+    "wpm": 546.9462169553327,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-08T06:49:51Z",
+    "asin": "B007RMYE9M",
+    "wpm": 218.6588921282799,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-08T23:23:24Z",
+    "asin": "B007RMYE9M",
+    "wpm": 2941.176470588235,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-08T23:23:37Z",
+    "asin": "B00BUP18U0",
+    "wpm": 489.3964110929853,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-09T03:36:50Z",
+    "asin": "B00BUP18U0",
+    "wpm": 118.21366024518387,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-09T22:19:35Z",
+    "asin": "B00BUP18U0",
+    "wpm": 2173.913043478261,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-10T03:04:27Z",
+    "asin": "B00BUP18U0",
+    "wpm": 13.287270794578793,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-10T03:38:07Z",
+    "asin": "B00BUP18U0",
+    "wpm": 501.43266475644697,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-10T03:42:27Z",
+    "asin": "B0BJSGV831",
+    "wpm": 363.30608537693007,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-10T03:48:39Z",
+    "asin": "B092T8QDYW",
+    "wpm": 260.37146328762367,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-11T03:39:28Z",
+    "asin": "B092T8QDYW",
+    "wpm": 315.3178071582674,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-11T04:10:28Z",
+    "asin": "B092T8QDYW",
+    "wpm": 1562.5,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-11T04:15:58Z",
+    "asin": "B092T8QDYW",
+    "wpm": 186.63348738002134,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-11T22:16:12Z",
+    "asin": "B092T8QDYW",
+    "wpm": 1388.888888888889,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-11T22:37:10Z",
+    "asin": "B0BQGJVCMT",
+    "wpm": 25.037556334501755,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-12T03:11:45Z",
+    "asin": "B0BQGJVCMT",
+    "wpm": 276.1074978524972,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-12T03:53:28Z",
+    "asin": "B00BUP18U0",
+    "wpm": 24.9708673214583,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-13T22:34:07Z",
+    "asin": "B00BUP18U0",
+    "wpm": 275.22935779816515,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-14T21:37:52Z",
+    "asin": "B00BUP18U0",
+    "wpm": 1923.076923076923,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-14T21:38:13Z",
+    "asin": "B0BJSGV831",
+    "wpm": 76.6311487374106,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-15T20:34:21Z",
+    "asin": "B0BJSGV831",
+    "wpm": 1923.076923076923,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-15T20:36:29Z",
+    "asin": "B003B4IW2U",
+    "wpm": 972.1322099805573,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-15T20:45:04Z",
+    "asin": "B003B4IW2U",
+    "wpm": 2689.2430278884462,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-16T03:33:43Z",
+    "asin": "B003B4IW2U",
+    "wpm": 525.3940455341506,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-16T03:35:55Z",
+    "asin": "B0BJSGV831",
+    "wpm": 170.2739518692296,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-18T03:56:32Z",
+    "asin": "B0BJSGV831",
+    "wpm": 254.10924408223067,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-18T16:56:14Z",
+    "asin": "B0BJSGV831",
+    "wpm": 128.71853546910754,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-19T03:38:08Z",
+    "asin": "B0BJSGV831",
+    "wpm": 151.3928138877675,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-19T17:03:03Z",
+    "asin": "B0BJSGV831",
+    "wpm": 116.0726478219309,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-20T04:00:32Z",
+    "asin": "B0BJSGV831",
+    "wpm": 88.87133405747012,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-21T03:45:01Z",
+    "asin": "B0BJSGV831",
+    "wpm": 228.32208635648686,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-21T04:29:54Z",
+    "asin": "B0BJSGV831",
+    "wpm": 177.83548805961723,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-21T21:41:42Z",
+    "asin": "B0BJSGV831",
+    "wpm": 370.8281829419036,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-22T03:34:54Z",
+    "asin": "B0BJSGV831",
+    "wpm": 394.7368421052632,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-22T03:36:25Z",
+    "asin": "B0BJSGV831",
+    "wpm": 88.33922261484099,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-22T21:41:20Z",
+    "asin": "B0BJSGV831",
+    "wpm": 521.9660722053067,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-22T21:45:17Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 93.59790340696368,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-22T23:40:02Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 322.215941209723,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-23T03:12:56Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 215.42993923770945,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-24T02:56:49Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 224.0389906453895,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-25T03:31:09Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 231.31922052432358,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-25T20:57:35Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 222.71714922048997,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-26T03:25:01Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 266.48055326438674,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-26T18:16:19Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 161.97732317475553,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-26T23:49:31Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 34.538337554685704,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-27T03:38:30Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 334.3239227340267,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-27T15:45:20Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 604.8387096774194,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-27T15:48:19Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 10606.060606060606,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-27T18:46:13Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 529.3258700413726,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-27T19:09:48Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 188.0484747179273,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-28T23:04:32Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 1395.3488372093022,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-28T23:13:51Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 161.72506738544473,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-28T23:18:05Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 3191.4893617021276,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-28T23:21:41Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 2752.293577981651,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T03:21:00Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 156.7070622649394,
+    "period": "morning"
+  },
+  {
+    "start": "2024-04-29T18:01:01Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 113.46444780635402,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:03:16Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:06:13Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 1597.6331360946745,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:08:20Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 2586.206896551724,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:09:49Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 37500,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:12:05Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 7653.061224489796,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:23:40Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 3214.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:41:32Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 4143.646408839779,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:46:31Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 6308.41121495327,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:52:19Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 7627.118644067797,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:53:14Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 2173.913043478261,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:54:01Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 6818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T18:58:42Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 313.73460376481523,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T19:08:17Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 5585.106382978723,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T19:17:30Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 435.09789702683105,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T19:22:10Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 3846.153846153846,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-29T21:02:26Z",
+    "asin": "B0C772ZLMQ",
+    "wpm": 1094.890510948905,
+    "period": "evening"
+  },
+  {
+    "start": "2024-04-30T03:20:52Z",
+    "asin": "B092T8QDYW",
+    "wpm": 103.07254343771474,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-01T03:40:36Z",
+    "asin": "B092T8QDYW",
+    "wpm": 307.29833546734955,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-01T03:47:25Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 309.5638950741324,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-02T03:33:51Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 229.5662155052848,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-03T03:08:07Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 254.00153207273314,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-04T17:43:50Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 540.9582689335394,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-04T17:47:16Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 283.26180257510725,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-04T19:31:25Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 27.86809103576405,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T03:48:38Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 580.2707930367504,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-05T03:52:23Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 313.10398144569,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-05T18:17:47Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 769.2307692307692,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:23:49Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 16964.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:31:44Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 6818.181818181818,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:34:29Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 10135.135135135135,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:43:19Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 13043.478260869566,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:46:31Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 8881.57894736842,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:48:29Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 3658.536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:51:53Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 12972.972972972972,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T18:57:56Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T19:05:23Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 1657.4585635359115,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T19:05:48Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T20:44:18Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 3488.3720930232557,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T21:10:26Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 1685.3932584269662,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T21:11:04Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 895.5223880597015,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T21:11:16Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 1685.3932584269662,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-05T21:11:45Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 164.3321073636435,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-06T03:36:56Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 329.28064842958463,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-06T04:56:29Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 344.7219243143864,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-06T05:22:10Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 1013.5135135135135,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-06T05:22:28Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 351.5802207772569,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-06T05:49:50Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 212.13679609154025,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-07T02:42:22Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 176.97026899480886,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-07T20:44:08Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 136.25525150448507,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T02:38:32Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 151.8602885345482,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-08T02:58:51Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 312.97904956566174,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-08T16:27:06Z",
+    "asin": "B00BUP18U0",
+    "wpm": 19.362333806634826,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T16:48:49Z",
+    "asin": "B00BUP18U0",
+    "wpm": 834.8794063079778,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T16:49:55Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 785.3403141361256,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T16:51:17Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 147.34774066797644,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T20:00:02Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T20:00:05Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 175.55059048834983,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T20:16:06Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 58.4339696143358,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T22:36:54Z",
+    "asin": "B00BUP18U0",
+    "wpm": 2238.805970149254,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T22:43:23Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 581.3648981302048,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-08T23:15:18Z",
+    "asin": "B0C4PX8RD7",
+    "wpm": 2027.027027027027,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-09T03:36:46Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 217.44860305745914,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-09T21:43:41Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 104.10641989589358,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-10T03:15:49Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 800,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-10T03:45:44Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 341.7375455650061,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-10T21:28:03Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 286.3589031586255,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-10T21:50:19Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 545.2795894365445,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-10T22:33:29Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 222.2457402899778,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-11T03:53:44Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 24.61437479488021,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-11T04:50:02Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 572.5190839694657,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-11T04:54:42Z",
+    "asin": "B0BJSGV831",
+    "wpm": 2750.352609308886,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-11T04:55:59Z",
+    "asin": "B0BJSGV831",
+    "wpm": 609.7560975609756,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-11T04:57:00Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 1376.1467889908256,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-11T04:57:59Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 398.5122210414453,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-11T20:33:21Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 35.0426352061675,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-11T21:05:10Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 371.6375648890986,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-11T21:19:22Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 24.995834027662056,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-11T22:39:02Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 126.1715933669791,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-11T22:55:07Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 168.6599202698559,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-11T23:37:32Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 219.22088393892054,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-12T04:22:10Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 139.90971159944783,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-12T17:12:08Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 117.37089201877934,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-13T02:31:54Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 402.2795843110962,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-13T02:42:02Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 72.17610970768675,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-13T02:58:00Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 543.7409376510392,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-13T03:05:18Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 441.0143329658214,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-13T03:10:13Z",
+    "asin": "B0BPNP7YQB",
+    "wpm": 468.75,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-13T03:16:17Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 117.15699036709191,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-14T01:44:16Z",
+    "asin": "B0C97G1ZR6",
+    "wpm": 769.9757869249395,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-14T08:00:48Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 97.21322099805575,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-15T03:44:37Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 735.2941176470588,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-15T03:45:31Z",
+    "asin": "B081914PR7",
+    "wpm": 242.71844660194174,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-16T02:45:34Z",
+    "asin": "B081914PR7",
+    "wpm": 77.13668620796051,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-17T00:32:52Z",
+    "asin": "B081914PR7",
+    "wpm": 453.85779122541607,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-17T00:59:31Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 160.25641025641025,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-17T02:51:49Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 610.3074141048825,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-17T02:55:35Z",
+    "asin": "B092T8QDYW",
+    "wpm": 354.83067729083666,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-18T03:01:21Z",
+    "asin": "B081914PR7",
+    "wpm": 113.32973556395035,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-20T03:43:20Z",
+    "asin": "B081914PR7",
+    "wpm": 249.27295388450352,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-21T04:33:36Z",
+    "asin": "B092T8QDYW",
+    "wpm": 1470.5882352941176,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-21T04:33:56Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 36.64345914254306,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-21T04:37:01Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 379.56666139490744,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-21T04:50:13Z",
+    "asin": "B081914PR7",
+    "wpm": 97.65625,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-21T21:33:21Z",
+    "asin": "B092T8QDYW",
+    "wpm": 125.83892617449665,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-22T03:54:38Z",
+    "asin": "B092T8QDYW",
+    "wpm": 315.9224936815501,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-22T04:10:16Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 277.6492364645997,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-22T22:03:20Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 893.5219657483246,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-22T22:05:46Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 1724.1379310344828,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-22T22:06:42Z",
+    "asin": "B07QN87LQB",
+    "wpm": 189.01606636564108,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-23T03:37:55Z",
+    "asin": "B07QN87LQB",
+    "wpm": 140.7459535538353,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-23T21:17:06Z",
+    "asin": "B07QN87LQB",
+    "wpm": 95.67546880979717,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-23T21:31:16Z",
+    "asin": "B07QN87LQB",
+    "wpm": 138.64640032864332,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-24T17:26:46Z",
+    "asin": "B07QN87LQB",
+    "wpm": 141.7546070247283,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-25T04:02:23Z",
+    "asin": "B07QN87LQB",
+    "wpm": 488.33423765599565,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-25T04:08:39Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 302.13139969237534,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-25T15:33:22Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 199.85565980125463,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-25T19:02:05Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 622.4066390041494,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-26T04:16:30Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 186.55116219229777,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-26T15:13:31Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 164.85163352982315,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-26T21:36:53Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 280.98982423681775,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-26T23:16:18Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 368.8918986349218,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T01:16:58Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 465.39379474940336,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-27T03:43:21Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 253.55958650282815,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-27T17:09:46Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 307.79964295241416,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T19:40:29Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 234.30635555989457,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T20:05:28Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 230.06134969325154,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T20:37:38Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 240.6516105146242,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T21:23:43Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 105.85744530698659,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T21:52:13Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 204.16710292116008,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T22:58:35Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 592.7620632279534,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T23:20:16Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 304.43253774963466,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-27T23:42:44Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 321.4512088376445,
+    "period": "evening"
+  },
+  {
+    "start": "2024-05-28T00:45:42Z",
+    "asin": "B0CJ9TSSYB",
+    "wpm": 688.9966969446738,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-28T03:20:52Z",
+    "asin": "B07QN87LQB",
+    "wpm": 374.56780637725706,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-29T03:34:28Z",
+    "asin": "B07QN87LQB",
+    "wpm": 218.26118588577665,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-30T03:47:27Z",
+    "asin": "B0B8GZ58DK",
+    "wpm": 463.91752577319585,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-30T03:54:38Z",
+    "asin": "B092T8QDYW",
+    "wpm": 756.3025210084033,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-30T03:59:47Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 484.1997961264016,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-31T03:41:07Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 806.8459657701712,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-31T04:04:00Z",
+    "asin": "B09X34KMRM",
+    "wpm": 378.2523975088832,
+    "period": "morning"
+  },
+  {
+    "start": "2024-05-31T22:04:03Z",
+    "asin": "B09X34KMRM",
+    "wpm": 220.44415414761593,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-01T04:32:11Z",
+    "asin": "B09X34KMRM",
+    "wpm": 261.69099187268625,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-01T17:22:02Z",
+    "asin": "B09X34KMRM",
+    "wpm": 430.1515772224498,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-01T17:43:24Z",
+    "asin": "B09X34KMRM",
+    "wpm": 252.24215246636774,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-01T18:43:36Z",
+    "asin": "B09X34KMRM",
+    "wpm": 2238.805970149254,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-02T04:00:23Z",
+    "asin": "B09X34KMRM",
+    "wpm": 213.7158054711246,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-03T03:33:19Z",
+    "asin": "B09X34KMRM",
+    "wpm": 259.10544305193133,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-03T20:44:16Z",
+    "asin": "B09X34KMRM",
+    "wpm": 287.6480541455161,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-04T00:19:23Z",
+    "asin": "B09X34KMRM",
+    "wpm": 277.2268301478543,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-04T02:01:16Z",
+    "asin": "B09X34KMRM",
+    "wpm": 24.850894632206757,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-04T02:46:25Z",
+    "asin": "B09X34KMRM",
+    "wpm": 283.107895564643,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-04T03:57:31Z",
+    "asin": "B09X34KMRM",
+    "wpm": 229.12108326796843,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-04T19:50:12Z",
+    "asin": "B09X34KMRM",
+    "wpm": 159.42606616181746,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-04T22:57:50Z",
+    "asin": "B09X34KMRM",
+    "wpm": 238.433865975069,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-05T03:37:38Z",
+    "asin": "B09X34KMRM",
+    "wpm": 259.94865211810014,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-05T04:37:30Z",
+    "asin": "B09X34KMRM",
+    "wpm": 308.8130493309051,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-05T05:02:05Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 803.2128514056225,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-06T03:32:15Z",
+    "asin": "B0CDKLBD2W",
+    "wpm": 106.23229461756374,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-06T03:34:56Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 355.9149677981695,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-06T21:55:56Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 433.2230865980342,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-07T02:55:26Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 345.92403647926204,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-07T21:48:16Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 151.48454857604523,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-07T22:56:36Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 174.80819656210548,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-08T00:41:20Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 254.6689303904924,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-08T01:15:30Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 266.7578659370725,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-08T01:52:44Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 181.52813686121348,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-08T08:26:39Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 189.51358180669615,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-08T09:04:25Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 184.6087019474408,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-08T20:44:58Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 178.90510078320676,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-08T22:36:56Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 199.49019173223982,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-08T23:27:55Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 314.99692685925015,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-09T03:17:25Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 216.5317266051591,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-09T03:45:42Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 165.48984995586937,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-09T16:03:49Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 263.1655896371239,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-09T21:12:59Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 566.7369032914336,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-09T21:39:24Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 306.9446220744341,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-11T02:28:56Z",
+    "asin": "B0B3Y9JVMK",
+    "wpm": 890.9126905563255,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T02:38:22Z",
+    "asin": "B0CL5G23ZF",
+    "wpm": 1234.567901234568,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T02:39:25Z",
+    "asin": "B0CL5G23ZF",
+    "wpm": 2830.188679245283,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T02:39:47Z",
+    "asin": "B002C7Z57C",
+    "wpm": 2186.8250539956807,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T03:33:26Z",
+    "asin": "B0CGTHLBT9",
+    "wpm": 556.5862708719852,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T03:34:46Z",
+    "asin": "B002C7Z57C",
+    "wpm": 453.99515738498786,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T03:37:53Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 290.79568442346596,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T04:24:08Z",
+    "asin": "B0CL5G23ZF",
+    "wpm": 378.1194857574994,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-11T04:39:43Z",
+    "asin": "B002C7Z57C",
+    "wpm": 187.96992481203006,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-13T02:31:37Z",
+    "asin": "B002C7Z57C",
+    "wpm": 417.2461752433936,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-13T02:33:25Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 1127.8195488721803,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-13T02:33:43Z",
+    "asin": "B0CGTHLBT9",
+    "wpm": 295.90948651000866,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-13T03:02:52Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 152.4196621364156,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-14T04:27:27Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 202.45950809838033,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-14T20:20:40Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 112.58846236328544,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-15T21:46:27Z",
+    "asin": "B0BWGKNK7G",
+    "wpm": 1648.3516483516482,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-15T21:47:38Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 1153.8461538461538,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-15T23:00:58Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 461.36811023622045,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-15T23:32:25Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 6976.7441860465115,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-16T03:37:40Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 166.9263298464278,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-16T20:42:08Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 270.1972439881113,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-17T03:52:38Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 1829.268292682927,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-17T03:56:15Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 303.0497386396434,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-17T11:54:06Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 76.21951219512195,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-17T11:59:49Z",
+    "asin": "B09S3WWY98",
+    "wpm": 11538.461538461537,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-17T18:05:47Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 1840.4907975460123,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-17T18:15:52Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 4838.709677419355,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-18T02:51:19Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 178.53094536386308,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-19T03:50:35Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 226.5597769257581,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-20T04:11:01Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 324.77575007732753,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-20T04:22:44Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 220.47475564047915,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-20T21:23:26Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 246.78663239074552,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-21T03:12:13Z",
+    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
+    "wpm": 371.2488398473755,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-21T03:45:31Z",
+    "asin": "B0C7RK8P8K",
+    "wpm": 2400,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-21T03:45:57Z",
+    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
+    "wpm": 288.5386053967406,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-21T04:31:06Z",
+    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
+    "wpm": 1282.051282051282,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-21T04:31:27Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 360.9450196879102,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-21T20:08:24Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 66.74577276772472,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-21T20:19:47Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 152.74242073594075,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-21T22:35:29Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 134.4219854625112,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-25T04:26:38Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 248.4815019326339,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-25T17:21:51Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 245.49918166939443,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-25T18:04:38Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 115.2395585975695,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-25T19:57:49Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 215.18333620244448,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-25T21:10:14Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 445.91813400411615,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-26T05:08:38Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 173.2768579129765,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-28T04:12:22Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 24.626498111968477,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-29T03:58:35Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 1630.4347826086957,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-29T04:23:56Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 337.05701078582433,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-30T02:44:43Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 1470.5882352941176,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-30T04:05:38Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 246.0456942003515,
+    "period": "morning"
+  },
+  {
+    "start": "2024-06-30T17:11:32Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 492.25720438929346,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-30T21:15:48Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 292.0081967213115,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-30T22:09:17Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 447.2843450479233,
+    "period": "evening"
+  },
+  {
+    "start": "2024-06-30T22:54:40Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 446.8718967229394,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-01T02:47:00Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 231.67754471625727,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-01T21:30:07Z",
+    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
+    "wpm": 398.5174494883233,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-01T22:21:43Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 705.8437294812869,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-02T02:59:29Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 263.03562596483863,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-02T05:09:00Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 328.4763749684157,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-02T05:52:34Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 351.75367047308316,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-02T19:49:13Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 397.63188124061145,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-02T21:15:00Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 2205.8823529411766,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-02T21:19:12Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 298.5322166017083,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-03T02:14:29Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 124.5502352615555,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-03T02:26:48Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 275.68286963685915,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-05T03:58:15Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 299.49684529989617,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-06T04:12:53Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 24.822108224391858,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-06T20:01:25Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 137.53056234718827,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-07T05:15:30Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 330.1056338028169,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-07T15:58:46Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 162.03078584931137,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T01:27:17Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 212.40916713247623,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-08T20:05:27Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 367.4014696058784,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T20:19:45Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 145.91439688715954,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T21:42:37Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 400.14227280810957,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T22:00:29Z",
+    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T22:00:48Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 4411.764705882352,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T22:04:55Z",
+    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
+    "wpm": 320.5128205128205,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-08T22:05:47Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 192.51653667686838,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-09T02:43:55Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 226.89947272884433,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-09T21:45:11Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 385.60411311053986,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-09T22:27:54Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 24.715768660405338,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-10T03:44:29Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 258.91181988742966,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-10T20:24:17Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 86.81560365783076,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-11T03:02:38Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 67.28468899521532,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-11T03:16:39Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 171.83442798228197,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-12T03:26:06Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 294.0764598795687,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-12T19:15:43Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 629.1946308724832,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-12T19:17:46Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 3910.6145251396647,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-12T20:09:32Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 212.33734414983394,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-13T04:25:43Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 219.55165241506816,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-13T19:24:01Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 127.15456343599887,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-14T00:00:25Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 5714.285714285715,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-14T04:09:18Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 196.18993460335514,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-14T23:59:14Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 4054.054054054054,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-14T23:59:49Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 2631.578947368421,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-14T23:59:57Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 405.40540540540536,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-15T03:29:16Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 281.5211371607901,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-15T19:40:22Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 188.54584020740043,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-15T21:24:30Z",
+    "asin": "2C4B5A07F41247DAAF830F1590836876",
+    "wpm": 429.6747525290982,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-15T22:10:55Z",
+    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
+    "wpm": 1666.6666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-15T22:11:29Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1155.624036979969,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-15T22:12:42Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 320.5128205128205,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-15T22:19:29Z",
+    "asin": "15072C88D12543BE9BF38E06D831641A",
+    "wpm": 1166.4074650077762,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-16T03:10:37Z",
+    "asin": "15072C88D12543BE9BF38E06D831641A",
+    "wpm": 339.23303834808263,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-17T02:48:46Z",
+    "asin": "15072C88D12543BE9BF38E06D831641A",
+    "wpm": 234.9501383595259,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-17T10:48:59Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 131.23359580052494,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-17T10:54:57Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 677.2009029345372,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-17T11:41:55Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 3409.090909090909,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-17T19:47:26Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1981.3519813519813,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-17T22:38:46Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 343.2494279176201,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-17T22:39:24Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-17T22:39:31Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 182.67435252090607,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-18T00:19:33Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 1500,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-18T03:31:28Z",
+    "asin": "B0C7729CF8",
+    "wpm": 298.3095790520385,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-18T17:51:47Z",
+    "asin": "B0C7729CF8",
+    "wpm": 99.62049335863378,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-18T18:31:44Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 700.9345794392523,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-18T22:09:17Z",
+    "asin": "B0C7729CF8",
+    "wpm": 157.63120479693393,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-19T03:49:12Z",
+    "asin": "B0C7729CF8",
+    "wpm": 253.43189017951426,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-19T21:14:03Z",
+    "asin": "B0C7729CF8",
+    "wpm": 346.75399730302445,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-19T21:34:50Z",
+    "asin": "B0C7729CF8",
+    "wpm": 1260.5042016806722,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-19T21:35:10Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 119.38450654403961,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-20T03:42:28Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 294.11764705882354,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-20T03:52:15Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 874.1721854304635,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-20T18:48:51Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1595.7446808510638,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-20T18:49:07Z",
+    "asin": "B0C7729CF8",
+    "wpm": 144.97422680412373,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-21T04:37:58Z",
+    "asin": "B0C7729CF8",
+    "wpm": 111.00358626971025,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-21T16:38:20Z",
+    "asin": "B0C7729CF8",
+    "wpm": 329.903385437122,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-22T03:51:27Z",
+    "asin": "B0C7729CF8",
+    "wpm": 130.77593722755014,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-22T21:13:41Z",
+    "asin": "B0C7729CF8",
+    "wpm": 171.05815977432326,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-23T01:13:15Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 3461.5384615384614,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-23T01:13:31Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 3488.3720930232557,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-23T01:13:47Z",
+    "asin": "B0C7729CF8",
+    "wpm": 1339.2857142857142,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-23T01:16:23Z",
+    "asin": "B0C7729CF8",
+    "wpm": 301.20481927710847,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-23T03:17:44Z",
+    "asin": "B0C7729CF8",
+    "wpm": 462.24961479198765,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-23T04:05:41Z",
+    "asin": "B0C7729CF8",
+    "wpm": 192.01228878648234,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-23T20:54:03Z",
+    "asin": "B0C7729CF8",
+    "wpm": 41.73042147725692,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-24T02:50:19Z",
+    "asin": "B0C7729CF8",
+    "wpm": 303.35715248752865,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-24T03:03:08Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 300.40964952207554,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-24T03:21:38Z",
+    "asin": "B0C7729CF8",
+    "wpm": 207.3556695405435,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-24T20:13:32Z",
+    "asin": "B0C7729CF8",
+    "wpm": 97.63313609467455,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-24T20:45:16Z",
+    "asin": "B0C7729CF8",
+    "wpm": 369.5491500369549,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-24T21:47:56Z",
+    "asin": "B0C7729CF8",
+    "wpm": 10873.146622734761,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-25T00:58:40Z",
+    "asin": "B0C7729CF8",
+    "wpm": 1851.8518518518517,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-25T01:17:28Z",
+    "asin": "B0C7729CF8",
+    "wpm": 2054.794520547945,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-25T03:25:35Z",
+    "asin": "B0C7729CF8",
+    "wpm": 249.0566037735849,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-25T17:16:26Z",
+    "asin": "B0C7729CF8",
+    "wpm": 3203.240058910162,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-25T20:40:31Z",
+    "asin": "B0C7729CF8",
+    "wpm": 79.1765637371338,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-25T23:20:05Z",
+    "asin": "B0C7729CF8",
+    "wpm": 977.1986970684038,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-25T23:38:40Z",
+    "asin": "B0C7729CF8",
+    "wpm": 2564.102564102564,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T03:02:50Z",
+    "asin": "B0C7729CF8",
+    "wpm": 1775.1479289940828,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-26T03:22:42Z",
+    "asin": "B0C7729CF8",
+    "wpm": 262.23776223776224,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-26T03:23:52Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 219.76009522937457,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-26T19:10:25Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 334.9282296650718,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T19:17:23Z",
+    "asin": "B0C7729CF8",
+    "wpm": 439.88269794721407,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T19:18:00Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 61.09150149334781,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T21:49:28Z",
+    "asin": "B0C7729CF8",
+    "wpm": 2586.206896551724,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T22:45:53Z",
+    "asin": "B0C7729CF8",
+    "wpm": 2112.676056338028,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T22:57:45Z",
+    "asin": "B0C7729CF8",
+    "wpm": 4945.054945054945,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-26T23:20:06Z",
+    "asin": "B0C7729CF8",
+    "wpm": 2439.0243902439024,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-27T02:19:32Z",
+    "asin": "B0C7729CF8",
+    "wpm": 3488.3720930232557,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-27T03:54:39Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 132.6259946949602,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-27T04:05:00Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 343.08119588302566,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-27T17:07:10Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 11.076650420912715,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-27T17:07:20Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 134.0382753741902,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-28T03:26:56Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 276.4745308310992,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-28T21:39:14Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 103.7241924330732,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-29T03:25:21Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 441.4361389052384,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-29T03:28:38Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 301.4469453376206,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-29T03:49:26Z",
+    "asin": "B078R46LCY",
+    "wpm": 279.06275140788415,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-29T20:27:47Z",
+    "asin": "B078R46LCY",
+    "wpm": 181.01795982111167,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-30T03:22:07Z",
+    "asin": "B078R46LCY",
+    "wpm": 290.3225806451613,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-30T03:27:34Z",
+    "asin": "B0CH1NHWNW",
+    "wpm": 291.76904176904173,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-30T03:44:08Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 248.4815019326339,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-30T21:39:33Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 215.10927551196008,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-31T02:37:42Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 281.42589118198873,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-31T10:17:54Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 831.7929759704252,
+    "period": "morning"
+  },
+  {
+    "start": "2024-07-31T14:24:39Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1485.148514851485,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-31T14:27:53Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 6835.128417564209,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-31T21:34:29Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1724.1379310344828,
+    "period": "evening"
+  },
+  {
+    "start": "2024-07-31T21:34:44Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 104.4984076433121,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-01T03:17:40Z",
+    "asin": "9CF67106DC3A4A8F90A685EE6DAA2B9F",
+    "wpm": 393.1332721792688,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-01T03:30:58Z",
+    "asin": "B0CQ38FNR9",
+    "wpm": 308.89621087314663,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-01T03:51:38Z",
+    "asin": "B097XBXQ1T",
+    "wpm": 813.5883528404225,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-01T03:58:05Z",
+    "asin": "B0C7RK8P8K",
+    "wpm": 1635.5140186915887,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-01T04:00:04Z",
+    "asin": "B078R46LCY",
+    "wpm": 189.4736842105263,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-01T23:58:31Z",
+    "asin": "B078R46LCY",
+    "wpm": 107.76968079646926,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-02T04:56:21Z",
+    "asin": "B078R46LCY",
+    "wpm": 113.49566652909616,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-02T19:56:45Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 900,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-04T03:15:39Z",
+    "asin": "B078R46LCY",
+    "wpm": 92.9054054054054,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-04T17:18:06Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 688.0733944954128,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-04T17:19:14Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 651.1123168746609,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-04T20:27:02Z",
+    "asin": "B078R46LCY",
+    "wpm": 106.33270321361059,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-04T20:34:19Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 213.036877418091,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-04T23:44:40Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 333.5292155710497,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T02:03:34Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 1491.2280701754385,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-05T02:14:43Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 122.93066710375349,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-05T03:09:41Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 214.6969844832634,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-05T15:56:55Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 1036.8663594470045,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T15:58:43Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T15:58:48Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:01:20Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 9677.41935483871,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:01:25Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 4411.764705882353,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:02:08Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 13636.363636363636,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:03:07Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 4838.709677419355,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:04:09Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 11538.461538461537,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:04:53Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 2500,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:07:03Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 5769.230769230769,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:09:18Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:12:06Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 1481.4814814814813,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:14:42Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:15:05Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 8333.333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:16:22Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 2083.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:17:05Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:18:18Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 8571.42857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:19:07Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 10344.827586206897,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:41:57Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 5172.413793103448,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T16:45:10Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T17:18:00Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 18750,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T18:50:29Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 478.4688995215311,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T18:55:55Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T20:03:08Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 252.52525252525254,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T20:04:20Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 7894.736842105262,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T21:40:54Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 618.4001157239983,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T23:12:11Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 331.56498673740055,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T23:25:27Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 2230.483271375465,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T23:28:20Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 4166.666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T23:28:59Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 5172.413793103448,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-05T23:31:53Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 9493.67088607595,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-06T02:46:18Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 540.9791723018664,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-06T20:31:02Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 3191.4893617021276,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-07T21:05:17Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 309.0107535742244,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-08T03:12:46Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 1006.7114093959732,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-08T03:14:09Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 1327.4336283185842,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-08T03:15:23Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 145.56682840758714,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-09T02:39:31Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 2205.8823529411766,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-09T02:40:03Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 202.88548241659151,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-09T03:00:48Z",
+    "asin": "B0CL3FMNKJ",
+    "wpm": 391.83978106729694,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-09T03:14:47Z",
+    "asin": "B078R46LCY",
+    "wpm": 986.8421052631578,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-09T03:19:22Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-09T03:32:53Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 446.12875371773964,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-12T02:14:46Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 326.6736104535555,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-12T21:01:46Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 141.83055975794252,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-13T02:56:53Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 314.0346342724218,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-13T21:30:21Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 299.07287409032,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-14T02:27:35Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 224.323025156225,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-14T21:54:39Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 223.65805168986083,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-15T02:59:34Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 211.19324181626186,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-15T19:36:34Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 245.17087667161962,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-15T22:33:11Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 439.5095998149434,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-16T02:02:44Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 24.983344437041975,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-16T03:05:37Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 230.67583974099557,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-16T03:50:31Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 229.5386042198006,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-16T20:57:15Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 249.9679528265607,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-16T23:39:58Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 713.0509939498704,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-17T00:01:30Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 24.995834027662056,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-17T03:11:58Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 221.58911047799936,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-17T18:02:27Z",
+    "asin": "15DCD55913DF40F990711B36DCA2CC83",
+    "wpm": 733.4148238693189,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-17T19:59:11Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 284.0203625527688,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-17T22:43:10Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 2307.6923076923076,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-18T03:15:09Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 285.77115559599633,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-18T15:03:01Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 602.4096385542169,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-18T21:31:40Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 318.22294325024177,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-18T22:26:17Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 358.4154265353175,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-19T01:32:53Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 206.97811945594322,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-19T04:50:36Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 202.27628243163062,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-19T16:59:59Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 286.0169491525424,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-19T19:22:51Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 416.84035014589415,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-19T19:46:55Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 222.85977765254367,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-19T21:08:37Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 226.94185150295453,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-19T23:25:20Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 190.01490312965723,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-20T03:36:07Z",
+    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
+    "wpm": 335.345405767941,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-20T03:58:56Z",
+    "asin": "43CBE4C46DC444119BB4453B4EF2473B",
+    "wpm": 4742.096505823627,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-20T04:08:12Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 237.70613578963005,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-20T22:39:35Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 304.8367429887549,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-21T01:29:13Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 275.33622789367786,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-21T13:50:33Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 5357.142857142857,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-21T13:50:38Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 16666.666666666668,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-21T21:44:28Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 226.50833962523166,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-21T22:18:14Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 150.7537688442211,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-22T03:22:33Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 239.73239174874558,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-22T04:12:24Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 284.984860179303,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-22T21:33:03Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 338.1424706943192,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-23T01:08:40Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 233.4966849236091,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-23T10:46:40Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 4285.714285714285,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-23T10:46:49Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 2036.1990950226243,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-24T03:23:10Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 248.745363299149,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-24T04:25:03Z",
+    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
+    "wpm": 262.6418265863566,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-24T04:49:34Z",
+    "asin": "0A7C416992574F5E9E06498F5AC4E33E",
+    "wpm": 584.0071877807726,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-24T16:58:04Z",
+    "asin": "0A7C416992574F5E9E06498F5AC4E33E",
+    "wpm": 284.7740792304772,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-25T03:07:57Z",
+    "asin": "0A7C416992574F5E9E06498F5AC4E33E",
+    "wpm": 165.3196179279941,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-25T11:04:27Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 710.9004739336492,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-26T02:17:35Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 552.1472392638036,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-26T02:41:30Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1171.875,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-26T02:49:28Z",
+    "asin": "0A7C416992574F5E9E06498F5AC4E33E",
+    "wpm": 234.91334307788682,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-27T04:48:44Z",
+    "asin": "0A7C416992574F5E9E06498F5AC4E33E",
+    "wpm": 329.46344524631314,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-27T05:02:28Z",
+    "asin": "A7E4563B33564CA4904BBD751938CA1C",
+    "wpm": 7527.881040892194,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-27T05:03:28Z",
+    "asin": "A7E4563B33564CA4904BBD751938CA1C",
+    "wpm": 97.15025906735751,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-27T05:05:44Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 3191.4893617021276,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-27T05:05:54Z",
+    "asin": "A7E4563B33564CA4904BBD751938CA1C",
+    "wpm": 4347.826086956522,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-27T12:09:08Z",
+    "asin": "BBD0AD78686243CD9C5F343AFC7E83D6",
+    "wpm": 9230.76923076923,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-27T21:59:04Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 3061.2244897959185,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-27T22:05:07Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 1632.2089227421109,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-27T22:06:30Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 251.33282559025133,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-28T02:44:15Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 259.0371286551072,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-28T20:49:42Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 223.3747560850365,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-28T23:30:16Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 46.47560030983734,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-29T03:18:16Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 138.0368098159509,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-29T21:29:48Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 242.98961009943022,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-30T01:42:10Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 128.15533980582526,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-30T03:15:09Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 100.67114093959732,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-30T03:39:40Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 223.70606379012304,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-30T20:54:53Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 294.91833030852996,
+    "period": "evening"
+  },
+  {
+    "start": "2024-08-31T03:36:14Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 324.1254453074812,
+    "period": "morning"
+  },
+  {
+    "start": "2024-08-31T19:15:05Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 145.16129032258064,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T04:25:54Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 257.23797034197514,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-01T15:58:40Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 24.55393681453593,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T16:50:10Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 1714.2857142857142,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T16:51:48Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 7857.142857142858,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T18:32:04Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 11.257880516361453,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T18:36:40Z",
+    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
+    "wpm": 4411.764705882353,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T18:54:25Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 265.1180406514329,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-01T19:18:14Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 186.33540372670808,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-02T05:06:57Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 262.2107969151671,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-02T14:22:22Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 3571.428571428571,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-02T14:43:46Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 1145.0381679389313,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-02T15:11:49Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 73.25411036952629,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-02T17:30:52Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 5660.377358490566,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-02T17:38:43Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 135.58709210883126,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-03T01:28:02Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 5555.555555555555,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-03T01:28:12Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 240.3846153846154,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-03T01:47:22Z",
+    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
+    "wpm": 309.5549288023664,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-03T02:41:14Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 341.54835253147604,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-03T11:10:17Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-04T02:58:16Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 7031.25,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-05T02:52:17Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 164.94845360824743,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-05T11:19:11Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 370.3703703703703,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-06T03:25:04Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 284.2650911320439,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-07T03:57:04Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 56.92599620493359,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-07T04:36:01Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 280.65997618642626,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-07T21:57:58Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 57.42725880551301,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-08T04:02:45Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 279.4897520424251,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-09T02:52:02Z",
+    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
+    "wpm": 427.24899121765964,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-09T02:59:32Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 870.3329969727548,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-09T23:12:52Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 176.70817906428812,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-10T03:05:08Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 355.96236969234684,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-10T23:28:01Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 379.57971173946527,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-11T00:34:34Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 142.59787399533315,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-11T03:13:24Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 337.91735314885176,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-11T16:59:20Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-12T01:58:46Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 200.85300535608013,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-12T07:24:29Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 221.65114037905556,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-12T22:12:25Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 10714.285714285714,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-12T22:12:36Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 3092.7835051546394,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-12T22:13:00Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 244.39152776037096,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-13T00:28:37Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 437.1053909664886,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-13T00:32:07Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 167.3894848969033,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-13T02:58:49Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 136.64313368253246,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-13T04:18:18Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 83.66904245429191,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-14T02:56:22Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 44.97751124437781,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-15T02:52:34Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 261.32404181184666,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-15T23:55:02Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 259.63377972123527,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-16T01:35:11Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 205.9025394646534,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-16T02:13:25Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 24.37043054427295,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-16T03:15:09Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 159.60276644795175,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-17T02:22:39Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 261.78010471204186,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-17T22:58:22Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 213.31849378593955,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-18T00:12:43Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 45.83651642475172,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-18T00:54:05Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 277.8225157030118,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-18T02:20:36Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 157.55431477693625,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-19T00:18:46Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 223.94249377937518,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-19T02:56:43Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 255.3822495606327,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-19T03:38:25Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 192.01228878648232,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-19T04:24:54Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 260.29950510958287,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-19T23:41:18Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 650.0541711809317,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-19T23:43:23Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 231.98050426469212,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-20T01:50:34Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 166.54770402093743,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-20T02:20:48Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 117.85834549332137,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-21T03:17:37Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 595.2380952380952,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-21T03:19:25Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 148.69888475836433,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-21T04:03:32Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 162.62366174278358,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-21T21:07:47Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 331.90160093713394,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-22T01:44:14Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 1764.7058823529412,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-22T01:44:48Z",
+    "asin": "B0CQFXKTPW",
+    "wpm": 3876.739562624254,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-22T01:45:43Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 315.466890998678,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-22T01:46:35Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 472.4409448818898,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-22T02:16:24Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 669.6428571428571,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-22T02:40:28Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 302.14126198712614,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-22T20:57:52Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 595.2380952380953,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-22T20:58:45Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 9836.065573770491,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-22T20:59:46Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 588.2352941176471,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-22T21:39:05Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 4687.5,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-22T21:55:15Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 3370.7865168539324,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-22T21:58:54Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 3879.3103448275865,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-23T01:45:09Z",
+    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
+    "wpm": 1500,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-23T01:45:32Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 250.74294205052007,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-23T02:30:45Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 106.33270321361059,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-23T18:47:32Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 703.6747458952306,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-23T19:26:59Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 5113.636363636364,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-24T02:18:22Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 281.09627547434997,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-24T03:11:47Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 408.149721263605,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-24T13:28:40Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 326.797385620915,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-24T18:52:03Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 2830.188679245283,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-24T20:02:24Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 4891.304347826087,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-24T22:21:30Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 260.9186215974801,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-25T01:33:38Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 704.7768206734534,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-25T03:17:46Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 2941.176470588235,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-25T03:55:50Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 470.52996532937095,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-26T20:58:36Z",
+    "asin": "B0CQJHF3HQ",
+    "wpm": 678.119349005425,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-26T21:20:36Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 2459.0163934426228,
+    "period": "evening"
+  },
+  {
+    "start": "2024-09-27T03:42:17Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 482.7290281055567,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-27T03:50:17Z",
+    "asin": "1D1B7C54B5BC44799C3596D902FF13AC",
+    "wpm": 395.778364116095,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-28T04:06:03Z",
+    "asin": "1D1B7C54B5BC44799C3596D902FF13AC",
+    "wpm": 420.54006197432494,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-28T04:18:35Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 471.1282918579367,
+    "period": "morning"
+  },
+  {
+    "start": "2024-09-30T20:48:12Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 771.4915503306391,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-01T03:06:31Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 449.80008884940025,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-01T20:21:48Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 1714.2857142857142,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-01T23:29:48Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 354.4154255094722,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-02T02:36:23Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 400.96741344195516,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-02T02:49:42Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 847.4576271186442,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-02T02:50:21Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 366.21546449100686,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-02T17:36:23Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 307.42954739538857,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-02T20:01:07Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 3947.368421052631,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-02T20:04:59Z",
+    "asin": "B0CQHM2KL5",
+    "wpm": 223.88059701492537,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-02T21:37:05Z",
+    "asin": "CFB210D125DE496195B7AE70BACDA51C",
+    "wpm": 1704.5454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-02T21:39:01Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 191.80709686258393,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-03T01:32:35Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 318.5401144584818,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-03T02:43:44Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 387.40104429846724,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-03T18:48:39Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 2083.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-03T18:51:23Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 1517.3410404624278,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-03T19:31:19Z",
+    "asin": "B0CQHM2KL5",
+    "wpm": 1190.4761904761906,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-03T19:31:37Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 2173.913043478261,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-03T20:46:01Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 3409.090909090909,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-03T22:17:20Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 333.441393044042,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-04T04:00:08Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 417.22468321829604,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-05T04:00:12Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 261.2512191723562,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-06T03:50:52Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 505.4897271442548,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-06T04:06:29Z",
+    "asin": "B0CQHM2KL5",
+    "wpm": 187.33413123796637,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-06T20:49:49Z",
+    "asin": "B0CQHM2KL5",
+    "wpm": 307.17472390843267,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-07T03:50:13Z",
+    "asin": "B0CQHM2KL5",
+    "wpm": 723.7635705669481,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-07T03:53:36Z",
+    "asin": "B0CGZFPKTZ",
+    "wpm": 805.1197357555739,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-07T03:58:49Z",
+    "asin": "B097XBXQ1T",
+    "wpm": 1194.6902654867256,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-07T04:18:12Z",
+    "asin": "ZPWKCGLPBBCYS2KJQQBLM6VSBP3NWID3",
+    "wpm": 392.56739073540956,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-07T22:20:35Z",
+    "asin": "ZPWKCGLPBBCYS2KJQQBLM6VSBP3NWID3",
+    "wpm": 25.050100200400802,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-07T22:37:30Z",
+    "asin": "ZPWKCGLPBBCYS2KJQQBLM6VSBP3NWID3",
+    "wpm": 2000,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-07T22:38:02Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 303.6375781866764,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-08T02:54:06Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 309.35194733084796,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-08T03:15:09Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 388.90634820867376,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-09T02:24:23Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 700.9345794392523,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-09T02:25:08Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 293.69039348196804,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-09T05:57:10Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 24.98750624687656,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-09T19:20:30Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 591.7159763313609,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-10T01:16:14Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 3169.0140845070423,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-10T02:51:40Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 1357.9387186629526,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-11T03:12:16Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 356.78447987512544,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-12T12:54:19Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 51.440329218106996,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-15T03:17:02Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 3550.2958579881656,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-15T03:18:36Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 242.69390231570432,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-15T22:32:39Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 470.479704797048,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-15T22:41:49Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 348.4067648980184,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-16T03:23:22Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 192.54001812141345,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-16T19:32:03Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 301.2804418779814,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-16T21:22:17Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 1595.7446808510638,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-16T21:22:54Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 160.08537886873,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-17T17:16:31Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 218.52237252861605,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-17T22:19:57Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 295.763897722936,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-18T02:32:26Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 206.04395604395606,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-19T02:40:33Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 469.55036994877634,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-20T02:48:22Z",
+    "asin": "B0CW1J3Y5G",
+    "wpm": 923.820352472996,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-20T03:07:58Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 257.2163475278651,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-20T20:37:54Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 224.26553038797934,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-21T03:23:58Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 232.04419889502762,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-21T22:16:03Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 259.6465921384782,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-22T03:00:42Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 369.9136868064118,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-22T03:14:29Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 455.44554455445547,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-22T03:48:43Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 253.83574007220216,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-22T21:54:09Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 283.7404391808537,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-22T23:04:45Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 131.57894736842104,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-22T23:42:00Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 1048.951048951049,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-23T01:46:33Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 382.7344248352116,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-23T01:54:35Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 320.4661325564457,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-23T03:12:52Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 501.2531328320802,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-23T03:27:09Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 296.6381015161503,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-23T09:06:27Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 151.08783239323125,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-24T02:56:44Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 347.537020247809,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-24T21:36:03Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 433.73493975903614,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-24T21:39:41Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 248.81516587677723,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-24T23:45:12Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 216.9482611268161,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-25T03:15:46Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 232.9674880927728,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-25T03:32:55Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 264.0612622128334,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-27T17:25:08Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 222.45037645448323,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-28T03:14:38Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 797.872340425532,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-28T03:18:35Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 427.96005706134093,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-28T03:50:17Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 147.52163650668766,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-29T02:39:04Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 435.5995900239153,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-29T02:48:59Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 85.1063829787234,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-29T07:26:53Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 322.32526577697354,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-29T07:49:56Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 824.1758241758241,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-29T07:50:30Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 84.29672447013486,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-29T22:08:23Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 14563.106796116504,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-29T22:09:08Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 484.33048433048435,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-29T23:23:19Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 168.70782304423895,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-30T02:35:29Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 265.3607179841215,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-30T20:25:55Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 337.32756016513946,
+    "period": "evening"
+  },
+  {
+    "start": "2024-10-31T02:39:17Z",
+    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
+    "wpm": 449.231958264902,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-31T03:00:39Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 319.4207836456559,
+    "period": "morning"
+  },
+  {
+    "start": "2024-10-31T03:24:39Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 199.07100199071002,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-01T03:16:33Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 267.82035434693034,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-02T03:26:19Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 421.3483146067416,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-02T03:35:47Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 265.9875495189587,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-03T04:17:49Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 430.1515772224498,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-03T04:26:21Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 188.90101586768535,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-03T17:13:39Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 281.70072115384613,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-04T04:24:01Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 1578.9473684210527,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-04T04:24:39Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 549.3355655540441,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-04T21:15:35Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 67.69971415676245,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-04T22:03:18Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 449.49431889124736,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-05T03:56:38Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 675.3354462249341,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-05T22:20:47Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 1524.6286161063329,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-05T22:23:08Z",
+    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
+    "wpm": 2036.1990950226245,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-05T22:30:53Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 2748.6910994764394,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-05T22:31:59Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 240.05761382731856,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-06T04:28:13Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 582.5242718446602,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-06T04:29:11Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 1819.1056910569105,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-06T17:15:37Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 84.3644544431946,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-06T17:18:55Z",
+    "asin": "B0BBC9K8C3",
+    "wpm": 6666.666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-07T02:35:43Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 1954.8941676679915,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-07T03:38:56Z",
+    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
+    "wpm": 1630.4347826086957,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-07T03:39:14Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 478.9006107717935,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-08T04:56:45Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1595.7446808510638,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-08T04:58:13Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 212.7522403455612,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-08T19:44:46Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 410.8338405356056,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-11T04:52:28Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 1181.1023622047244,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-11T04:52:53Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 437.23554301833565,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-12T04:30:03Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 367.64705882352945,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-13T04:17:47Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 259.74858902001023,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-14T03:41:32Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 180.05658921375291,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-14T08:05:40Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 305.6323679231553,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-14T12:27:58Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 1464.4351464435147,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-15T04:43:06Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 364.6005966191581,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-16T06:14:20Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 251.29982668977468,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-17T04:16:03Z",
+    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
+    "wpm": 539.568345323741,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-17T04:16:44Z",
+    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
+    "wpm": 38.47140292382662,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-17T04:27:21Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 6250,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-17T04:29:47Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 304.53563714902805,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-17T05:18:07Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 192.090395480226,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-18T03:57:13Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 359.1858454170547,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-18T04:41:39Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 202.0338069903697,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-19T01:20:38Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 179.44014674216444,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-19T04:30:51Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 250.26343519494205,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-19T05:08:51Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 177.7180996011216,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-20T04:05:54Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 231.37161841480778,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-21T02:46:59Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 153.71275421724735,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-22T04:26:16Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 188.9582648701939,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-23T03:40:17Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 123.83048981838193,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-23T04:00:36Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 247.77006937561944,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-23T04:05:49Z",
+    "asin": "B0CDWDLCNS",
+    "wpm": 459.946339593714,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-23T04:14:42Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 246.89422737782652,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-24T04:22:29Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 241.09867751780263,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-24T21:56:35Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 132.9198050509526,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-25T01:59:15Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 198.63961957503162,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-25T04:07:10Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 186.60287081339712,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-25T17:49:24Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 2912.621359223301,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-25T22:04:14Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 140.66219433023156,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-25T23:24:04Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 202.02020202020202,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-26T03:23:44Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 24.991669443518827,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-26T03:34:19Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 193.7105162123486,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-26T04:22:48Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 149.78853383458645,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-27T20:58:08Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 119.06651849499922,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-27T22:12:36Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2024-11-28T03:40:36Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 244.3415637860082,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-29T05:01:01Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 277.3326759521755,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-29T05:57:15Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 168.05781188728923,
+    "period": "morning"
+  },
+  {
+    "start": "2024-11-30T05:54:11Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 210.72743109213002,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-01T04:48:29Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 181.71245820613458,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-02T04:54:07Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 225.93526691887348,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-02T20:57:16Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 163.33197223356473,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-03T03:55:07Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 424.78760619690155,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-03T04:45:33Z",
+    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
+    "wpm": 60.410793395086586,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-03T04:50:07Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 222.71714922048997,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-04T04:02:10Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 161.29754917335006,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-04T04:57:41Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 151.8691588785047,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-04T21:33:22Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 98.12740207703001,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-05T04:03:28Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 239.7506593143131,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-06T03:50:50Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 731.7073170731708,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-06T03:52:08Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 98.02174300481198,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-06T05:06:43Z",
+    "asin": "WHTDURZESVWW5KLTDUQAP5QTQ4MYV36N",
+    "wpm": 800.9153318077803,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-06T05:09:24Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 168.22429906542058,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-06T22:04:29Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 94.72687085569939,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-07T06:22:37Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 330.57851239669424,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-07T06:36:35Z",
+    "asin": "B0CDWDLCNS",
+    "wpm": 3421.052631578947,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-07T06:39:44Z",
+    "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
+    "wpm": 309.6392030156166,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-07T17:47:15Z",
+    "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
+    "wpm": 341.8704368988295,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-07T18:34:48Z",
+    "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
+    "wpm": 1898.7341772151901,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-07T21:11:02Z",
+    "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
+    "wpm": 179.17133258678612,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-08T04:04:57Z",
+    "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
+    "wpm": 322.3795383328138,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-08T05:47:10Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 114.00651465798046,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-08T21:05:48Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 58.915946582875094,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-09T04:27:59Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 441.6094210009814,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-09T04:31:58Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 297.5474873767733,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-09T05:02:10Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 173.51660315732173,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-10T04:38:23Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 318.45145176397125,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-11T05:28:44Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 407.0803629293584,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-11T06:33:51Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 212.12352851245987,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-11T21:57:20Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 135.74660633484163,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-12T02:57:19Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 202.6342451874367,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-12T03:31:54Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 226.70762030130172,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-13T22:56:56Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 151.97568389057753,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-14T05:27:57Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 66.9244497323022,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-14T06:01:18Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 250.04944480547,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-14T18:03:48Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 458.90094666358806,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-15T03:25:49Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 393.13795568263043,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-15T08:22:47Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 203.13161235717308,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-15T20:12:21Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 363.3648581383773,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-16T03:04:21Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 397.7156842749337,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-16T19:01:23Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 1470.5882352941176,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-16T19:11:24Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 2135.8159912376777,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-16T19:14:46Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 15789.473684210525,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-16T19:20:34Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 7894.736842105263,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-16T20:12:28Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 4419.121734296831,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-16T20:39:48Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 2083.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-17T05:28:16Z",
+    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
+    "wpm": 986.8421052631578,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-17T05:29:16Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 614.5741878841088,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-17T05:40:54Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 274.68502783474946,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-17T06:04:26Z",
+    "asin": "O2SJMZT5JBNX55LFEWETQP4C7RXJPGOT",
+    "wpm": 1165.2999568407422,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-18T21:05:05Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 171.26842433049615,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-19T04:22:48Z",
+    "asin": "B0BZ5Y513V",
+    "wpm": 741.3020558777016,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-19T04:49:59Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 358.34509718753395,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-19T05:05:45Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 1829.268292682927,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-19T05:06:24Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 343.2494279176201,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-19T05:41:40Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 443.13146233382565,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-19T05:44:12Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 268.04328402660576,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-20T20:14:50Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 101.17361392148928,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-20T23:42:44Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 24.983344437041975,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-21T06:49:02Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 1500,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-21T06:58:04Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 165.79165515335728,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-22T07:05:40Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 205.84199176632032,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-23T05:10:07Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 228.53312206715827,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-23T15:34:26Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 24.98750624687656,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-23T18:43:32Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 6382.978723404255,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-24T03:51:42Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 301.381331100879,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-26T03:39:49Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 254.22338855174675,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-26T05:24:55Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 24.465829391616374,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-26T05:47:01Z",
+    "asin": "B0CN8TPKSP",
+    "wpm": 453.6812996889043,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-26T06:16:19Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 181.10692552883222,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-26T07:11:02Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 710.9004739336492,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-26T07:11:42Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 339.95467271030526,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-27T06:19:19Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 231.15220483641536,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-28T05:49:09Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 479.2332268370607,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-28T05:49:54Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 277.7445944331621,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-29T06:41:04Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 200.8672363218977,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-30T05:03:11Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 426.3420389338768,
+    "period": "morning"
+  },
+  {
+    "start": "2024-12-30T20:02:55Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 5555.555555555556,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:06:47Z",
+    "asin": "B0CZXNTCFX",
+    "wpm": 3044.2804428044283,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:10:29Z",
+    "asin": "B0CZXNTCFX",
+    "wpm": 6338.028169014085,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:10:49Z",
+    "asin": "OOAZWAIV63UB2CXNZN7NGGRP3MSZBQBM",
+    "wpm": 8522.727272727272,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:32:16Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 552.9953917050691,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:38:23Z",
+    "asin": "B0BQGDMFH6",
+    "wpm": 541.4012738853503,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:39:18Z",
+    "asin": "OOAZWAIV63UB2CXNZN7NGGRP3MSZBQBM",
+    "wpm": 1948.051948051948,
+    "period": "evening"
+  },
+  {
+    "start": "2024-12-30T20:39:30Z",
+    "asin": "B0BQGDMFH6",
+    "wpm": 1412.8728414442699,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-02T03:53:01Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 302.3959060246569,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-02T04:14:52Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 169.6309242315205,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-02T04:40:01Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 370.5463182897862,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-02T04:57:57Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 48.56726566294318,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-02T20:11:47Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 205.27859237536657,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-03T05:26:26Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 494.05952240912836,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-04T05:15:04Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 290.82774049217,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-04T20:06:36Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 1293.103448275862,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T04:53:35Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 352.9622017692789,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-05T05:49:43Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 356.0830860534125,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-05T05:52:42Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 623.5385814497272,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-05T16:53:59Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 133.26564284807716,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:21:13Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 5660.377358490566,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:21:30Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 3658.536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:22:35Z",
+    "asin": "B0CH9KQYHS",
+    "wpm": 438.91733723482076,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:32:01Z",
+    "asin": "B0CH9KQYHS",
+    "wpm": 323.97408207343415,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:36:58Z",
+    "asin": "B0CH9KQYHS",
+    "wpm": 377.35849056603774,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:44:10Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 2439.0243902439024,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:46:38Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 464.97210167389954,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T18:49:32Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 117.04380782521459,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T19:18:41Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 115.69610489780179,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T19:36:12Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 137.74679634344866,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T21:21:49Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 96.71959377770612,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T21:43:43Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 141.89041693953286,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-05T22:14:22Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 270.67249558180634,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-06T00:29:06Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 153.49979533360622,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-06T04:08:12Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 294.6204488415233,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-06T21:43:45Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 294.33962264150944,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-06T22:53:48Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 264.72318452186414,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-06T23:57:53Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 304.112763081676,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-07T01:53:34Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 5555.555555555556,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T01:53:43Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 2272.7272727272725,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T01:55:09Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 1067.6156583629893,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T03:53:42Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 348.5034850348503,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T05:31:28Z",
+    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
+    "wpm": 1327.4336283185842,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T05:52:00Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 550.9908168197196,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T06:13:55Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 254.36046511627907,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-07T21:41:28Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 23.22700526478786,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-07T22:04:23Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 262.3557043626006,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-08T05:02:04Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 396.4710504696932,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-09T05:16:08Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 378.8835564536499,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-10T04:20:41Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 126.58227848101265,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-10T04:23:04Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 849.0566037735849,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-10T04:25:01Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 349.61059632766757,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-10T05:13:19Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 107.08336638375506,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-10T23:00:06Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 77.90588968526019,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-12T20:54:31Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 110.54958938723942,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-13T04:53:51Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 391.38943248532286,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-13T04:56:37Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 357.25627183232774,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-14T04:46:13Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 582.0026861662438,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-14T20:03:41Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 343.3703116745906,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-14T20:18:26Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 864.5533141210374,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-15T05:10:17Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 1145.0381679389313,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-15T05:12:12Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 360.3553271132466,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-15T05:13:57Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 2112.676056338028,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-15T22:00:57Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 434.1724410139462,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-15T22:58:44Z",
+    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
+    "wpm": 579.5311185870479,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-16T00:02:42Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 25.016677785190126,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-16T00:19:35Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 470.0352526439483,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-16T04:26:18Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 453.60496578067807,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-16T21:42:48Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 130.89005235602093,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-17T18:42:45Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 99.51348960636886,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-18T05:20:50Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 244.09684168576266,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-18T08:10:23Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 182.78497839813892,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-18T18:22:06Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 245.55659494855007,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-19T05:54:43Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 232.71689214347774,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-19T19:41:12Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 1470.5882352941176,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-19T21:11:14Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 249.93828684275488,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-20T05:16:06Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 482.54497795782197,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-20T05:30:36Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 1000,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-20T05:46:03Z",
+    "asin": "2CTL27BREQN7JTZSLXXAM2YMSI6DZDZV",
+    "wpm": 445.05983582237167,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-20T18:47:57Z",
+    "asin": "2CTL27BREQN7JTZSLXXAM2YMSI6DZDZV",
+    "wpm": 683.371298405467,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-20T18:54:17Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 755.2315518959459,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-20T20:15:34Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 175.3507014028056,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-20T20:42:28Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 104.8364551299972,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-20T21:36:25Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 298.24461739476226,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T03:47:10Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 288.6574598143537,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-21T04:02:10Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 671.3831937626336,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-21T04:13:53Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 25.008336112037348,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-21T04:25:51Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 375.5588673621461,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-21T20:55:16Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 58.4339696143358,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T20:59:37Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 12500,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T21:11:30Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 119.90407673860912,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T21:15:41Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 1785.7142857142856,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T21:18:10Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 108.01080108010801,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T21:28:17Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 116.80726800778714,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T21:41:56Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 118.8010235165103,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T22:09:51Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 6250,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T22:10:46Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 13.722440764797366,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T22:29:43Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 409.8360655737705,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T22:31:37Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 123.47711557458018,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-21T23:10:24Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 243.61296770566554,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-22T00:18:58Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 127.89281364190012,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-22T03:59:11Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 365.65888649163605,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-22T23:36:23Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 84.49514152936206,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-22T23:49:44Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 340.348289749844,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-23T01:33:54Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 262.93348493462196,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-23T04:13:05Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 403.9226719183313,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-23T04:59:40Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 127.44265080713679,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-23T05:11:30Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 397.65485597756816,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-23T22:06:40Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 166.5741254858412,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-23T22:57:53Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 260.2602602602602,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T00:12:53Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 427.57190982119715,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-24T04:49:44Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 268.6108979278588,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-24T05:48:26Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 191.59966939664886,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-24T16:34:19Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 342.20532319391634,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T16:36:40Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 10000,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T16:37:47Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 15000,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T16:45:16Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 3388.2352941176473,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T16:50:24Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 7894.736842105262,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T21:20:06Z",
+    "asin": "B0CC1J32NG",
+    "wpm": 1315.7894736842104,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-24T21:21:04Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 272.7095643140056,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-25T05:05:54Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 279.08343125734433,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-25T20:31:11Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 344.4152116718488,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-26T05:26:07Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 669.6428571428571,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-26T05:26:59Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 279.1365376435559,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-26T16:11:03Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 737.6337865201041,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-26T16:17:19Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 108.13148788927334,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-26T16:52:37Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 283.952125061065,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-26T17:41:55Z",
+    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
+    "wpm": 1705.9835982585805,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-26T18:38:43Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 1079.136690647482,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-26T21:53:53Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 183.25345362277983,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-27T04:00:01Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 296.030991886558,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-27T04:23:42Z",
+    "asin": "B0BL6YQ61Y",
+    "wpm": 1949.5412844036696,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-27T04:29:01Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 490.19607843137254,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-27T04:58:20Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 436.3924887595874,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-28T01:26:37Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 266.0989888238425,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-28T05:22:03Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 462.6773596545342,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-28T05:32:20Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 444.5065697511881,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-28T06:02:35Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 288.4060757546626,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-29T04:10:11Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 445.44654641443026,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-29T04:25:54Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 570.4679490712672,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-29T22:15:15Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 188.02228412256267,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-30T04:06:45Z",
+    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
+    "wpm": 677.47667703243,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-30T04:29:46Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 228.76024655271019,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-31T02:10:34Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 479.7172193233462,
+    "period": "morning"
+  },
+  {
+    "start": "2025-01-31T17:49:47Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 78.52815795378056,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-31T18:27:36Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 5172.413793103448,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-31T18:30:28Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 367.2869735553379,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-31T23:29:46Z",
+    "asin": "B0DMDYK6Y6",
+    "wpm": 943.3962264150942,
+    "period": "evening"
+  },
+  {
+    "start": "2025-01-31T23:31:10Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 296.0270059724747,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-01T04:44:52Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 117.12214166201896,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-01T05:02:20Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 366.1513425549227,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-03T02:13:13Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 258.66441251056636,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-03T03:24:18Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 160.56338028169014,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-03T20:22:02Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 167.31734523145568,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-04T01:43:10Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 23.492560689115113,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-04T04:45:55Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 52.953636149682275,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-04T05:00:09Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 282.39202657807306,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-04T21:31:28Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 129.41261053993816,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-05T04:54:51Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 262.51760788833394,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-05T05:29:28Z",
+    "asin": "B000JML2Z6",
+    "wpm": 683.371298405467,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-05T21:45:42Z",
+    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
+    "wpm": 522.6480836236934,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-05T21:46:38Z",
+    "asin": "OEEFKAZSYAYOEA57JWRZYSEGYRAUE75X",
+    "wpm": 223.69696517783908,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-06T04:25:51Z",
+    "asin": "OEEFKAZSYAYOEA57JWRZYSEGYRAUE75X",
+    "wpm": 215.67217828900073,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-06T21:38:44Z",
+    "asin": "OEEFKAZSYAYOEA57JWRZYSEGYRAUE75X",
+    "wpm": 449.10179640718565,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-06T21:41:03Z",
+    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
+    "wpm": 1001.908396946565,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-06T21:43:06Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 311.8896099804675,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-06T22:46:07Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 419.6048720787925,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-07T04:53:52Z",
+    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
+    "wpm": 1026.0193133047212,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-07T05:12:19Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 229.1825821237586,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-07T05:29:11Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 207.82265799850794,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-07T22:51:27Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 329.54961552544853,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-07T22:56:30Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 273.61167409809485,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-08T05:10:04Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 181.69233431389515,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-09T05:36:29Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 688.0733944954128,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-09T05:37:09Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 192.6605504587156,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-09T19:07:28Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 284.58997962195207,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-09T20:19:10Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 489.30062630480165,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-09T20:32:19Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 457.2921770374,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-09T21:06:19Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 497.29209900288504,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-09T22:27:39Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 292.6134865819581,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-09T23:05:23Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 24.855012427506214,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-10T02:34:24Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 24.84266313348791,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-10T02:44:34Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 365.48659882470974,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-10T21:17:51Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 582.977069568597,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-10T22:26:36Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 3913.0434782608695,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-10T23:22:21Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 1530.6122448979593,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-10T23:23:13Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 458.1005586592179,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-11T22:09:18Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 167.18913270637407,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-11T22:58:23Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 554.5286506469502,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-11T23:10:00Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 4205.607476635514,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-11T23:17:03Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 6338.028169014085,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-11T23:25:57Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 2608.695652173913,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-12T00:50:08Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 388.99294049848726,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-12T01:02:15Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 788.091068301226,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-12T04:19:00Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 2830.188679245283,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-12T04:51:10Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 313.21779077051576,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-12T05:27:39Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 310.01984126984127,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-12T05:47:59Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 286.6546342499204,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-12T12:00:41Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 1515.151515151515,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-12T20:38:51Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 1127.8195488721803,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-12T22:10:56Z",
+    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
+    "wpm": 1388.888888888889,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-13T04:22:17Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 276.46446029329275,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-13T16:05:20Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 174.72335468841,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-15T05:43:18Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 285.9866539561487,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-16T04:15:40Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 449.79554747841894,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-16T04:34:09Z",
+    "asin": "B003K15IF8",
+    "wpm": 358.9347742184485,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-16T20:03:51Z",
+    "asin": "B003K15IF8",
+    "wpm": 219.6997436836324,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-16T21:35:37Z",
+    "asin": "B003K15IF8",
+    "wpm": 211.75564681724848,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-16T23:19:06Z",
+    "asin": "B003K15IF8",
+    "wpm": 172.58480460226147,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-17T00:31:43Z",
+    "asin": "B003K15IF8",
+    "wpm": 150.31733659948782,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-17T00:52:19Z",
+    "asin": "B003K15IF8",
+    "wpm": 107.7070368597415,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-17T01:50:56Z",
+    "asin": "B003K15IF8",
+    "wpm": 13.144058885383807,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-17T04:16:57Z",
+    "asin": "B003K15IF8",
+    "wpm": 250.50582907794583,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-17T05:10:50Z",
+    "asin": "B003K15IF8",
+    "wpm": 300.24726245143063,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T00:34:33Z",
+    "asin": "B003K15IF8",
+    "wpm": 205.69234519746465,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T01:33:00Z",
+    "asin": "B003K15IF8",
+    "wpm": 149.6342274440257,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T02:06:30Z",
+    "asin": "B003K15IF8",
+    "wpm": 267.86925267869253,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T03:55:49Z",
+    "asin": "B003K15IF8",
+    "wpm": 382.47909707260186,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T05:23:37Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 3488.3720930232557,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T05:23:51Z",
+    "asin": "B003K15IF8",
+    "wpm": 317.36872475476054,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-18T12:30:15Z",
+    "asin": "B003K15IF8",
+    "wpm": 3488.3720930232557,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-18T22:04:03Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 91.35995823544766,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-19T05:20:01Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 570.3422053231939,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-19T05:21:16Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 25.008336112037348,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-19T05:47:00Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 714.2857142857143,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-19T05:47:53Z",
+    "asin": "SD42OYMUUNT3QF4OVGG6Y2M6HXLDJ2NZ",
+    "wpm": 354.49020931802835,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-19T05:53:07Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 384.8431024274719,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-19T06:14:26Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 343.03288384196827,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-19T21:32:19Z",
+    "asin": "B081M4F8GH",
+    "wpm": 1764.7058823529412,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-19T22:16:51Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 962.9101283880173,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-19T22:19:21Z",
+    "asin": "B081M4F8GH",
+    "wpm": 216.43820411787559,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-20T00:18:57Z",
+    "asin": "B081M4F8GH",
+    "wpm": 221.99007573779056,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-20T01:14:54Z",
+    "asin": "B081M4F8GH",
+    "wpm": 396.86139332365747,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-20T03:32:17Z",
+    "asin": "B081M4F8GH",
+    "wpm": 336.70955379140435,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-20T04:06:19Z",
+    "asin": "B081M4F8GH",
+    "wpm": 163.38500209467952,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-20T18:49:04Z",
+    "asin": "B081M4F8GH",
+    "wpm": 128.9213579716373,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-20T18:53:23Z",
+    "asin": "B081M4F8GH",
+    "wpm": 251.46689019279128,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-20T20:27:35Z",
+    "asin": "B081M4F8GH",
+    "wpm": 141.91106906338695,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-20T20:55:57Z",
+    "asin": "B081M4F8GH",
+    "wpm": 531.9148936170213,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-20T21:50:15Z",
+    "asin": "B081M4F8GH",
+    "wpm": 955.4140127388536,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-20T21:50:45Z",
+    "asin": "XUTYDSDJUGD5CEHPJUSBR6WPEFKRWCFB",
+    "wpm": 259.0827873734366,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-21T04:49:57Z",
+    "asin": "XUTYDSDJUGD5CEHPJUSBR6WPEFKRWCFB",
+    "wpm": 311.9185728357229,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-21T05:05:56Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 161.39711968217182,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-21T06:01:51Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 319.1489361702128,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-21T22:53:26Z",
+    "asin": "LJEYEFSOIDZ6GLUVVI6NH52QJH5ZDYED",
+    "wpm": 649.3506493506494,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-21T22:57:55Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 844.5945945945946,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-21T23:01:02Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 423.5294117647059,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-21T23:04:41Z",
+    "asin": "4LXTLEYZY7L7ETOIXN5BEITXMZHJAT2H",
+    "wpm": 155.0120564932828,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-22T06:15:28Z",
+    "asin": "4LXTLEYZY7L7ETOIXN5BEITXMZHJAT2H",
+    "wpm": 167.3338145547608,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-22T06:40:59Z",
+    "asin": "4LXTLEYZY7L7ETOIXN5BEITXMZHJAT2H",
+    "wpm": 2083.3333333333335,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-22T06:41:12Z",
+    "asin": "4LXTLEYZY7L7ETOIXN5BEITXMZHJAT2H",
+    "wpm": 1875,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-22T06:41:45Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 194.4684528954192,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-22T19:39:29Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 146.01382264187677,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-23T05:09:05Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 259.86525505293554,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-23T19:12:51Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 235.70081709616593,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T04:05:19Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 382.0986211731713,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-24T18:35:44Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 491.1591355599214,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T18:47:40Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 9531.772575250836,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T20:43:13Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 13548.387096774191,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T21:00:10Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 11157.02479338843,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T21:09:55Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 9868.421052631578,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T21:21:44Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 7653.061224489796,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-24T22:41:54Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 221.77046756606913,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-25T04:41:01Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 252.83042869863885,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-25T22:36:44Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 326.590813316477,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T04:02:31Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 330.5671292310871,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-26T10:51:28Z",
+    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
+    "wpm": 279.98133457769484,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-26T21:41:42Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 3688.524590163934,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T21:42:17Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 316.4556962025316,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T21:44:09Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 315.45741324921136,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T21:45:51Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 469.85121378230224,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T21:48:12Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 387.8474466709761,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T21:50:58Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 447.76119402985074,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-26T23:53:57Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 184.86916951080775,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-27T00:11:42Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 198.62490450725744,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-27T02:26:16Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 24.979184013322232,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-27T03:57:59Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 286.2261842335256,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-27T17:26:26Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 1724.1379310344828,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-27T22:52:10Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 295.2351612240707,
+    "period": "evening"
+  },
+  {
+    "start": "2025-02-28T00:37:30Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 470.09663097414466,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-28T00:50:51Z",
+    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
+    "wpm": 938.4775808133472,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-28T00:53:07Z",
+    "asin": "TZP5HFOTIFXZOUVZML2TN6JMK26OPH5M",
+    "wpm": 1740.506329113924,
+    "period": "morning"
+  },
+  {
+    "start": "2025-02-28T05:07:47Z",
+    "asin": "TZP5HFOTIFXZOUVZML2TN6JMK26OPH5M",
+    "wpm": 100.7387508394896,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-01T05:02:16Z",
+    "asin": "TZP5HFOTIFXZOUVZML2TN6JMK26OPH5M",
+    "wpm": 216.91973969631235,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-01T21:39:19Z",
+    "asin": "TZP5HFOTIFXZOUVZML2TN6JMK26OPH5M",
+    "wpm": 1393.188854489164,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-01T21:57:45Z",
+    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
+    "wpm": 1158.3011583011585,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-01T21:59:22Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 280.8988764044944,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-03T04:27:54Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 234.58542095050538,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-04T00:06:25Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 244.405822289811,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-04T01:55:41Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 287.01267639320736,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-04T03:33:13Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 304.89526283100895,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-05T00:58:17Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 282.5181211118087,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-05T03:16:52Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 348.575712143928,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-06T00:18:26Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 249.38875305623472,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-06T01:09:46Z",
+    "asin": "6NDGE2NIHCVUABABQEW7LNCIZ7TO6CGC",
+    "wpm": 288.1185401993963,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-06T01:28:59Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 166.61377340526815,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-06T04:04:59Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 438.05309734513276,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-07T02:29:12Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 2459.0163934426228,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-07T04:10:07Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 298.11195760185495,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-07T04:15:20Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 111.02886750555145,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-07T04:36:32Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 121.15891132572432,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-07T22:16:51Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 143.84656366542353,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-08T05:30:18Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 288.2703777335984,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-08T21:02:30Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 267.4463190184049,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-09T03:54:25Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 277.91059048529763,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-09T12:09:22Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 1415.0943396226414,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-09T17:51:45Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 246.97336561743344,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-10T03:25:28Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 277.6103985538435,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-10T23:04:37Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 78.20646506777894,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-11T03:58:05Z",
+    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
+    "wpm": 384.8867791391366,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-11T20:42:35Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 180.65034122842232,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-12T02:49:36Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 180.97100303698465,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-12T22:25:08Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 124.77718360071302,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-13T04:09:08Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 219.48007608642638,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-14T02:47:45Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 378.78787878787875,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-14T02:48:31Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 717.7033492822967,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-14T02:49:00Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 397.9952830188679,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-14T21:04:13Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 1428.5714285714287,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-14T21:04:33Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 24.59419576979833,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-15T01:48:40Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 357.00119000396666,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-15T03:46:41Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 24.24438338451592,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-15T04:01:17Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 205.76131687242798,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-16T03:19:06Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 229.59528204204744,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-16T17:01:19Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 232.50664304694422,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-16T18:10:45Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 368.1885125184094,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-16T23:54:57Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 1948.051948051948,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-16T23:55:26Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 207.36530855189895,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-17T00:57:37Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 212.4505928853755,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-17T02:22:09Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 10.572314632083451,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-17T03:05:58Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 272.9077075752564,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-18T03:37:13Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 361.4167536744037,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-19T02:57:58Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 336.6934661061911,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-19T04:16:38Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 160.26782534368544,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-19T21:29:12Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 126.0857383020454,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-20T00:39:48Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 5263.157894736842,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-20T00:39:59Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 1546.3917525773197,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-20T04:01:25Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 165.3267634854772,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-21T04:39:26Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 198.85108263367212,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-21T22:08:43Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 86.9061413673233,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-22T01:04:52Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 1851.8518518518517,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-22T03:26:47Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 23.95018361807441,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-23T03:55:27Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 459.4180704441041,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-23T03:57:02Z",
+    "asin": "TH6GPQAVDDTMCR2XKAXXE5XUWQF5DODY",
+    "wpm": 326.51902328222604,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-24T04:29:54Z",
+    "asin": "TH6GPQAVDDTMCR2XKAXXE5XUWQF5DODY",
+    "wpm": 74.30340557275541,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-25T20:32:29Z",
+    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
+    "wpm": 323.97408207343415,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-25T21:54:08Z",
+    "asin": "TH6GPQAVDDTMCR2XKAXXE5XUWQF5DODY",
+    "wpm": 815.2173913043479,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-25T21:55:59Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 3986.7109634551493,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-25T21:57:11Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 2419.3548387096776,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-25T21:58:30Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 172.7447216890595,
+    "period": "evening"
+  },
+  {
+    "start": "2025-03-26T03:31:09Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 1145.0381679389313,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-26T03:33:44Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 366.91506911655955,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-26T04:04:44Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 316.0112359550562,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-26T05:09:58Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 153.95141977420457,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-27T01:47:47Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 1415.0943396226414,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-27T01:48:23Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 2027.027027027027,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-28T03:27:14Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 287.7823319089561,
+    "period": "morning"
+  },
+  {
+    "start": "2025-03-28T03:59:57Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 324.9390739236393,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-01T03:58:44Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 308.29199149539335,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-02T03:31:38Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 199.33554817275746,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-03T02:28:14Z",
+    "asin": "B0D57LWBM6",
+    "wpm": 945.4304196384143,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-03T02:38:42Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 247.62690879075527,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-05T17:30:42Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 161.05941302791697,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-06T16:46:21Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 3750,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-06T16:46:36Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 6037.151702786377,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-06T16:47:10Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 1293.103448275862,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-06T16:47:44Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 4120.879120879121,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-07T02:27:23Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 813.8351983723296,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-07T02:32:23Z",
+    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
+    "wpm": 6178.977272727273,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-07T02:34:13Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 312.99682034976155,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-07T03:07:49Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 108.78762238607518,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-08T02:56:41Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 348.8849363798057,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-08T22:40:30Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 225.2083176938668,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-09T01:22:12Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 842.6966292134831,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-09T01:22:30Z",
+    "asin": "B0CQHL1XV7",
+    "wpm": 2307.6923076923076,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-09T01:48:50Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 239.90403838464613,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-09T02:33:39Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 301.4610961154794,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-11T01:47:39Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 218.71202916160388,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-11T02:25:21Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 199.04769338849425,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-11T16:47:27Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 228.53185595567868,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-12T03:44:38Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 195.37609899055684,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-12T20:51:01Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 255.80293699668405,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-12T21:22:16Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 247.09070620117967,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-13T04:53:23Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 278.947153308538,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-13T19:29:21Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 447.9872123837967,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-13T20:09:06Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 2238.805970149254,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-13T20:09:28Z",
+    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
+    "wpm": 1327.4336283185842,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-13T20:13:26Z",
+    "asin": "B0D57LWBM6",
+    "wpm": 350.79513564078576,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-13T20:17:20Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 188.80590752706217,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-14T04:09:16Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 312.3048094940662,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-14T04:18:06Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 285.3834064025147,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-14T22:45:11Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 2189.78102189781,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-14T22:46:52Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 136.275146009085,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-14T23:05:03Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 202.91815634360805,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T03:46:35Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 418.6231948259059,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-15T20:39:58Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 1863.354037267081,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T20:40:40Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 4195.804195804196,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T20:41:40Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 5813.9534883720935,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T20:42:12Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 15983.606557377048,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T20:43:14Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 8333.333333333334,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T21:38:05Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 1442.3076923076922,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-15T21:38:45Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 190.50498941638946,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T03:21:44Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 489.6626768226333,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-16T03:35:49Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 427.47533796127146,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-16T17:24:46Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T17:25:19Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 663.7168141592921,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T17:34:58Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T17:49:27Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3947.368421052631,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T17:55:39Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 4285.714285714285,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T18:05:05Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3658.536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T18:05:18Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 4285.714285714285,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T18:42:59Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 236.59305993690853,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T18:47:07Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3157.8947368421054,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T18:50:27Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3225.8064516129034,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T18:58:48Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 4225.352112676056,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T19:01:42Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3333.3333333333335,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-16T19:11:44Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 348.83720930232556,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T01:59:01Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3879.3103448275865,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:14:06Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 3629.032258064516,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:18:13Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 9782.608695652174,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:19:44Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 601.6042780748663,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:22:46Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 262.17228464419475,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:39:37Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 418.99441340782124,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:41:05Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 143.95393474088291,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T03:42:52Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 285.81798384901555,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T04:01:24Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 310.98825155494126,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T07:07:07Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 24.98750624687656,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-17T19:31:55Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 621.4396685655101,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T20:33:00Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 5696.20253164557,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T20:36:11Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 1072.9613733905578,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T20:39:59Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 4166.666666666667,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T21:43:26Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 24.983344437041975,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T22:01:30Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 186.59037193680805,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-17T22:26:17Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 369.39313984168865,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-18T01:11:10Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 98.8793671720501,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T01:26:29Z",
+    "asin": "TSTOZDLY54TMFJPMV5UY3P7FBETFAS6Y",
+    "wpm": 143.67816091954023,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T01:47:05Z",
+    "asin": "TSTOZDLY54TMFJPMV5UY3P7FBETFAS6Y",
+    "wpm": 2159.777055271714,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T01:56:17Z",
+    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
+    "wpm": 3037.974683544304,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T01:57:08Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 24.96671105193076,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T02:25:13Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 619.9899799599199,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T02:45:11Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 1642.3357664233577,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T03:06:11Z",
+    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
+    "wpm": 6000,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T03:25:25Z",
+    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
+    "wpm": 785.3403141361256,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T03:27:12Z",
+    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
+    "wpm": 781.25,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-18T03:34:25Z",
+    "asin": "2QNZAYQAE5R4PFN6F24WIOEU6LELQLZZ",
+    "wpm": 260.2197411147191,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-20T04:42:36Z",
+    "asin": "2QNZAYQAE5R4PFN6F24WIOEU6LELQLZZ",
+    "wpm": 298.2107355864811,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-20T04:46:28Z",
+    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
+    "wpm": 139.25960311013114,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-21T02:27:38Z",
+    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
+    "wpm": 1666.6666666666667,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-21T02:27:58Z",
+    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
+    "wpm": 1027.3972602739725,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-21T22:11:34Z",
+    "asin": "B0D3CBLLPH",
+    "wpm": 2451.781627983001,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-21T22:28:32Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 276.72589571803087,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-22T04:01:34Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 366.80959399705216,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-22T11:16:50Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 24.98750624687656,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-23T02:56:00Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 269.1759076059449,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-24T01:08:57Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 426.54028436018956,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-24T01:21:52Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 344.82758620689657,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-24T01:31:06Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 2941.176470588235,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-24T01:35:23Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 3846.153846153846,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-24T01:35:38Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 3448.2758620689656,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-24T04:14:03Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 159.49734171097148,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-26T04:05:16Z",
+    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
+    "wpm": 650.0541711809317,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-27T03:29:39Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 5791.505791505791,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-27T03:30:42Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 306.17243631613326,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-28T03:21:39Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 155.08191506282805,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-29T03:13:44Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 292.5345190732507,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-30T00:24:23Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 571.9733079122974,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-30T00:26:16Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 258.0559782968306,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-30T03:36:22Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 308.37759122837076,
+    "period": "morning"
+  },
+  {
+    "start": "2025-04-30T20:23:51Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 4109.58904109589,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-30T20:24:39Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 552.2827687776141,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-30T21:03:55Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 312.10986267166044,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-30T22:12:13Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 333.54952283887707,
+    "period": "evening"
+  },
+  {
+    "start": "2025-04-30T23:07:34Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 157.44274809160308,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-01T01:11:42Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 82.41758241758242,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-01T01:30:11Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 254.65091603593407,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-01T03:31:13Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 355.8335130472288,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-02T03:03:34Z",
+    "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
+    "wpm": 356.5990864652616,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-03T20:37:31Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 802.1390374331552,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-03T20:38:24Z",
+    "asin": "28C62463866C4CC99233564ED847A1A5",
+    "wpm": 2142.8571428571427,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-03T20:38:42Z",
+    "asin": "B0DLLGPNMQ",
+    "wpm": 185.07972665148066,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-04T18:33:25Z",
+    "asin": "B0DLLGPNMQ",
+    "wpm": 659.3406593406594,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-04T18:34:21Z",
+    "asin": "LTCRXOXA6TOUTCKMTU3ZCVIOM5BKGXOC",
+    "wpm": 161.20365394948954,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-05T01:42:32Z",
+    "asin": "LTCRXOXA6TOUTCKMTU3ZCVIOM5BKGXOC",
+    "wpm": 24.561978057966268,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-05T03:15:10Z",
+    "asin": "LTCRXOXA6TOUTCKMTU3ZCVIOM5BKGXOC",
+    "wpm": 269.4170794100038,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-06T03:08:30Z",
+    "asin": "LTCRXOXA6TOUTCKMTU3ZCVIOM5BKGXOC",
+    "wpm": 1778.6561264822135,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-06T03:10:17Z",
+    "asin": "B0DY9TZD8Z",
+    "wpm": 566.1903478026422,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-06T03:17:38Z",
+    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
+    "wpm": 216.76300578034682,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-06T03:27:16Z",
+    "asin": "B09SKWT6SF",
+    "wpm": 736.8421052631579,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-06T03:35:38Z",
+    "asin": "WF76OBCUMHIJ33X2SQRIIWKQ4MIBU6FK",
+    "wpm": 1007.2314049586777,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-08T03:22:48Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 510.8929119361767,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-08T23:15:39Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 250.14889815366288,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-09T03:59:12Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 474.57414042365957,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-09T05:35:59Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 412.5331499852667,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-10T03:15:37Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 411.8993135011442,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-10T19:28:07Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 313.54029573430364,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-11T03:09:39Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 443.3261442607237,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-11T03:30:49Z",
+    "asin": "B0CWFMT5SC",
+    "wpm": 428.12077512392966,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-11T03:42:41Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 253.3783783783784,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-13T03:31:03Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 293.7268340443388,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-13T03:57:40Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 444.3048200341083,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-13T23:39:47Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 332.214416721459,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-14T03:22:22Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 387.4269005847953,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-14T21:18:07Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 546.4480874316939,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-14T23:56:38Z",
+    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
+    "wpm": 629.9580027998134,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-15T00:15:58Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 842.6966292134831,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-15T00:17:53Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 629.3188548864758,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-15T22:24:34Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 206.40623805519456,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-16T02:35:14Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 344.7285262855501,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-16T20:40:55Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 219.2982456140351,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-16T21:15:50Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 196.48203592814372,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-17T06:36:49Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 2542.3728813559323,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-17T14:56:36Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 203.87359836901123,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-17T19:38:39Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 380.7432336080769,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-18T03:18:09Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 289.9017555161862,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-18T19:20:09Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 164.726553920492,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-19T03:59:25Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 333.12182741116754,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-19T23:01:38Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 271.3178294573643,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-20T01:47:54Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 307.55136762203904,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-20T02:26:16Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 311.34016991785546,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-21T01:47:16Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 375.37817950920703,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-21T03:16:34Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 350.2069404648201,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-21T04:14:36Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 204.37956204379563,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-21T04:39:47Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 282.8712434297637,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-21T18:49:01Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 364.27415002698325,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-21T21:31:23Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 406.9992801373277,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-21T23:24:17Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 360.1440576230492,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-21T23:31:35Z",
+    "asin": "FTT7VNOWFIXZCCUGO3PVUC2EFP5UBTOU",
+    "wpm": 482.71216883700043,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-22T00:16:35Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 627.2571754419313,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-22T00:25:26Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 316.622691292876,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-22T03:23:18Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 396.57282741738067,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-22T23:52:24Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 378.1512605042017,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-22T23:54:35Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 369.0740227335736,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-23T04:03:17Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 231.46163737676812,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-23T21:51:54Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 233.51834303506158,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-24T02:58:32Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 440.1479218586703,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-24T03:40:23Z",
+    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
+    "wpm": 1500,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-24T03:44:21Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 350.5582965463516,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-24T18:48:20Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 277.1472311671858,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-25T02:43:55Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 389.0646884888728,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-26T15:41:24Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 203.6578548039294,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-26T21:16:31Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 219.5359930615785,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-26T22:11:59Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 69.32676012940995,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-26T22:46:17Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 242.6997457431235,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-26T23:52:07Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 379.99383793776315,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-27T03:26:48Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 221.9591595146493,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-27T22:07:13Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 384.8456341400838,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-27T22:08:37Z",
+    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
+    "wpm": 1829.268292682927,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-27T22:27:13Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 918.3673469387755,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-27T22:33:57Z",
+    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
+    "wpm": 203.68903474029648,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-28T03:07:15Z",
+    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
+    "wpm": 344.0831196869518,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-28T03:20:19Z",
+    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
+    "wpm": 137.16938660664042,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-29T02:46:31Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 380.2281368821293,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-29T03:28:15Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 255.00196155355042,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-29T03:41:15Z",
+    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
+    "wpm": 286.1230329041488,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-29T19:54:30Z",
+    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
+    "wpm": 6382.978723404255,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-30T01:19:34Z",
+    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
+    "wpm": 1485.148514851485,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-30T01:20:44Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 269.29982046678634,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-30T01:28:09Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 1136.3636363636363,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-30T01:29:12Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 219.38139862412652,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-30T02:54:04Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 98.23182711198429,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-31T01:06:55Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 301.2048192771084,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-31T03:16:28Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 289.2030848329049,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-31T03:47:53Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 163.85902374518486,
+    "period": "morning"
+  },
+  {
+    "start": "2025-05-31T14:51:49Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 244.8915104276385,
+    "period": "evening"
+  },
+  {
+    "start": "2025-05-31T20:53:53Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 341.9544867656553,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-01T01:47:23Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 331.3027679811906,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-01T02:57:16Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 239.4202148311117,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-01T17:05:16Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 3125,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-01T17:05:34Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 742.9420505200594,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-01T23:26:45Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 288.93780957622454,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-01T23:27:25Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 2205.8823529411766,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-01T23:52:23Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 333.2707472775066,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-02T00:49:11Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 364.7376099739157,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-02T02:44:40Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 107.93585526315789,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-02T19:12:05Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 3658.536585365854,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-02T22:16:14Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 423.69141142201426,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-03T03:50:11Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 424.17026343205833,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-06T03:27:23Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 418.8039737679372,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-09T03:31:32Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 583.7258975334289,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-09T04:28:36Z",
+    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
+    "wpm": 118.20330969267138,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-09T04:31:14Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 324.0976105744789,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-10T01:06:30Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 270.8628917838256,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-10T01:53:59Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 279.6519886363636,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-10T02:25:00Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 399.8984384918116,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-11T02:59:36Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 527.0945071203995,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-11T03:08:48Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 660.7929515418501,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-11T03:09:34Z",
+    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
+    "wpm": 590.5511811023622,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-11T03:15:46Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 360.57692307692304,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-11T22:26:54Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 139.10969793322735,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T21:42:23Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 675.6756756756756,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T21:43:43Z",
+    "asin": "WE7SRD2LY7QFPPIYNFYUIFGDVUBNHMLP",
+    "wpm": 351.3628620102214,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T22:26:54Z",
+    "asin": "WE7SRD2LY7QFPPIYNFYUIFGDVUBNHMLP",
+    "wpm": 303.0180598763686,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T23:12:58Z",
+    "asin": "WE7SRD2LY7QFPPIYNFYUIFGDVUBNHMLP",
+    "wpm": 845.3879391320685,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T23:34:50Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 4559.8480050664975,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T23:38:10Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 1520.2702702702702,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-12T23:42:30Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 109.24981791697013,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-13T03:08:14Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 405.45758784914403,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-13T19:14:41Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 626.8656716417911,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-14T02:41:40Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 173.29202331565403,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-14T17:38:23Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 145.76079034739655,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-15T00:42:24Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 249.96296844911865,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-15T02:58:47Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 319.2818472074407,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-15T17:29:28Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 214.93594066082267,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-15T19:22:01Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 136.89700130378097,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-15T20:22:18Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 276.3885232956041,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-15T21:15:28Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 575.5395683453237,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-15T21:21:54Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 993.3774834437086,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-16T02:54:12Z",
+    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
+    "wpm": 1428.5714285714287,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-16T02:54:46Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 296.2252440331772,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-16T22:06:45Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 268.26935074657905,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-16T23:00:10Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 182.40343347639484,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-16T23:23:30Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 141.0105757931845,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-16T23:57:24Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 263.1318871374216,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-17T04:14:12Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 357.30039700044114,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-17T21:57:41Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 320.5318454324212,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-17T23:16:46Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 218.49963583394026,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-18T00:59:07Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 251.67785234899327,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-18T01:49:16Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 162.9881154499151,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-18T02:42:43Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 283.9038841342989,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-18T21:55:07Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 357.57657536094996,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-19T02:36:25Z",
+    "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
+    "wpm": 489.60659680467273,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-19T03:15:45Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 397.20068091545295,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-19T22:31:28Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 117.52415774353616,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-19T23:08:50Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 677.996745615621,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-19T23:18:14Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 605.8158319870759,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-20T00:40:03Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 227.4737773284469,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-20T01:10:17Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 242.96416278598906,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-20T01:44:39Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 71.23634636694634,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-20T01:55:14Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 164.30853491556368,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-20T02:42:35Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 387.5078936793157,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-20T21:34:47Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 260.94520150768335,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-20T23:52:44Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 285.30670470756064,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-21T01:33:05Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 269.8535080956052,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-21T02:41:06Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 366.3283217583759,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-21T21:21:42Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 270.11383368705384,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-21T22:12:24Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 24.98750624687656,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-22T01:10:31Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 239.37510498908114,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-22T04:01:31Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 294.44095477386935,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-22T17:50:53Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 357.5902056648753,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-22T20:39:07Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 511.2197607937443,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-22T22:26:28Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 324.59101532069593,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-23T00:07:42Z",
+    "asin": "B0DHDF2RDL",
+    "wpm": 707.3730829164275,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-23T23:40:09Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 522.5409836065575,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-23T23:53:42Z",
+    "asin": "B0DJ7XG2MQ",
+    "wpm": 486.5193594161768,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-24T00:02:45Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 108.48601735776278,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-24T04:13:44Z",
+    "asin": "B0D9F3KFPM",
+    "wpm": 602.4096385542169,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-24T04:41:02Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 259.6314907872697,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-24T22:43:15Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 327.08824707400646,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-25T01:08:06Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 322.0419847328244,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-25T03:20:46Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 306.3960168517809,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-25T04:07:01Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 228.0501710376283,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-25T21:52:41Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 238.26714801444044,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-25T22:49:26Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 99.00990099009901,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-26T01:24:34Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 255.36261491317674,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-26T02:52:42Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 393.74212515749684,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-27T19:08:42Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 542.9864253393665,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-27T21:49:48Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 515.3276955602537,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-27T21:56:20Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 309.12538125463686,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-27T22:21:11Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 428.9799809342231,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-28T02:47:47Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 337.9828326180258,
+    "period": "morning"
+  },
+  {
+    "start": "2025-06-28T16:59:55Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 190.12237762237763,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-28T20:39:47Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 316.20553359683794,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-30T20:33:56Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 526.8846257768171,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-30T20:40:26Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 1282.051282051282,
+    "period": "evening"
+  },
+  {
+    "start": "2025-06-30T20:40:47Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 180.43860460812436,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-01T02:36:45Z",
+    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
+    "wpm": 464.39628482972137,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-01T02:47:34Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 320.85561497326205,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-02T16:51:05Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 3030.30303030303,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-04T02:35:49Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 309.82252141982866,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-04T16:35:29Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 161.56176371592056,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-04T20:50:44Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 285.9866539561487,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-05T17:29:07Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 101.2518409425626,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-06T03:21:08Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 273.9448051948052,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-06T03:29:39Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 365.0904033379694,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-06T17:56:42Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 1578.9473684210527,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-06T19:57:10Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 986.8421052631579,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-06T19:59:00Z",
+    "asin": "DLPKNHHPHNJ4DUAQY2GFGV5CUSFQXXJU",
+    "wpm": 721.616420782553,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-06T20:11:01Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 457.1703561116458,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-06T21:05:38Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 296.9241701350117,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-07T04:12:58Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 416.9774221981151,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-08T01:18:57Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 289.49146000192997,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-08T02:38:54Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 271.5378918785485,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-08T22:06:19Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 351.16469624253773,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-08T23:36:07Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 202.34950255747287,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-09T00:08:03Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 1401.8691588785045,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-09T03:20:45Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 208.44661953960485,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-09T21:52:38Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 204.4989775051125,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-10T00:12:45Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 177.15998909784685,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-10T00:31:12Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 333.7919788003873,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-10T02:24:52Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 364.4211718086612,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-10T03:43:47Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 371.0001545833978,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-10T20:47:57Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 398.5122210414453,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-10T21:20:32Z",
+    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
+    "wpm": 961.7006917496203,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-11T05:44:38Z",
+    "asin": "B0DJM99D77",
+    "wpm": 579.1505791505792,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-11T05:45:26Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 300.46027957722464,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-11T20:00:49Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 16.729868391701984,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-11T20:48:46Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 238.2015780854548,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T00:25:04Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 270.21034836349526,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-12T02:49:45Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 258.91829689298044,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-12T03:26:28Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 199.27669938740866,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-12T17:09:47Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 523.2558139534883,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T17:12:53Z",
+    "asin": "B0DJM99D77",
+    "wpm": 799.5735607675907,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T17:14:34Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 568.7618492051918,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T17:26:19Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 212.00164890171368,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T19:04:23Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 594.6481665014867,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T21:30:28Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 324.85110990795886,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-12T23:09:13Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 211.64767716674308,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-13T05:11:32Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 210.8345534407028,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-13T16:19:35Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 251.73064820641912,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-13T19:04:21Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 301.6147992328157,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-13T21:02:07Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 333.1285734536691,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-13T22:28:32Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 67.07407959457446,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-13T23:48:53Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 288.1605160800683,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-14T01:01:44Z",
+    "asin": "VE4SJJEMPCNJIYM5H66WC62DAPYE4BQI",
+    "wpm": 439.3361143161445,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-14T01:23:17Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 25,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-14T02:24:30Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 364.31883417973063,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-14T02:49:17Z",
+    "asin": "B0DJM99D77",
+    "wpm": 128.74531835205994,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-14T22:16:39Z",
+    "asin": "B0DJM99D77",
+    "wpm": 338.8189738625363,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-14T22:22:05Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 222.8205366261257,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-14T23:39:44Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 267.85714285714283,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-14T23:41:01Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 191.31026273276083,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-15T03:50:16Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 1773.049645390071,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-15T03:52:09Z",
+    "asin": "B0DJM99D77",
+    "wpm": 328.7310979618672,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-15T04:00:03Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 967.7419354838709,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-15T04:06:18Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 1219.5121951219512,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-15T04:06:56Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 312.6699293094073,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-16T02:31:42Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 460.63651591289783,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-16T02:38:03Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 344.8945885553288,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-16T18:32:05Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 593.4184499190793,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-16T18:41:26Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 455.5573223087932,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-16T21:08:18Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 343.96273737011825,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-17T00:22:00Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 265.5807365439094,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-17T00:55:12Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 315.92708257680295,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-17T03:18:03Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 335.5569439126141,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-17T19:57:59Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 417.72151898734177,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-17T21:04:29Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 340.522133938706,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-17T21:13:22Z",
+    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
+    "wpm": 2142.8571428571427,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-18T03:22:02Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 242.10068905580732,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-18T16:30:23Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 1162.7906976744187,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-18T16:31:46Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 4213.483146067415,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-18T16:32:28Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 1470.5882352941176,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-18T20:19:17Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 321.3242453748783,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-18T21:28:04Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 25.016677785190126,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-18T22:09:48Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 259.19732441471575,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-19T01:16:06Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 204.52686119443686,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-19T01:52:33Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 217.90448520065374,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-19T02:28:11Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 294.11764705882354,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-19T02:45:54Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 316.27961460743256,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-19T16:53:29Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 426.855372837392,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-19T18:38:39Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 452.16774536749716,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-19T19:20:50Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 409.49181016379674,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-19T20:02:09Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 141.72670367308373,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-19T21:54:41Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 47.16239584970916,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-20T02:25:21Z",
+    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
+    "wpm": 389.5325609268877,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-20T02:50:55Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 360.9651067063517,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-20T20:14:21Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 252.986647926915,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T04:03:39Z",
+    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
+    "wpm": 413.0605822187254,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-21T04:38:01Z",
+    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
+    "wpm": 2250,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-21T04:38:27Z",
+    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
+    "wpm": 124.5995016019936,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-21T14:21:59Z",
+    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
+    "wpm": 1229.5081967213114,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T14:22:16Z",
+    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
+    "wpm": 4411.764705882353,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T14:22:31Z",
+    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
+    "wpm": 25.342118601115054,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T19:55:07Z",
+    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
+    "wpm": 290.69767441860466,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T19:56:43Z",
+    "asin": "B0DJM99D77",
+    "wpm": 974.025974025974,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T20:46:07Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 175.81409570402081,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-21T22:44:09Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 250.90415913200724,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-22T03:36:03Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 239.6740433011105,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-22T03:57:10Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 509.11559348332037,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-23T03:35:44Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 304.52988199467075,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-23T21:46:36Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 1086.9565217391305,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-23T21:47:07Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 242.13075060532688,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-25T03:23:58Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 351.1288982858869,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-25T22:34:47Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 263.2733655111891,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-26T03:00:46Z",
+    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
+    "wpm": 466.48363662868394,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-26T04:12:36Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 1296.0934647681636,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-26T04:29:22Z",
+    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
+    "wpm": 1363.6363636363637,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-26T04:33:20Z",
+    "asin": "LLUQMOFNTTDE4U47XIA344P55IEPDQDW",
+    "wpm": 358.23950870010236,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-26T17:59:16Z",
+    "asin": "LLUQMOFNTTDE4U47XIA344P55IEPDQDW",
+    "wpm": 206.23778855199365,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-26T19:39:03Z",
+    "asin": "LLUQMOFNTTDE4U47XIA344P55IEPDQDW",
+    "wpm": 203.52781546811397,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-26T20:14:39Z",
+    "asin": "LLUQMOFNTTDE4U47XIA344P55IEPDQDW",
+    "wpm": 330.613496037017,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-26T22:08:59Z",
+    "asin": "LLUQMOFNTTDE4U47XIA344P55IEPDQDW",
+    "wpm": 282.3086574654956,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-26T22:59:35Z",
+    "asin": "LLUQMOFNTTDE4U47XIA344P55IEPDQDW",
+    "wpm": 449.22824890572605,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-27T02:15:22Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 413.22314049586777,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-27T18:29:11Z",
+    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
+    "wpm": 1271.1864406779662,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-27T18:33:16Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 234.26433734064577,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-28T03:25:38Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 316.9014084507042,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-28T22:27:26Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 264.12027631044293,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-29T02:24:21Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 199.83223960132233,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-29T03:11:26Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 291.9766418686505,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-29T15:46:38Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 607.2874493927126,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-29T20:26:23Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 469.1164972634871,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T03:27:23Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 316.42175265472486,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-30T13:47:20Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 277.2643253234751,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T13:48:17Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 617.283950617284,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T13:48:44Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 4545.454545454545,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T13:49:05Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 1648.3516483516482,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T13:49:18Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 6000,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T13:49:29Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 2000,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T13:49:43Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 129.08777969018934,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T17:21:57Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 1376.1467889908256,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T21:08:59Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 346.72970843183606,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T22:42:18Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 301.6323633782825,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T23:22:04Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 240.71102333045303,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-30T23:45:14Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 236.9219105382866,
+    "period": "evening"
+  },
+  {
+    "start": "2025-07-31T03:11:42Z",
+    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
+    "wpm": 526.7778753292362,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-31T03:13:50Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 349.7804569472352,
+    "period": "morning"
+  },
+  {
+    "start": "2025-07-31T23:02:07Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 223.9328201539538,
+    "period": "evening"
+  },
+  {
+    "start": "2025-08-01T02:59:31Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 404.4943820224719,
+    "period": "morning"
+  },
+  {
+    "start": "2025-08-01T03:18:18Z",
+    "asin": "FL3NEUQ2GAR53VPJA4427F67PPROIYBM",
+    "wpm": 420.40596778303086,
+    "period": "morning"
+  },
+  {
+    "start": "2025-08-01T04:20:08Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 329.89820284026644,
+    "period": "morning"
+  },
+  {
+    "start": "2025-08-01T21:01:49Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 815.2173913043479,
+    "period": "evening"
+  },
+  {
+    "start": "2025-08-01T21:02:13Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 1442.3076923076922,
+    "period": "evening"
+  },
+  {
+    "start": "2025-08-01T21:03:34Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 1578.9473684210527,
+    "period": "evening"
+  },
+  {
+    "start": "2025-08-02T04:47:13Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 319.8059108954565,
+    "period": "morning"
+  },
+  {
+    "start": "2025-08-02T17:27:23Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 177.22878625134263,
+    "period": "evening"
+  },
+  {
+    "start": "2025-08-02T21:55:45Z",
+    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
+    "wpm": 356.0830860534125,
+    "period": "evening"
+  }
 ]


### PR DESCRIPTION
## Summary
- add a script to derive reading speed from Kindle sessions CSV
- populate reading-speed.json with computed entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689207a264a883248cef2a2ca43d7c14