### PR TITLE
Add headings to Kindle Insights chart pages

### DIFF
--- a/src/pages/charts/BookNetwork.jsx
+++ b/src/pages/charts/BookNetwork.jsx
@@ -4,6 +4,7 @@ import BookNetwork from '@/components/network/BookNetwork.jsx';
 export default function BookNetworkPage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Related Books Network</h1>
       <BookNetwork />
     </div>
   );

--- a/src/pages/charts/GenreSankey.jsx
+++ b/src/pages/charts/GenreSankey.jsx
@@ -4,6 +4,7 @@ import GenreSankey from '@/components/genre/GenreSankey.jsx';
 export default function GenreSankeyPage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Genre Transition Sankey</h1>
       <GenreSankey />
     </div>
   );

--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -5,6 +5,7 @@ import genreHierarchy from '@/data/kindle/genre-hierarchy.json';
 export default function GenreSunburstPage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Genre Hierarchy Sunburst</h1>
       <GenreSunburst data={genreHierarchy} />
     </div>
   );

--- a/src/pages/charts/ReadingCalendarHeatmap.jsx
+++ b/src/pages/charts/ReadingCalendarHeatmap.jsx
@@ -4,6 +4,7 @@ import CalendarHeatmap from '@/components/calendar/CalendarHeatmap.jsx';
 export default function ReadingCalendarHeatmapPage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Daily Reading Calendar</h1>
       <CalendarHeatmap />
     </div>
   );

--- a/src/pages/charts/ReadingMap.jsx
+++ b/src/pages/charts/ReadingMap.jsx
@@ -4,6 +4,7 @@ import ReadingMap from '@/components/map/ReadingMap.jsx';
 export default function ReadingMapPage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Reading Locations Map</h1>
       <ReadingMap />
     </div>
   );

--- a/src/pages/charts/ReadingSpeedViolin.jsx
+++ b/src/pages/charts/ReadingSpeedViolin.jsx
@@ -4,6 +4,7 @@ import ReadingSpeedViolin from '@/components/stats/ReadingSpeedViolin.jsx';
 export default function ReadingSpeedViolinPage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Reading Speed Distribution</h1>
       <ReadingSpeedViolin />
     </div>
   );

--- a/src/pages/charts/ReadingTimeline.jsx
+++ b/src/pages/charts/ReadingTimeline.jsx
@@ -8,6 +8,7 @@ export default function ReadingTimelinePage() {
   if (isLoading) return <div>Loading...</div>;
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Reading Timeline</h1>
       <ReadingTimeline sessions={data || []} />
     </div>
   );

--- a/src/pages/charts/WordTree.jsx
+++ b/src/pages/charts/WordTree.jsx
@@ -4,6 +4,7 @@ import WordTree from '@/components/highlights/WordTree.jsx';
 export default function WordTreePage() {
   return (
     <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Highlight Word Tree</h1>
       <WordTree />
     </div>
   );


### PR DESCRIPTION
## Summary
- add consistent heading to Kindle Insights chart pages

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68921beefcec8324912013fe522fe92c