### PR TITLE
feat: add adjustable KDE violin plot

### DIFF
--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -4,13 +4,14 @@ import ReadingSpeedViolin from '../ReadingSpeedViolin';
 import '@testing-library/jest-dom';
 
 describe('ReadingSpeedViolin', () => {
-  it('renders toggles and chart', async () => {
+  it('renders controls and chart', async () => {
     render(<ReadingSpeedViolin />);
     expect(screen.getByLabelText('Morning')).toBeInTheDocument();
     expect(screen.getByLabelText('Evening')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bandwidth')).toBeInTheDocument();
     await waitFor(() => {
-      const rects = document.querySelectorAll('rect');
-      expect(rects.length).toBeGreaterThan(0);
+      const paths = document.querySelectorAll('path');
+      expect(paths.length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace histogram-based violin chart with d3 kernel density estimation
- expose bandwidth slider to control smoothing and recompute curves on change
- update tests for new controls and SVG output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689243da123483249ad2c030ee2ff2cd