### PR TITLE
feat: add skeleton loading states

### DIFF
--- a/src/components/map/ReadingMap.jsx
+++ b/src/components/map/ReadingMap.jsx
@@ -14,9 +14,11 @@ import { interpolateYlOrRd } from 'd3-scale-chromatic';
 import locationsData from '@/data/kindle/locations.json';
 import statesTopo from '@/lib/us-states.json';
 import worldTopo from '@/lib/world-countries.json';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function ReadingMap() {
   const [locations, setLocations] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
   const [title, setTitle] = useState('');
@@ -36,6 +38,7 @@ export default function ReadingMap() {
         (a, b) => new Date(a.start) - new Date(b.start)
       )
     );
+    setLoading(false);
   }, []);
 
   const filtered = useMemo(() => {
@@ -124,6 +127,9 @@ export default function ReadingMap() {
     () => scaleSequential(interpolateYlOrRd).domain([0, maxCount || 1]),
     [maxCount]
   );
+
+  if (loading)
+    return <Skeleton className="h-[480px] w-full" data-testid="loading" />;
 
   return (
     <div>

--- a/src/pages/TimelinePage.jsx
+++ b/src/pages/TimelinePage.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import useReadingSessions from '@/hooks/useReadingSessions';
 import ReadingTimeline from '@/components/timeline/ReadingTimeline.jsx';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function TimelinePage() {
   const { data, error, isLoading } = useReadingSessions();
+
   if (error) return <div>Failed to load sessions</div>;
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <Skeleton className="h-64 w-full" />;
   return <ReadingTimeline sessions={data || []} />;
 }

--- a/src/pages/charts/ReadingTimeline.jsx
+++ b/src/pages/charts/ReadingTimeline.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import useReadingSessions from '@/hooks/useReadingSessions';
 import ReadingTimeline from '@/components/timeline/ReadingTimeline.jsx';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function ReadingTimelinePage() {
   const { data, error, isLoading } = useReadingSessions();
-  if (error) return <div>Failed to load sessions</div>;
-  if (isLoading) return <div>Loading...</div>;
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Reading Timeline</h1>
-      <ReadingTimeline sessions={data || []} />
+      {error ? (
+        <div>Failed to load sessions</div>
+      ) : isLoading ? (
+        <Skeleton className="h-64 w-full" />
+      ) : (
+        <ReadingTimeline sessions={data || []} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show map skeleton while reading locations load
- use skeleton placeholders for reading timeline pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689247087c7c83249af4293da40abdc4