### PR TITLE
feat(wordtree): add count bars

### DIFF
--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -192,30 +192,22 @@ export default function WordTree() {
       })
       .remove();
 
-    nodeMerge.select('rect').remove();
-
-    nodeMerge.each(d => {
-      if (d.parent) {
-        const counts = d.parent.children.map(c => c.data.count || 0);
-        d.siblingMax = Math.max(...counts);
-      }
+    nodeMerge.each(function (d) {
+      select(this).select('rect').remove();
+      if (!d.data.count) return;
+      const siblingMax = d.parent
+        ? Math.max(...d.parent.children.map(c => c.data.count || 0))
+        : d.data.count;
+      const textWidth = select(this).select('text').node().getBBox().width;
+      const scale = scaleLinear().domain([0, siblingMax]).range([0, 60]);
+      select(this)
+        .append('rect')
+        .attr('x', 8 + textWidth + 4)
+        .attr('y', -3)
+        .attr('height', 6)
+        .attr('width', scale(d.data.count))
+        .attr('fill', 'var(--chart-wordtree-bar)');
     });
-
-    nodeMerge
-      .filter(d => d.data.count)
-      .each(function (d) {
-        const textWidth = select(this).select('text').node().getBBox().width;
-        const scale = scaleLinear()
-          .domain([0, d.siblingMax || d.data.count])
-          .range([0, 60]);
-        select(this)
-          .append('rect')
-          .attr('x', 8 + textWidth + 4)
-          .attr('y', -3)
-          .attr('height', 6)
-          .attr('width', scale(d.data.count))
-          .attr('fill', 'var(--chart-wordtree-bar)');
-      });
 
     nodes.forEach(d => {
       d.data.x0 = d.x;

--- a/src/styles/chartPalette.css
+++ b/src/styles/chartPalette.css
@@ -4,6 +4,7 @@
     --chart-network-link: #999;
     --chart-network-node-border: #fff;
     --chart-wordtree-node: #555;
+    --chart-wordtree-bar: #999;
   }
 
   .dark {
@@ -11,6 +12,7 @@
     --chart-network-link: #999;
     --chart-network-node-border: #fff;
     --chart-wordtree-node: #bbb;
+    --chart-wordtree-bar: #666;
   }
 
   .contrast {
@@ -18,5 +20,6 @@
     --chart-network-link: #fff;
     --chart-network-node-border: #000;
     --chart-wordtree-node: #fff;
+    --chart-wordtree-bar: #fff;
   }
 }


### PR DESCRIPTION
## Summary
- add bars to WordTree nodes showing relative counts
- style wordtree bar color in palette

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6892445e00e883248eac0d71dbedeb50