### PR TITLE
feat: centralize chart colors with variables

### DIFF
--- a/src/components/__tests__/BookNetwork.test.jsx
+++ b/src/components/__tests__/BookNetwork.test.jsx
@@ -22,4 +22,13 @@ describe('BookNetwork component', () => {
       expect(nodes.length).toBe(expected);
     });
   });
+
+  it('renders nodes with CSS variable fill', async () => {
+    const { container } = render(<BookNetwork />);
+    await waitFor(() => {
+      const node = container.querySelector('[data-testid="node"]');
+      expect(node).toBeTruthy();
+      expect(node.getAttribute('fill')).toBe('var(--chart-network-node)');
+    });
+  });
 });

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -56,7 +56,7 @@ export default function GenreSankey() {
       .data(l)
       .join('path')
       .attr('d', sankeyLinkHorizontal())
-      .attr('stroke', '#999')
+      .attr('stroke', 'var(--chart-network-link)')
       .attr('fill', 'none')
       .attr('stroke-width', (d) => Math.max(1, d.width));
 

--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -38,7 +38,7 @@ export default function WordTree() {
       .data(root.links())
       .join('path')
       .attr('fill', 'none')
-      .attr('stroke', '#999')
+      .attr('stroke', 'var(--chart-network-link)')
       .attr('d', link);
     const node = svg
       .selectAll('g')
@@ -50,7 +50,7 @@ export default function WordTree() {
         d.data.children = expansions.map(e => ({ word: e.word, count: e.count }));
         setData({ ...data });
       });
-    node.append('circle').attr('r', 4).attr('fill', '#555');
+    node.append('circle').attr('r', 4).attr('fill', 'var(--chart-wordtree-node)');
     node
       .append('text')
       .attr('x', 8)

--- a/src/components/network/BookNetwork.jsx
+++ b/src/components/network/BookNetwork.jsx
@@ -39,7 +39,7 @@ export default function BookNetwork() {
 
     const link = svg
       .append('g')
-      .attr('stroke', '#999')
+      .attr('stroke', 'var(--chart-network-link)')
       .attr('stroke-opacity', 0.6)
       .selectAll('line')
       .data(filteredLinks)
@@ -48,13 +48,13 @@ export default function BookNetwork() {
 
     const node = svg
       .append('g')
-      .attr('stroke', '#fff')
+      .attr('stroke', 'var(--chart-network-node-border)')
       .attr('stroke-width', 1.5)
       .selectAll('circle')
       .data(filteredNodes)
       .join('circle')
       .attr('r', 5)
-      .attr('fill', '#69b3a2')
+      .attr('fill', 'var(--chart-network-node)')
       .attr('data-testid', 'node')
       .call(
         drag()

--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -49,7 +49,7 @@ export default function ReadingSpeedViolin() {
         .attr('y', y1)
         .attr('width', w * 2)
         .attr('height', y0 - y1)
-        .attr('fill', '#69b3a2');
+        .attr('fill', 'var(--chart-network-node)');
     });
   }, [data, showMorning, showEvening]);
 

--- a/src/styles/chartPalette.css
+++ b/src/styles/chartPalette.css
@@ -1,0 +1,22 @@
+@layer base {
+  :root {
+    --chart-network-node: #69b3a2;
+    --chart-network-link: #999;
+    --chart-network-node-border: #fff;
+    --chart-wordtree-node: #555;
+  }
+
+  .dark {
+    --chart-network-node: #69b3a2;
+    --chart-network-link: #999;
+    --chart-network-node-border: #fff;
+    --chart-wordtree-node: #bbb;
+  }
+
+  .contrast {
+    --chart-network-node: #69b3a2;
+    --chart-network-link: #fff;
+    --chart-network-node-border: #000;
+    --chart-wordtree-node: #fff;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import "./chartPalette.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- define shared chart color tokens in `chartPalette.css` and import into global styles
- use the new CSS variables across network and other chart components
- test that BookNetwork nodes use the CSS variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921fecb5408324a1f0c7bc7d0beae1