### PR TITLE
Group calendar heatmaps by year

### DIFF
--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -61,4 +61,18 @@ describe('CalendarHeatmap', () => {
     expect(minuteTexts.length).toBeGreaterThan(0);
     expect(screen.getAllByTestId('sparkline').length).toBeGreaterThan(0);
   });
+
+  it('renders separate heatmaps for each year', () => {
+    const twoYearData = [
+      { date: '2023-12-31', minutes: 30, pages: 10 },
+      { date: '2024-01-01', minutes: 5, pages: 2 },
+    ];
+    const { container, getByText } = render(
+      <CalendarHeatmap data={twoYearData} />
+    );
+    const svgs = container.querySelectorAll('svg.react-calendar-heatmap');
+    expect(svgs.length).toBe(2);
+    getByText('2023');
+    getByText('2024');
+  });
 });

--- a/src/pages/charts/ReadingCalendarHeatmap.jsx
+++ b/src/pages/charts/ReadingCalendarHeatmap.jsx
@@ -3,7 +3,7 @@ import CalendarHeatmap from '@/components/calendar/CalendarHeatmap.jsx';
 
 export default function ReadingCalendarHeatmapPage() {
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-8">
       <h1 className="text-xl font-bold mb-4">Daily Reading Calendar</h1>
       <CalendarHeatmap />
     </div>


### PR DESCRIPTION
## Summary
- Render a heatmap for each year of reading data with a year label stacked vertically
- Allow CalendarHeatmap to accept data via prop for easier testing
- Space page container to accommodate multiple yearly heatmaps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892321ca2dc83248c09438d708f2fa6