### PR TITLE
feat: add zoomable sunburst breadcrumbs

### DIFF
--- a/src/components/genre/GenreSunburst.jsx
+++ b/src/components/genre/GenreSunburst.jsx
@@ -1,16 +1,41 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { hierarchy, partition } from 'd3-hierarchy';
 import { arc } from 'd3-shape';
-import { scaleOrdinal } from 'd3-scale';
+import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
+import { interpolate } from 'd3-interpolate';
+import 'd3-transition';
 
 const SIZE = 400;
 const RADIUS = SIZE / 2;
 
 export default function GenreSunburst({ data }) {
   const ref = useRef(null);
-  const [titles, setTitles] = useState([]);
+  const [currentNode, setCurrentNode] = useState(null);
+  const xScale = useRef(scaleLinear().range([0, 2 * Math.PI]).domain([0, 2 * Math.PI]));
+  const yScale = useRef(scaleLinear().range([0, RADIUS]).domain([0, RADIUS]));
+  const arcGen = useRef(
+    arc()
+      .startAngle((d) => xScale.current(d.x0))
+      .endAngle((d) => xScale.current(d.x1))
+      .innerRadius((d) => yScale.current(d.y0))
+      .outerRadius((d) => yScale.current(d.y1))
+  );
+
+  const zoomTo = useCallback((node) => {
+    const svg = select(ref.current);
+    const t = svg.transition().duration(750);
+    t.tween('scale', () => {
+      const xd = interpolate(xScale.current.domain(), [node.x0, node.x1]);
+      const yd = interpolate(yScale.current.domain(), [node.y0, RADIUS]);
+      return (t) => {
+        xScale.current.domain(xd(t));
+        yScale.current.domain(yd(t));
+      };
+    });
+    t.selectAll('path').attrTween('d', (d) => () => arcGen.current(d));
+  }, []);
 
   useEffect(() => {
     const svg = select(ref.current);
@@ -19,13 +44,9 @@ export default function GenreSunburst({ data }) {
 
     const root = hierarchy(data).sum((d) => d.value || 0);
     partition().size([2 * Math.PI, RADIUS])(root);
+    setCurrentNode(root);
 
     const color = scaleOrdinal(schemeCategory10);
-    const arcGen = arc()
-      .startAngle((d) => d.x0)
-      .endAngle((d) => d.x1)
-      .innerRadius((d) => d.y0)
-      .outerRadius((d) => d.y1);
 
     const g = svg
       .attr('viewBox', `${-RADIUS} ${-RADIUS} ${SIZE} ${SIZE}`)
@@ -34,29 +55,37 @@ export default function GenreSunburst({ data }) {
     g.selectAll('path')
       .data(root.descendants().filter((d) => d.depth))
       .join('path')
-      .attr('d', arcGen)
+      .attr('d', (d) => arcGen.current(d))
+      .attr('data-name', (d) => d.data.name)
       .attr('fill', (d) => color(d.ancestors().map((d) => d.data.name).join('-')))
       .on('click', (_event, d) => {
-        const leaves = d
-          .descendants()
-          .filter((n) => !n.children)
-          .map((n) => n.data.name);
-        setTitles(leaves);
+        setCurrentNode(d);
+        zoomTo(d);
       })
       .append('title')
       .text((d) => d.data.name);
-  }, [data]);
+  }, [data, zoomTo]);
+  const ancestors = currentNode ? currentNode.ancestors().reverse() : [];
 
   return (
     <div>
+      <div>
+        {ancestors.map((node, i) => (
+          <span key={node.data.name}>
+            {i > 0 && ' / '}
+            <button
+              type="button"
+              onClick={() => {
+                setCurrentNode(node);
+                zoomTo(node);
+              }}
+            >
+              {node.data.name}
+            </button>
+          </span>
+        ))}
+      </div>
       <svg ref={ref} style={{ width: '100%', height: SIZE }} />
-      {titles.length > 0 && (
-        <ul>
-          {titles.map((t) => (
-            <li key={t}>{t}</li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/src/components/genre/__tests__/GenreSunburst.test.jsx
+++ b/src/components/genre/__tests__/GenreSunburst.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import GenreSunburst from '../GenreSunburst';
+
+describe('GenreSunburst', () => {
+  const data = {
+    name: 'root',
+    children: [
+      {
+        name: 'A',
+        children: [
+          { name: 'A1', value: 1 },
+          { name: 'A2', value: 1 },
+        ],
+      },
+      { name: 'B', value: 1 },
+    ],
+  };
+
+  it('updates breadcrumb and zooms on interactions', async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(<GenreSunburst data={data} />);
+    const svg = container.querySelector('svg');
+    const pathA = svg.querySelector('path[data-name="A"]');
+    const initial = pathA.getAttribute('d');
+
+    await user.click(pathA);
+    await new Promise((r) => setTimeout(r, 800));
+
+    expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument();
+    const zoomed = pathA.getAttribute('d');
+    expect(zoomed).not.toBe(initial);
+
+    await user.click(screen.getByRole('button', { name: 'root' }));
+    await new Promise((r) => setTimeout(r, 800));
+
+    expect(screen.queryByRole('button', { name: 'A' })).not.toBeInTheDocument();
+    expect(pathA.getAttribute('d')).toBe(initial);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add zoomable navigation to GenreSunburst and show ancestor breadcrumbs
- replace leaf-title list with focused zoom view
- test breadcrumb updates and zoom behavior

## Testing
- `npx vitest run src/components/genre/__tests__/GenreSunburst.test.jsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68922c8f5ea0832493b3c536d8c6ded9