### PR TITLE
Add axis and session annotations to reading timeline

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -106,7 +106,10 @@ export default function ReadingTimeline({ sessions = [] }) {
           .append('text')
           .attr('class', `annotation ${cls}`)
           .attr('x', xPos)
-          .attr('y', 0)
+          .attr(
+            'y',
+            session.lane * LANE_HEIGHT + LANE_PADDING - 2,
+          )
           .attr('text-anchor', 'middle')
           .text(label);
       };

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -87,8 +87,23 @@ describe('ReadingTimeline', () => {
     const svg = container.querySelector('svg');
     const ticks = svg.querySelectorAll('.x-axis .tick');
     expect(ticks.length).toBeGreaterThan(0);
-    expect(svg.querySelector('.annotation-longest')).toBeInTheDocument();
-    expect(svg.querySelector('.annotation-shortest')).toBeInTheDocument();
+    // axis uses monthly ticks with abbreviated month names
+    expect(ticks[0].textContent).toMatch(/^[A-Za-z]{3}$/);
+
+    const rects = svg.querySelectorAll('rect[height="30"]');
+    const longestAnnot = svg.querySelector('.annotation-longest');
+    const shortestAnnot = svg.querySelector('.annotation-shortest');
+    expect(longestAnnot).toBeInTheDocument();
+    expect(shortestAnnot).toBeInTheDocument();
+    expect(longestAnnot.textContent).toBe('Longest');
+    expect(shortestAnnot.textContent).toBe('Shortest');
+    // annotations should sit just above their respective bars
+    expect(Number(shortestAnnot.getAttribute('y'))).toBe(
+      Number(rects[0].getAttribute('y')) - 2,
+    );
+    expect(Number(longestAnnot.getAttribute('y'))).toBe(
+      Number(rects[1].getAttribute('y')) - 2,
+    );
   });
 
   it('places overlapping sessions in distinct vertical positions', () => {


### PR DESCRIPTION
## Summary
- Draw monthly x-axis with D3's axisBottom
- Annotate longest and shortest reading sessions near their bars
- Test for axis ticks and annotation positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689238caee7483248e06db232b9d4c08