### PR TITLE
feat: add reading heatmap tooltips

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -2,6 +2,13 @@ import React from 'react';
 import Heatmap from 'react-calendar-heatmap';
 import 'react-calendar-heatmap/dist/styles.css';
 import useDailyReading from '@/hooks/useDailyReading';
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from '@/ui/tooltip';
+import { getISOWeek, getISOWeekYear } from 'date-fns';
 
 export default function CalendarHeatmap() {
   const { data } = useDailyReading();
@@ -34,6 +41,50 @@ export default function CalendarHeatmap() {
 
   const maxMinutes = Math.max(...data.map((d) => d.minutes), 0);
   const values = data.map((d) => ({ date: d.date, count: d.minutes }));
+
+  // map date -> minutes for quick lookup
+  const minutesByDate = data.reduce((acc, d) => {
+    acc[d.date] = d.minutes;
+    return acc;
+  }, {});
+
+  // build series of minutes for each ISO week (Mon-Sun)
+  const weekSeries = {};
+  data.forEach((d) => {
+    const dt = new Date(d.date);
+    const weekKey = `${getISOWeekYear(dt)}-${getISOWeek(dt)}`;
+    if (!weekSeries[weekKey]) weekSeries[weekKey] = Array(7).fill(0);
+    const dayIdx = (dt.getDay() + 6) % 7; // Monday=0
+    weekSeries[weekKey][dayIdx] = d.minutes;
+  });
+
+  const Sparkline = ({ series }) => {
+    const width = 40;
+    const height = 10;
+    const max = Math.max(...series, 1);
+    const points = series
+      .map((v, i) => {
+        const x = (i / (series.length - 1)) * width;
+        const y = height - (v / max) * height;
+        return `${x},${y}`;
+      })
+      .join(' ');
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        data-testid="sparkline"
+      >
+        <polyline
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+        />
+      </svg>
+    );
+  };
   const classForValue = (value) => {
     if (!value || !value.count || maxMinutes === 0) return 'reading-scale-0';
     const level = Math.ceil((value.count / maxMinutes) * 4);
@@ -43,21 +94,45 @@ export default function CalendarHeatmap() {
   const transformDayElement = (element, value, index) => {
     const date = new Date(startWithEmptyDays);
     date.setDate(startWithEmptyDays.getDate() + index);
+    const dateKey = date.toISOString().slice(0, 10);
+    const weekKey = `${getISOWeekYear(date)}-${getISOWeek(date)}`;
+    const series = weekSeries[weekKey] || Array(7).fill(0);
+    const minutes = minutesByDate[dateKey] || 0;
+    const formatted = date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    const dayRect = React.cloneElement(element, { 'data-date': dateKey });
+    const cell = (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{dayRect}</TooltipTrigger>
+          <TooltipContent>
+            <div className="flex flex-col">
+              <span>{formatted}</span>
+              <span>{minutes} min</span>
+              <Sparkline series={series} />
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
     if (date.getDate() === 1) {
       const key = `${date.getFullYear()}-${date.getMonth()}`;
       return (
-        <g key={key}>
+        <g key={dateKey}>
           <text x={element.props.x} y={element.props.y - 2} className="text-xs">
             {monthNames[date.getMonth()]}
           </text>
-          {element}
+          {cell}
           <text x={element.props.x} y={element.props.y + 12} className="text-xs">
             {monthTotals[key]}
           </text>
         </g>
       );
     }
-    return element;
+    return <g key={dateKey}>{cell}</g>;
   };
 
   const legendScale = [0, 1, 2, 3, 4];

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 
@@ -46,5 +47,18 @@ describe('CalendarHeatmap', () => {
     getByText('Feb');
     getByText('15');
     getByText('20');
+  });
+
+  it('shows tooltip with date, minutes, and sparkline', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<CalendarHeatmap />);
+    const day = container.querySelector('rect[data-date="2024-01-02"]');
+    expect(day).not.toBeNull();
+    await user.hover(day);
+    const dateTexts = await screen.findAllByText('Jan 2, 2024');
+    expect(dateTexts.length).toBeGreaterThan(0);
+    const minuteTexts = await screen.findAllByText('10 min');
+    expect(minuteTexts.length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('sparkline').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- show formatted date, minutes, and weekly sparkline on CalendarHeatmap cells via tooltip
- test tooltip rendering with date, minutes, and sparkline svg

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68922f464fd4832494e833c251bae5d4