### PR TITLE
feat: add heatmap legend and reading scale

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -6,9 +6,41 @@ import useDailyReading from '@/hooks/useDailyReading';
 export default function CalendarHeatmap() {
   const { data } = useDailyReading();
   if (!data || data.length === 0) return null;
+
   const dates = data.map((d) => new Date(d.date));
-  const startDate = new Date(Math.min(...dates));
+  const minDate = new Date(Math.min(...dates));
+  const startDate = new Date(minDate);
+  startDate.setDate(startDate.getDate() - 1);
   const endDate = new Date(Math.max(...dates));
+
+  const maxMinutes = Math.max(...data.map((d) => d.minutes), 0);
   const values = data.map((d) => ({ date: d.date, count: d.minutes }));
-  return <Heatmap startDate={startDate} endDate={endDate} values={values} />;
+  const classForValue = (value) => {
+    if (!value || !value.count || maxMinutes === 0) return 'reading-scale-0';
+    const level = Math.ceil((value.count / maxMinutes) * 4);
+    return `reading-scale-${level}`;
+  };
+
+  const legendScale = [0, 1, 2, 3, 4];
+
+  return (
+    <div>
+      <Heatmap
+        startDate={startDate}
+        endDate={endDate}
+        values={values}
+        classForValue={classForValue}
+      />
+      <div
+        className="flex items-center gap-1 mt-2 text-xs"
+        data-testid="reading-legend"
+      >
+        <span>Less</span>
+        {legendScale.map((level) => (
+          <div key={level} className={`w-3 h-3 reading-scale-${level}`} />
+        ))}
+        <span>More</span>
+      </div>
+    </div>
+  );
 }

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
-import CalendarHeatmap from '../CalendarHeatmap';
 
 vi.mock('@/hooks/useDailyReading', () => ({
   __esModule: true,
@@ -15,10 +14,27 @@ vi.mock('@/hooks/useDailyReading', () => ({
   }),
 }));
 
+import CalendarHeatmap from '../CalendarHeatmap';
+
 describe('CalendarHeatmap', () => {
   it('renders heatmap cells', () => {
     const { container } = render(<CalendarHeatmap />);
     const svg = container.querySelector('svg.react-calendar-heatmap');
     expect(svg).not.toBeNull();
+  });
+
+  it('renders legend and assigns classes', () => {
+    const { container, getByTestId } = render(<CalendarHeatmap />);
+    const legend = getByTestId('reading-legend');
+    expect(legend).not.toBeNull();
+
+    const rects = container.querySelectorAll('svg.react-calendar-heatmap rect');
+    expect(rects[0].classList.contains('reading-scale-2')).toBe(true);
+    expect(rects[1].classList.contains('reading-scale-4')).toBe(true);
+
+    const swatches = legend.querySelectorAll('div');
+    expect(swatches.length).toBe(5);
+    expect(swatches[0].classList.contains('reading-scale-0')).toBe(true);
+    expect(swatches[4].classList.contains('reading-scale-4')).toBe(true);
   });
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -149,7 +149,30 @@
     --font-slab: "Georgia", "Times New Roman", serif;
   }
 
-  html, body {
-    @apply bg-background text-foreground;
+html, body {
+  @apply bg-background text-foreground;
+}
+}
+
+@layer utilities {
+  .reading-scale-0 {
+    background-color: #ebedf0;
+    fill: #ebedf0;
+  }
+  .reading-scale-1 {
+    background-color: #c6e48b;
+    fill: #c6e48b;
+  }
+  .reading-scale-2 {
+    background-color: #7bc96f;
+    fill: #7bc96f;
+  }
+  .reading-scale-3 {
+    background-color: #239a3b;
+    fill: #239a3b;
+  }
+  .reading-scale-4 {
+    background-color: #196127;
+    fill: #196127;
   }
 }


### PR DESCRIPTION
## Summary
- map reading minutes to `reading-scale-*` classes and show a legend on the calendar heatmap
- add Tailwind utility classes for reading intensity swatches
- test heatmap class assignment and legend rendering

## Testing
- `npm test src/components/calendar/__tests__/CalendarHeatmap.test.jsx -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689225e1118483248cd609c38665109f