### PR TITLE
feat: use chart tokens for genre visuals

### DIFF
--- a/src/components/genre/GenreIcicle.jsx
+++ b/src/components/genre/GenreIcicle.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { hierarchy, partition } from 'd3-hierarchy';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
 import { hsl } from 'd3-color';
 import { interpolate } from 'd3-interpolate';
 import 'd3-transition';
@@ -43,7 +42,14 @@ export default function GenreIcicle({ data }) {
     partition().size([WIDTH, HEIGHT])(root);
     setCurrentNode(root);
 
-    const color = scaleOrdinal(schemeCategory10);
+    const style = getComputedStyle(document.documentElement);
+    const chartColors = Array.from({ length: 10 }, (_, i) =>
+      `hsl(${style
+        .getPropertyValue(`--chart-${i + 1}`)
+        .trim()
+        .replace(/\s+/g, ',')})`
+    );
+    const color = scaleOrdinal().range(chartColors);
 
     const getColor = (d) => {
       if (d.color) return d.color;

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
 import { scaleOrdinal } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
 import transitions from '@/data/kindle/genre-transitions.json';
 
 export default function GenreSankey() {
@@ -46,7 +45,14 @@ export default function GenreSankey() {
         links: links.map((d) => ({ ...d })),
       });
 
-    const color = scaleOrdinal(schemeCategory10);
+    const style = getComputedStyle(document.documentElement);
+    const chartColors = Array.from({ length: 10 }, (_, i) =>
+      `hsl(${style
+        .getPropertyValue(`--chart-${i + 1}`)
+        .trim()
+        .replace(/\s+/g, ',')})`
+    );
+    const color = scaleOrdinal().range(chartColors);
 
     svg.attr('viewBox', `0 0 ${width} ${height}`);
 

--- a/src/components/genre/GenreSunburst.jsx
+++ b/src/components/genre/GenreSunburst.jsx
@@ -3,7 +3,6 @@ import { select } from 'd3-selection';
 import { hierarchy, partition } from 'd3-hierarchy';
 import { arc } from 'd3-shape';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
 import { hsl } from 'd3-color';
 import { interpolate } from 'd3-interpolate';
 import 'd3-transition';
@@ -47,7 +46,14 @@ export default function GenreSunburst({ data }) {
     partition().size([2 * Math.PI, RADIUS])(root);
     setCurrentNode(root);
 
-    const color = scaleOrdinal(schemeCategory10);
+    const style = getComputedStyle(document.documentElement);
+    const chartColors = Array.from({ length: 10 }, (_, i) =>
+      `hsl(${style
+        .getPropertyValue(`--chart-${i + 1}`)
+        .trim()
+        .replace(/\s+/g, ',')})`
+    );
+    const color = scaleOrdinal().range(chartColors);
 
     const getColor = (d) => {
       if (d.color) return d.color;

--- a/src/components/genre/__tests__/GenreIcicle.test.jsx
+++ b/src/components/genre/__tests__/GenreIcicle.test.jsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { hsl as d3hsl } from 'd3-color';
+import GenreIcicle from '../GenreIcicle';
+
+describe('GenreIcicle', () => {
+  const data = {
+    name: 'root',
+    children: [
+      {
+        name: 'A',
+        children: [
+          { name: 'A1', value: 1 },
+          { name: 'A2', value: 1 },
+        ],
+      },
+      { name: 'B', value: 1 },
+    ],
+  };
+
+  beforeEach(() => {
+    for (let i = 1; i <= 10; i++) {
+      document.documentElement.style.setProperty(
+        `--chart-${i}`,
+        `${(i - 1) * 36} 100% 50%`
+      );
+    }
+  });
+
+  it('maps top-level genres to --chart-1 and reuses token for descendants', () => {
+    const { container } = render(<GenreIcicle data={data} />);
+    const rectA = container.querySelector('rect[data-name="A"]');
+    const rectA1 = container.querySelector('rect[data-name="A1"]');
+
+    const colorA = d3hsl(rectA.getAttribute('fill'));
+    const colorA1 = d3hsl(rectA1.getAttribute('fill'));
+
+    const chart1 = getComputedStyle(document.documentElement)
+      .getPropertyValue('--chart-1')
+      .trim();
+    const chart1Color = d3hsl(`hsl(${chart1.replace(/\s+/g, ',')})`);
+
+    expect(colorA.h).toBeCloseTo(chart1Color.h, 0);
+    expect(colorA.h).toBeCloseTo(colorA1.h, 0);
+  });
+});

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -4,6 +4,15 @@ import React from 'react';
 import GenreSankey from '../GenreSankey';
 
 describe('GenreSankey', () => {
+  beforeEach(() => {
+    for (let i = 1; i <= 10; i++) {
+      document.documentElement.style.setProperty(
+        `--chart-${i}`,
+        `${(i - 1) * 36} 100% 50%`
+      );
+    }
+  });
+
   it('renders date controls and svg', async () => {
     const { container } = render(<GenreSankey />);
     expect(screen.getByLabelText('Start')).toBeInTheDocument();
@@ -24,6 +33,23 @@ describe('GenreSankey', () => {
         return stroke && stroke !== '#999' && stroke !== 'var(--chart-network-link)';
       });
       expect(hasColoredLink).toBe(true);
+    });
+  });
+
+  it('uses chart token palette for nodes', async () => {
+    const { container } = render(<GenreSankey />);
+    const chart1 = getComputedStyle(document.documentElement)
+      .getPropertyValue('--chart-1')
+      .trim()
+      .replace(/\s+/g, ',');
+    const expected = `hsl(${chart1})`;
+    await waitFor(() => {
+      const rects = container.querySelectorAll('rect');
+      expect(rects.length).toBeGreaterThan(0);
+      const hasChart1 = Array.from(rects).some(
+        (r) => r.getAttribute('fill') === expected
+      );
+      expect(hasChart1).toBe(true);
     });
   });
 });

--- a/src/components/genre/__tests__/GenreSunburst.test.jsx
+++ b/src/components/genre/__tests__/GenreSunburst.test.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import GenreSunburst from '../GenreSunburst';
 import { hsl as d3hsl } from 'd3-color';
 
-  describe('GenreSunburst', () => {
+describe('GenreSunburst', () => {
   const data = {
     name: 'root',
     children: [
@@ -20,7 +20,16 @@ import { hsl as d3hsl } from 'd3-color';
     ],
   };
 
-    it('updates breadcrumb and zooms on interactions', async () => {
+  beforeEach(() => {
+    for (let i = 1; i <= 10; i++) {
+      document.documentElement.style.setProperty(
+        `--chart-${i}`,
+        `${(i - 1) * 36} 100% 50%`
+      );
+    }
+  });
+
+  it('updates breadcrumb and zooms on interactions', async () => {
     const user = userEvent.setup();
 
     const { container } = render(<GenreSunburst data={data} />);
@@ -40,35 +49,41 @@ import { hsl as d3hsl } from 'd3-color';
 
     expect(screen.queryByRole('button', { name: 'A' })).not.toBeInTheDocument();
     expect(pathA.getAttribute('d')).toBe(initial);
-    });
-
-    it('applies depth-based colors and preserves them on hover and zoom', async () => {
-      const user = userEvent.setup();
-      const { container } = render(<GenreSunburst data={data} />);
-      const svg = container.querySelector('svg');
-      const pathA = svg.querySelector('path[data-name="A"]');
-      const pathB = svg.querySelector('path[data-name="B"]');
-      const pathA1 = svg.querySelector('path[data-name="A1"]');
-
-      const colorA = d3hsl(pathA.getAttribute('fill'));
-      const colorB = d3hsl(pathB.getAttribute('fill'));
-      const colorA1 = d3hsl(pathA1.getAttribute('fill'));
-
-      expect(colorA.h).not.toBe(colorB.h);
-        expect(colorA.h).toBeCloseTo(colorA1.h, 0);
-      expect(colorA.s).not.toBe(colorA1.s);
-      expect(colorA.l).not.toBe(colorA1.l);
-
-      const initialA1 = pathA1.getAttribute('fill');
-      await user.hover(pathA1);
-      expect(pathA1.getAttribute('fill')).toBe(initialA1);
-      await user.unhover(pathA1);
-      expect(pathA1.getAttribute('fill')).toBe(initialA1);
-
-      const initialA = pathA.getAttribute('fill');
-      await user.click(pathA);
-      await new Promise((r) => setTimeout(r, 800));
-      expect(pathA.getAttribute('fill')).toBe(initialA);
-    });
   });
+
+  it('applies depth-based colors and preserves them on hover and zoom', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<GenreSunburst data={data} />);
+    const svg = container.querySelector('svg');
+    const pathA = svg.querySelector('path[data-name="A"]');
+    const pathB = svg.querySelector('path[data-name="B"]');
+    const pathA1 = svg.querySelector('path[data-name="A1"]');
+
+    const colorA = d3hsl(pathA.getAttribute('fill'));
+    const colorB = d3hsl(pathB.getAttribute('fill'));
+    const colorA1 = d3hsl(pathA1.getAttribute('fill'));
+
+    const chart1 = getComputedStyle(document.documentElement)
+      .getPropertyValue('--chart-1')
+      .trim();
+    const chart1Color = d3hsl(`hsl(${chart1.replace(/\s+/g, ',')})`);
+
+    expect(colorA.h).toBeCloseTo(chart1Color.h, 0);
+    expect(colorA.h).not.toBe(colorB.h);
+    expect(colorA.h).toBeCloseTo(colorA1.h, 0);
+    expect(colorA.s).not.toBe(colorA1.s);
+    expect(colorA.l).not.toBe(colorA1.l);
+
+    const initialA1 = pathA1.getAttribute('fill');
+    await user.hover(pathA1);
+    expect(pathA1.getAttribute('fill')).toBe(initialA1);
+    await user.unhover(pathA1);
+    expect(pathA1.getAttribute('fill')).toBe(initialA1);
+
+    const initialA = pathA.getAttribute('fill');
+    await user.click(pathA);
+    await new Promise((r) => setTimeout(r, 800));
+    expect(pathA.getAttribute('fill')).toBe(initialA);
+  });
+});
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,7 +25,11 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.65rem;
-    /* Chart color tokens */
+    /*
+     * Chart color tokens used by data visualizations.
+     * Each token represents an HSL color and is consumed
+     * by D3 components to build ordinal palettes.
+     */
     --chart-1: 210 100% 45%;
     --chart-2: 214 90% 50%;
     --chart-3: 218 80% 55%;
@@ -73,7 +77,11 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 224.3 76.3% 48%;
-    /* Chart color tokens */
+    /*
+     * Chart color tokens used by data visualizations.
+     * Dark theme variants of --chart-n tokens
+     * mirror the light theme hues with adjusted lightness.
+     */
     --chart-1: 210 100% 55%;
     --chart-2: 214 90% 60%;
     --chart-3: 218 80% 65%;
@@ -121,7 +129,11 @@
     --border: 0 0% 100%;
     --input: 0 0% 100%;
     --ring: 60 100% 50%;
-    /* Chart color tokens */
+    /*
+     * Chart color tokens used by data visualizations.
+     * High contrast variants ensure accessibility while
+     * preserving the ordinal palette.
+     */
     --chart-1: 60 100% 50%;
     --chart-2: 0 0% 100%;
     --chart-3: 120 100% 50%;


### PR DESCRIPTION
## Summary
- document chart color tokens in globals.css
- use CSS token palette for GenreSunburst, GenreSankey and GenreIcicle
- test genre charts map top-level genres to token palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892474566588324924adf7f4d6451d2