### PR TITLE
feat: color-code reading sessions

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { select } from 'd3-selection';
-import { scaleTime } from 'd3-scale';
+import { scaleTime, scaleOrdinal } from 'd3-scale';
 import { brushX } from 'd3-brush';
 
 const WIDTH = 600;
@@ -15,10 +15,21 @@ export default function ReadingTimeline({ sessions = [] }) {
     svg.selectAll('*').remove();
     if (!sessions.length) return;
 
+    const color = scaleOrdinal()
+      .domain(['short', 'medium', 'long'])
+      .range(['#4CAF50', '#2196F3', '#FFC107']);
+
+    const durationBucket = (mins) => {
+      if (mins < 20) return 'short';
+      if (mins < 40) return 'medium';
+      return 'long';
+    };
+
     const parsed = sessions.map((s) => ({
       ...s,
       startDate: new Date(s.start),
       endDate: new Date(s.end),
+      bucket: durationBucket(s.duration),
     }));
     const min = Math.min(...parsed.map((d) => d.startDate.getTime()));
     const max = Math.max(...parsed.map((d) => d.endDate.getTime()));
@@ -41,7 +52,7 @@ export default function ReadingTimeline({ sessions = [] }) {
         .attr('y', 5)
         .attr('width', (d) => Math.max(1, x(d.endDate) - x(d.startDate)))
         .attr('height', 30)
-        .attr('fill', 'steelblue');
+        .attr('fill', (d) => color(d.bucket));
 
       bars
         .append('title')

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -7,19 +7,27 @@ import ReadingTimeline from '../ReadingTimeline.jsx';
 const sessions = [
   {
     start: '2025-01-01T00:00:00Z',
-    end: '2025-01-01T00:30:00Z',
+    end: '2025-01-01T00:10:00Z',
     asin: 'B001',
     title: 'Test Book 1',
-    duration: 30,
+    duration: 10,
     highlights: 2,
   },
   {
-    start: '2025-01-01T00:30:00Z',
-    end: '2025-01-01T01:00:00Z',
+    start: '2025-01-01T00:10:00Z',
+    end: '2025-01-01T00:40:00Z',
     asin: 'B002',
     title: 'Test Book 2',
     duration: 30,
     highlights: 1,
+  },
+  {
+    start: '2025-01-01T00:40:00Z',
+    end: '2025-01-01T01:30:00Z',
+    asin: 'B003',
+    title: 'Test Book 3',
+    duration: 50,
+    highlights: 3,
   },
 ];
 
@@ -50,5 +58,15 @@ describe('ReadingTimeline', () => {
     rect = svg.querySelector('rect');
     const resetWidth = Number(rect.getAttribute('width'));
     expect(resetWidth).toBeCloseTo(initialWidth);
+  });
+
+  it('applies color based on duration buckets', () => {
+    const { container } = render(<ReadingTimeline sessions={sessions} />);
+    const svg = container.querySelector('svg');
+    const rects = svg.querySelectorAll('g:not(.brush) rect');
+    expect(rects.length).toBe(3);
+    expect(rects[0]).toHaveAttribute('fill', '#4CAF50');
+    expect(rects[1]).toHaveAttribute('fill', '#2196F3');
+    expect(rects[2]).toHaveAttribute('fill', '#FFC107');
   });
 });


### PR DESCRIPTION
## Summary
- bucket reading session durations into short/medium/long categories
- color-code each session with an ordinal scale in the timeline
- verify fill color assignments in ReadingTimeline tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68922c8309888324a2ff9e11b2aa6248