### PR TITLE
feat: add icicle chart option to genre hierarchy

### DIFF
--- a/src/components/genre/GenreIcicle.jsx
+++ b/src/components/genre/GenreIcicle.jsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { select } from 'd3-selection';
+import { hierarchy, partition } from 'd3-hierarchy';
+import { scaleLinear, scaleOrdinal } from 'd3-scale';
+import { schemeCategory10 } from 'd3-scale-chromatic';
+import { hsl } from 'd3-color';
+import { interpolate } from 'd3-interpolate';
+import 'd3-transition';
+
+const WIDTH = 600;
+const HEIGHT = 400;
+
+export default function GenreIcicle({ data }) {
+  const ref = useRef(null);
+  const [currentNode, setCurrentNode] = useState(null);
+  const xScale = useRef(scaleLinear().range([0, WIDTH]).domain([0, WIDTH]));
+  const yScale = useRef(scaleLinear().range([0, HEIGHT]).domain([0, HEIGHT]));
+
+  const zoomTo = useCallback((node) => {
+    const svg = select(ref.current);
+    const t = svg.transition().duration(750);
+    t.tween('scale', () => {
+      const xd = interpolate(xScale.current.domain(), [node.x0, node.x1]);
+      const yd = interpolate(yScale.current.domain(), [node.y0, HEIGHT]);
+      return (t) => {
+        xScale.current.domain(xd(t));
+        yScale.current.domain(yd(t));
+      };
+    });
+    t.selectAll('rect')
+      .attr('x', (d) => xScale.current(d.x0))
+      .attr('y', (d) => yScale.current(d.y0))
+      .attr('width', (d) => xScale.current(d.x1) - xScale.current(d.x0))
+      .attr('height', (d) => yScale.current(d.y1) - yScale.current(d.y0));
+  }, []);
+
+  useEffect(() => {
+    const svg = select(ref.current);
+    svg.selectAll('*').remove();
+    if (!data) return;
+
+    const root = hierarchy(data).sum((d) => d.value || 0);
+    partition().size([WIDTH, HEIGHT])(root);
+    setCurrentNode(root);
+
+    const color = scaleOrdinal(schemeCategory10);
+
+    const getColor = (d) => {
+      if (d.color) return d.color;
+      const top = d.ancestors().find((a) => a.depth === 1) || d;
+      const base = hsl(color(top.data.name));
+      const depth = d.depth - 1;
+      base.s = Math.max(0, base.s - depth * 0.15);
+      base.l = Math.min(1, base.l + depth * 0.1);
+      d.color = base.toString();
+      return d.color;
+    };
+
+    const g = svg
+      .attr('viewBox', `0 0 ${WIDTH} ${HEIGHT}`)
+      .append('g');
+
+    g.selectAll('rect')
+      .data(root.descendants().filter((d) => d.depth))
+      .join('rect')
+      .attr('x', (d) => xScale.current(d.x0))
+      .attr('y', (d) => yScale.current(d.y0))
+      .attr('width', (d) => xScale.current(d.x1) - xScale.current(d.x0))
+      .attr('height', (d) => yScale.current(d.y1) - yScale.current(d.y0))
+      .attr('data-name', (d) => d.data.name)
+      .attr('fill', (d) => getColor(d))
+      .on('mouseover', function (_event, d) {
+        select(this).attr('fill', getColor(d));
+      })
+      .on('mouseout', function (_event, d) {
+        select(this).attr('fill', getColor(d));
+      })
+      .on('click', (_event, d) => {
+        setCurrentNode(d);
+        zoomTo(d);
+      })
+      .append('title')
+      .text((d) => d.data.name);
+  }, [data, zoomTo]);
+
+  const ancestors = currentNode ? currentNode.ancestors().reverse() : [];
+
+  return (
+    <div>
+      <div>
+        {ancestors.map((node, i) => (
+          <span key={node.data.name}>
+            {i > 0 && ' / '}
+            <button
+              type="button"
+              onClick={() => {
+                setCurrentNode(node);
+                zoomTo(node);
+              }}
+            >
+              {node.data.name}
+            </button>
+          </span>
+        ))}
+      </div>
+      <svg ref={ref} style={{ width: '100%', height: HEIGHT }} />
+    </div>
+  );
+}

--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -1,12 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
+import GenreIcicle from '@/components/genre/GenreIcicle.jsx';
 import genreHierarchy from '@/data/kindle/genre-hierarchy.json';
 
 export default function GenreSunburstPage() {
+  const [view, setView] = useState('sunburst');
+
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Genre Hierarchy Sunburst</h1>
-      <GenreSunburst data={genreHierarchy} />
+      <h1 className="text-xl font-bold mb-4">Genre Hierarchy</h1>
+      <div className="mb-4 space-x-2">
+        <button
+          type="button"
+          onClick={() => setView('sunburst')}
+          className="px-2 py-1 border rounded"
+        >
+          Sunburst
+        </button>
+        <button
+          type="button"
+          onClick={() => setView('icicle')}
+          className="px-2 py-1 border rounded"
+        >
+          Icicle
+        </button>
+      </div>
+      {view === 'sunburst' ? (
+        <GenreSunburst data={genreHierarchy} />
+      ) : (
+        <GenreIcicle data={genreHierarchy} />
+      )}
     </div>
   );
 }

--- a/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import GenreSunburstPage from '../GenreSunburst.jsx';
+
+vi.mock('@/components/genre/GenreSunburst.jsx', () => ({
+  default: () => <div data-testid="sunburst-layout" />,
+}));
+
+vi.mock('@/components/genre/GenreIcicle.jsx', () => ({
+  default: () => <div data-testid="icicle-layout" />,
+}));
+
+describe('GenreSunburstPage', () => {
+  it('toggles between sunburst and icicle layouts', async () => {
+    const user = userEvent.setup();
+    render(<GenreSunburstPage />);
+
+    expect(screen.getByTestId('sunburst-layout')).toBeInTheDocument();
+    expect(screen.queryByTestId('icicle-layout')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /icicle/i }));
+    expect(screen.getByTestId('icicle-layout')).toBeInTheDocument();
+    expect(screen.queryByTestId('sunburst-layout')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /sunburst/i }));
+    expect(screen.getByTestId('sunburst-layout')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create `GenreIcicle` component using a D3 partition layout for a hierarchical icicle chart
- allow genre chart page to switch between sunburst and icicle layouts
- test page toggle functionality

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68923591d0d483248abc89804be6c6f2