### PR TITLE
feat: add daily reading stats dataset and tests

### DIFF
--- a/data/kindle/daily-stats.json
+++ b/data/kindle/daily-stats.json
@@ -1,0 +1,5 @@
+[
+  { "date": "2025-01-01", "minutes": 30, "pages": 20 },
+  { "date": "2025-01-02", "minutes": 25, "pages": 15 },
+  { "date": "2025-01-03", "minutes": 40, "pages": 30 }
+]

--- a/src/hooks/__tests__/useDailyReading.test.ts
+++ b/src/hooks/__tests__/useDailyReading.test.ts
@@ -1,0 +1,18 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import useDailyReading from '../useDailyReading'
+
+const sample = [
+  { date: '2025-01-01', minutes: 30, pages: 20 },
+  { date: '2025-01-02', minutes: 25, pages: 15 },
+  { date: '2025-01-03', minutes: 40, pages: 30 }
+]
+
+describe('useDailyReading', () => {
+  it('fetches daily reading data', async () => {
+    const { result } = renderHook(() => useDailyReading())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeNull()
+    expect(result.current.data).toEqual(sample)
+  })
+})

--- a/src/lib/__tests__/dailyReadingStats.test.ts
+++ b/src/lib/__tests__/dailyReadingStats.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { getDailyReadingStats } from '@/lib/api'
+
+// Expected sample data
+const sample = [
+  { date: '2025-01-01', minutes: 30, pages: 20 },
+  { date: '2025-01-02', minutes: 25, pages: 15 },
+  { date: '2025-01-03', minutes: 40, pages: 30 }
+]
+
+describe('getDailyReadingStats', () => {
+  it('returns daily reading stats from dataset', async () => {
+    const data = await getDailyReadingStats()
+    expect(data).toEqual(sample)
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,7 +10,7 @@ import { computeRouteMetrics } from "./routeMetrics";
 import { getAllSessionMeta } from "./sessionStore";
 export { calculateRouteSimilarity } from "./routeMetrics";
 export type { LocationVisit } from "./locationStore";
-import dailyReadingData from "../data/kindle/daily-stats.json";
+import dailyReadingData from "../../data/kindle/daily-stats.json";
 import sessionData from "../data/kindle/sessions.json";
 
 export type Activity = {


### PR DESCRIPTION
## Summary
- point `getDailyReadingStats` at new Kindle daily stats dataset
- add dataset and tests for daily reading stats and hook

## Testing
- `npm test`
- `npx vitest run src/hooks/__tests__/useDailyReading.test.ts src/lib/__tests__/dailyReadingStats.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689243f8a05c8324a9441a04aba03375