### PR TITLE
Add brush-based zoom to reading timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@turf/turf": "^7.2.0",
         "class-variance-authority": "^0.7.0",
         "cors": "^2.8.5",
+        "d3-brush": "^3.0.0",
         "d3-chord": "^3.0.1",
         "d3-contour": "^4.0.2",
         "d3-drag": "^3.0.0",
@@ -5730,6 +5731,22 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
       },
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@turf/turf": "^7.2.0",
     "class-variance-authority": "^0.7.0",
     "cors": "^2.8.5",
+    "d3-brush": "^3.0.0",
     "d3-chord": "^3.0.1",
     "d3-contour": "^4.0.2",
     "d3-drag": "^3.0.0",

--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -1,9 +1,11 @@
 import React, { useRef, useEffect } from 'react';
 import { select } from 'd3-selection';
 import { scaleTime } from 'd3-scale';
+import { brushX } from 'd3-brush';
 
 const WIDTH = 600;
 const HEIGHT = 40;
+const BRUSH_HEIGHT = 10;
 
 export default function ReadingTimeline({ sessions = [] }) {
   const ref = useRef(null);
@@ -20,24 +22,61 @@ export default function ReadingTimeline({ sessions = [] }) {
     }));
     const min = Math.min(...parsed.map((d) => d.startDate.getTime()));
     const max = Math.max(...parsed.map((d) => d.endDate.getTime()));
-    const x = scaleTime().domain([min, max]).range([0, WIDTH]);
-    svg.attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`);
-    svg
-      .selectAll('rect')
-      .data(parsed)
-      .enter()
-      .append('rect')
-      .attr('x', (d) => x(d.startDate))
-      .attr('y', 5)
-      .attr('width', (d) => Math.max(1, x(d.endDate) - x(d.startDate)))
-      .attr('height', 30)
-      .attr('fill', 'steelblue')
-      .append('title')
-      .text(
-        (d) =>
-          `${d.title}\n${d.duration.toFixed(1)} min, ${d.highlights} highlights`,
-      );
+    const initialDomain = [min, max];
+    const x = scaleTime().domain(initialDomain).range([0, WIDTH]);
+
+    svg.attr('viewBox', `0 0 ${WIDTH} ${HEIGHT + BRUSH_HEIGHT}`);
+
+    const barsG = svg.append('g').attr('transform', `translate(0,${BRUSH_HEIGHT})`);
+
+    const renderBars = (domain = initialDomain) => {
+      x.domain(domain);
+      barsG.selectAll('*').remove();
+      const bars = barsG
+        .selectAll('rect')
+        .data(parsed)
+        .enter()
+        .append('rect')
+        .attr('x', (d) => x(d.startDate))
+        .attr('y', 5)
+        .attr('width', (d) => Math.max(1, x(d.endDate) - x(d.startDate)))
+        .attr('height', 30)
+        .attr('fill', 'steelblue');
+
+      bars
+        .append('title')
+        .text(
+          (d) =>
+            `${d.title}\n${d.duration.toFixed(1)} min, ${d.highlights} highlights`,
+        );
+    };
+
+    renderBars();
+
+    const brush = brushX()
+      .extent([
+        [0, 0],
+        [WIDTH, BRUSH_HEIGHT],
+      ])
+      .on('end', (event) => {
+        if (event.selection) {
+          const [x0, x1] = event.selection.map(x.invert);
+          renderBars([x0, x1]);
+        } else {
+          renderBars(initialDomain);
+        }
+      });
+
+    svg.append('g').attr('class', 'brush').call(brush);
+
+    // expose brush for tests
+    ref.current.__brush = brush;
   }, [sessions]);
 
-  return <svg ref={ref} style={{ width: '100%', height: HEIGHT }} />;
+  return (
+    <svg
+      ref={ref}
+      style={{ width: '100%', height: HEIGHT + BRUSH_HEIGHT }}
+    />
+  );
 }

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -1,21 +1,54 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { select } from 'd3-selection';
 import ReadingTimeline from '../ReadingTimeline.jsx';
 
+const sessions = [
+  {
+    start: '2025-01-01T00:00:00Z',
+    end: '2025-01-01T00:30:00Z',
+    asin: 'B001',
+    title: 'Test Book 1',
+    duration: 30,
+    highlights: 2,
+  },
+  {
+    start: '2025-01-01T00:30:00Z',
+    end: '2025-01-01T01:00:00Z',
+    asin: 'B002',
+    title: 'Test Book 2',
+    duration: 30,
+    highlights: 1,
+  },
+];
+
 describe('ReadingTimeline', () => {
-  it('renders an svg element', () => {
-    const sessions = [
-      {
-        start: '2025-01-01T00:00:00Z',
-        end: '2025-01-01T00:30:00Z',
-        asin: 'B001',
-        title: 'Test Book',
-        duration: 30,
-        highlights: 2,
-      },
-    ];
+  it('renders an svg element with a brush', () => {
     const { container } = render(<ReadingTimeline sessions={sessions} />);
-    expect(container.querySelector('svg')).toBeInTheDocument();
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg.querySelector('.brush')).toBeInTheDocument();
+  });
+
+  it('updates bar widths when brushed', () => {
+    const { container } = render(<ReadingTimeline sessions={sessions} />);
+    const svg = container.querySelector('svg');
+    const brush = svg.__brush;
+    const viewWidth = Number(svg.getAttribute('viewBox').split(' ')[2]);
+
+    let rect = svg.querySelector('rect');
+    const initialWidth = Number(rect.getAttribute('width'));
+
+    select(svg.querySelector('.brush')).call(brush.move, [0, viewWidth / 2]);
+
+    rect = svg.querySelector('rect');
+    const zoomWidth = Number(rect.getAttribute('width'));
+    expect(zoomWidth).toBeGreaterThan(initialWidth);
+
+    select(svg.querySelector('.brush')).call(brush.move, null);
+    rect = svg.querySelector('rect');
+    const resetWidth = Number(rect.getAttribute('width'));
+    expect(resetWidth).toBeCloseTo(initialWidth);
   });
 });


### PR DESCRIPTION
## Summary
- allow brushing to zoom into reading timeline by attaching d3 brush above chart
- verify brush presence and zoom behavior with new tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689225fd56fc83248d4d984a339a1eb5