### PR TITLE
Add responsive top navigation sheet

### DIFF
--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -1,11 +1,53 @@
-import React from "react";
+import React, { useState } from "react";
 import { NavLink } from "react-router-dom";
+import { Menu } from "lucide-react";
 import { dashboardRoutes } from "@/routes";
+import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/ui/sheet";
 
 export default function TopNavigation() {
+  const [open, setOpen] = useState(false);
+
   return (
-    <nav>
-      <ul className="flex gap-4">
+    <nav className="flex items-center">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <button className="md:hidden p-2">
+            <Menu className="h-6 w-6" aria-hidden="true" />
+            <span className="sr-only">Open navigation menu</span>
+          </button>
+        </SheetTrigger>
+        <SheetContent side="left" className="p-4">
+          <ul className="flex flex-col gap-4">
+            <li>
+              <SheetClose asChild>
+                <NavLink to="/" className="block px-2 py-1 text-sm">
+                  Dashboard
+                </NavLink>
+              </SheetClose>
+            </li>
+            {dashboardRoutes.map((group) => {
+              const Icon = group.icon;
+              const firstItem = group.items[0];
+              return (
+                <li key={group.label}>
+                  <SheetClose asChild>
+                    <NavLink
+                      to={firstItem?.to ?? "#"}
+                      className="flex items-center gap-2 px-2 py-1 text-sm"
+                    >
+                      {Icon && (
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                      )}
+                      <span>{group.label}</span>
+                    </NavLink>
+                  </SheetClose>
+                </li>
+              );
+            })}
+          </ul>
+        </SheetContent>
+      </Sheet>
+      <ul className="hidden md:flex gap-4">
         <li>
           <NavLink to="/" className="block px-2 py-1 text-sm">
             Dashboard


### PR DESCRIPTION
## Summary
- add mobile navigation sheet with hamburger button
- render dashboard route links in vertical sheet list
- hide desktop nav on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689213285d488324bde66a118dd8bc76