### PR TITLE
Fetch genre transitions by date range

### DIFF
--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -11,13 +11,21 @@ export default function GenreSankey() {
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
 
-  const fetchData = () => {
-    setData(transitions);
+  const fetchData = async () => {
+    const res = await fetch(
+      `/api/kindle/genre-transitions?start=${start}&end=${end}`,
+    );
+    const json = await res.json();
+    setData(json);
   };
 
   useEffect(() => {
     setData(transitions);
   }, []);
+
+  useEffect(() => {
+    if (start && end) fetchData();
+  }, [start, end]);
 
   useEffect(() => {
     const svg = select(svgRef.current);

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -1,17 +1,52 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import GenreSankey from '../GenreSankey';
+import { vi } from 'vitest';
 
 describe('GenreSankey', () => {
-  it('renders date controls and svg', async () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('filters data when dates are applied', async () => {
+    const filtered = [{ source: 'A', target: 'B', count: 1 }];
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(filtered),
+    });
+
     const { container } = render(<GenreSankey />);
     expect(screen.getByLabelText('Start')).toBeInTheDocument();
     expect(screen.getByLabelText('End')).toBeInTheDocument();
+
     await waitFor(() => {
-      const rects = container.querySelectorAll('rect');
-      expect(rects.length).toBeGreaterThan(0);
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
     });
+    const initialCount = container.querySelectorAll('path').length;
+    expect(initialCount).toBeGreaterThan(filtered.length);
+
+    fireEvent.change(screen.getByLabelText('Start'), {
+      target: { value: '2024-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('End'), {
+      target: { value: '2024-01-31' },
+    });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        '/api/kindle/genre-transitions?start=2024-01-01&end=2024-01-31',
+      );
+      expect(container.querySelectorAll('path').length).toBe(filtered.length);
+    });
+    expect(container.querySelectorAll('path').length).not.toBe(initialCount);
   });
 
   it('renders links with non-gray strokes', async () => {


### PR DESCRIPTION
## Summary
- Fetch genre transition data from `/api/kindle/genre-transitions` using selected start/end dates and auto-refresh when dates change
- Test GenreSankey to ensure date entry triggers filtered fetch and rerender

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68924739fb38832492a61fb58e275775