### PR TITLE
refactor charts to use shared color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ All colours, spacings, radii, etc. should come from your CSS variables in `globa
 
 Add new tokens (e.g. `--chart-6`–`--chart-10`) in the same `:root { … }` block so everything—charts, rings, cards—uses the same palette.
 
+Charts share a unified palette exposed as `--chart-1` through `--chart-10`. Use them in components via `hsl(var(--chart-n))` so every visualisation draws from the same source.
+
 Dark mode is driven via the `<html class="dark">` class and the corresponding `.dark { … }` overrides in `globals.css`.
 
 ## Component conventions

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -2,7 +2,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
 import { scaleOrdinal } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
+
+const CHART_COLORS = Array.from(
+  { length: 10 },
+  (_, i) => `hsl(var(--chart-${i + 1}))`,
+);
 import transitions from '@/data/kindle/genre-transitions.json';
 
 export default function GenreSankey() {
@@ -46,7 +50,7 @@ export default function GenreSankey() {
         links: links.map((d) => ({ ...d })),
       });
 
-    const color = scaleOrdinal(schemeCategory10);
+    const color = scaleOrdinal(CHART_COLORS);
 
     svg.attr('viewBox', `0 0 ${width} ${height}`);
 

--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -10,7 +10,11 @@ import highlights from '@/data/kindle/highlights.json';
 const sentimentAnalyzer = new Sentiment();
 const sentimentColor = scaleLinear()
   .domain([-5, 0, 5])
-  .range(['#d73027', '#ffffbf', '#1a9850']);
+  .range([
+    'hsl(var(--chart-1))',
+    'hsl(var(--chart-5))',
+    'hsl(var(--chart-9))',
+  ]);
 
 function getExpansions(word) {
   const counts = {};
@@ -127,7 +131,7 @@ export default function WordTree() {
           enter
             .append('path')
             .attr('fill', 'none')
-            .attr('stroke', 'var(--chart-network-link)')
+            .attr('stroke', 'hsl(var(--chart-2))')
             .attr('d', d => {
               const o = { x: d.source.data.x0, y: d.source.data.y0 };
               return linkFn({ source: o, target: o });
@@ -162,7 +166,7 @@ export default function WordTree() {
     nodeEnter
       .append('circle')
       .attr('r', 0)
-      .attr('fill', 'var(--chart-wordtree-node)')
+      .attr('fill', 'hsl(var(--chart-6))')
       .transition(t)
       .attr('r', 4);
 
@@ -214,7 +218,7 @@ export default function WordTree() {
           .attr('y', -3)
           .attr('height', 6)
           .attr('width', scale(d.data.count))
-          .attr('fill', 'var(--chart-wordtree-bar)');
+          .attr('fill', 'hsl(var(--chart-3))');
       });
 
     nodes.forEach(d => {
@@ -268,13 +272,25 @@ export default function WordTree() {
       </form>
       <div className="mb-2 flex items-center gap-2 text-sm">
         <span className="flex items-center">
-          <span className="w-4 h-4 mr-1" style={{ background: '#d73027' }}></span>Negative
+          <span
+            className="w-4 h-4 mr-1"
+            style={{ background: 'hsl(var(--chart-1))' }}
+          ></span>
+          Negative
         </span>
         <span className="flex items-center">
-          <span className="w-4 h-4 mr-1 border" style={{ background: '#ffffbf' }}></span>Neutral
+          <span
+            className="w-4 h-4 mr-1 border"
+            style={{ background: 'hsl(var(--chart-5))' }}
+          ></span>
+          Neutral
         </span>
         <span className="flex items-center">
-          <span className="w-4 h-4 mr-1" style={{ background: '#1a9850' }}></span>Positive
+          <span
+            className="w-4 h-4 mr-1"
+            style={{ background: 'hsl(var(--chart-9))' }}
+          ></span>
+          Positive
         </span>
       </div>
       <svg ref={svgRef} width={layout === 'linear' ? 800 : 400} height={400}></svg>

--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -5,7 +5,11 @@ import { brushX } from 'd3-brush';
 import { axisBottom } from 'd3-axis';
 import { timeMonth } from 'd3-time';
 import { timeFormat } from 'd3-time-format';
-import { schemeTableau10 } from 'd3-scale-chromatic';
+
+const CHART_COLORS = Array.from(
+  { length: 10 },
+  (_, i) => `hsl(var(--chart-${i + 1}))`,
+);
 
 const WIDTH = 600;
 const BAR_HEIGHT = 30;
@@ -51,7 +55,7 @@ export default function ReadingTimeline({ sessions = [] }) {
     [sessions],
   );
   const colorScale = useMemo(
-    () => scaleOrdinal().domain(genres).range(schemeTableau10),
+    () => scaleOrdinal().domain(genres).range(CHART_COLORS),
     [genres],
   );
 

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -4,7 +4,6 @@ import '@testing-library/jest-dom';
 import { select } from 'd3-selection';
 import { act } from 'react';
 import { scaleOrdinal } from 'd3-scale';
-import { schemeTableau10 } from 'd3-scale-chromatic';
 import ReadingTimeline from '../ReadingTimeline.jsx';
 
 const sessions = [
@@ -124,9 +123,13 @@ describe('ReadingTimeline', () => {
     const { container } = render(<ReadingTimeline sessions={sessions} />);
     const svg = container.querySelector('svg');
     const rects = svg.querySelectorAll('rect[height="30"]');
+    const chartColors = Array.from(
+      { length: 10 },
+      (_, i) => `hsl(var(--chart-${i + 1}))`,
+    );
     const color = scaleOrdinal()
       .domain(['Mystery', 'Fantasy'])
-      .range(schemeTableau10.slice(0, 2));
+      .range(chartColors);
     expect(rects[0].getAttribute('fill')).toBe(color(sessions[0].genre));
     expect(rects[1].getAttribute('fill')).toBe(color(sessions[1].genre));
   });

--- a/src/components/trends/FocusTimeline.tsx
+++ b/src/components/trends/FocusTimeline.tsx
@@ -23,8 +23,8 @@ interface Segment {
 }
 
 const stateColors: Record<Segment["state"], string> = {
-  focus: "#d1fae5", // green-100
-  distracted: "#fee2e2", // red-100
+  focus: "hsl(var(--chart-3))",
+  distracted: "hsl(var(--chart-5))",
 };
 
 export default function FocusTimeline({ events }: FocusTimelineProps) {
@@ -77,8 +77,8 @@ export default function FocusTimeline({ events }: FocusTimelineProps) {
         <defs>
           {!lowEnd && (
             <linearGradient id="confidenceGradient" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+              <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0} />
             </linearGradient>
           )}
         </defs>
@@ -103,8 +103,8 @@ export default function FocusTimeline({ events }: FocusTimelineProps) {
         <Area
           type="monotone"
           dataKey="confidence"
-          stroke="#3b82f6"
-          fill={lowEnd ? "#3b82f6" : "url(#confidenceGradient)"}
+          stroke="hsl(var(--chart-1))"
+          fill={lowEnd ? "hsl(var(--chart-1))" : "url(#confidenceGradient)"}
           isAnimationActive={!lowEnd}
         />
         {!lowEnd &&
@@ -114,7 +114,7 @@ export default function FocusTimeline({ events }: FocusTimelineProps) {
               x={b.time}
               y={1}
               r={6}
-              fill="#ef4444"
+              fill="hsl(var(--chart-2))"
               stroke="none"
             />
           ))}


### PR DESCRIPTION
## Summary
- use CSS chart palette tokens in ReadingTimeline and tests
- replace hardcoded hues in WordTree, FocusTimeline, and GenreSankey with palette vars
- document shared chart palette in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892474f32208324b703a9c2ecefc745