### PR TITLE
feat: add mobile navigation sheet

### DIFF
--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -1,11 +1,58 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { NavLink } from "react-router-dom";
+import { Menu } from "lucide-react";
 import { dashboardRoutes } from "@/routes";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { Sheet, SheetContent, SheetTrigger } from "@/ui/sheet";
 
 export default function TopNavigation() {
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (!isMobile) setOpen(false);
+  }, [isMobile]);
+
   return (
-    <nav>
-      <ul className="flex gap-4">
+    <nav className="flex items-center">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <button
+            className="md:hidden p-2"
+            aria-label="Open menu"
+          >
+            <Menu className="h-6 w-6" />
+          </button>
+        </SheetTrigger>
+        <SheetContent side="left" className="p-4">
+          <ul className="flex flex-col gap-4">
+            <li>
+              <NavLink
+                to="/"
+                className="block px-2 py-1 text-sm"
+                onClick={() => setOpen(false)}
+              >
+                Dashboard
+              </NavLink>
+            </li>
+            {dashboardRoutes.map((group) => {
+              const firstItem = group.items[0];
+              return (
+                <li key={group.label}>
+                  <NavLink
+                    to={firstItem?.to ?? "#"}
+                    className="block px-2 py-1 text-sm"
+                    onClick={() => setOpen(false)}
+                  >
+                    {group.label}
+                  </NavLink>
+                </li>
+              );
+            })}
+          </ul>
+        </SheetContent>
+      </Sheet>
+      <ul className="hidden md:flex gap-4">
         <li>
           <NavLink to="/" className="block px-2 py-1 text-sm">
             Dashboard
@@ -26,7 +73,11 @@ export default function TopNavigation() {
               <ul className="absolute z-10 hidden w-48 flex-col gap-2 bg-white p-4 shadow-md group-hover:flex">
                 {group.items.map((item) => (
                   <li key={item.to}>
-                    <NavLink to={item.to} className="block px-2 py-1 text-sm">
+                    <NavLink
+                      to={item.to}
+                      className="block px-2 py-1 text-sm"
+                      onClick={() => setOpen(false)}
+                    >
                       {item.label}
                     </NavLink>
                   </li>


### PR DESCRIPTION
## Summary
- add responsive top navigation with mobile sheet menu

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6892132023a08324b1766c9126be4e51