### PR TITLE
feat: add loading skeleton for book network

### DIFF
--- a/src/pages/charts/BookNetwork.jsx
+++ b/src/pages/charts/BookNetwork.jsx
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import BookNetwork from '@/components/network/BookNetwork.jsx';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function BookNetworkPage() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    import('@/data/kindle/book-graph.json').then((mod) => {
+      setData(mod.default);
+    });
+  }, []);
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Related Books Network</h1>
-      <BookNetwork />
+      {data ? (
+        <BookNetwork />
+      ) : (
+        <Skeleton className="h-96 w-full" data-testid="book-network-skeleton" />
+      )}
     </div>
   );
 }

--- a/src/pages/charts/__tests__/BookNetworkPage.test.jsx
+++ b/src/pages/charts/__tests__/BookNetworkPage.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import BookNetworkPage from '../BookNetwork.jsx';
+
+vi.mock('@/components/network/BookNetwork.jsx', () => ({
+  default: () => <div data-testid="book-network" />,
+}));
+
+describe('BookNetworkPage', () => {
+  it('displays a skeleton before data resolves', async () => {
+    render(<BookNetworkPage />);
+
+    expect(
+      screen.getByTestId('book-network-skeleton')
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('book-network')).toBeInTheDocument();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Skeleton loading state for BookNetwork page
- add unit test confirming skeleton renders before graph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68922221d4d48324965e539c66861f4f