### PR TITLE
refactor: use tokenized chart colors

### DIFF
--- a/src/components/analytical/TransitionMatrix.tsx
+++ b/src/components/analytical/TransitionMatrix.tsx
@@ -12,18 +12,7 @@ interface TransitionMatrixProps {
   size?: number;
 }
 
-const defaultColors = [
-  "#1f77b4",
-  "#ff7f0e",
-  "#2ca02c",
-  "#d62728",
-  "#9467bd",
-  "#8c564b",
-  "#e377c2",
-  "#7f7f7f",
-  "#bcbd22",
-  "#17becf",
-];
+const defaultColors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
 
 export default function TransitionMatrix({ matrix, labels, size = 300 }: TransitionMatrixProps) {
   const ref = useRef<SVGSVGElement | null>(null);

--- a/src/components/analytical/__tests__/CorrelationRippleMatrix.test.tsx
+++ b/src/components/analytical/__tests__/CorrelationRippleMatrix.test.tsx
@@ -1,8 +1,9 @@
 import { render, waitFor, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeAll } from 'vitest'
 import React from 'react'
 import '@testing-library/jest-dom'
 import CorrelationRippleMatrix from '../CorrelationRippleMatrix'
+import { hsl as d3hsl } from 'd3-color'
 
 vi.mock('recharts', async () => {
   const actual: any = await vi.importActual('recharts')
@@ -14,6 +15,21 @@ vi.mock('recharts', async () => {
       </div>
     ),
   }
+})
+
+beforeAll(() => {
+  const root = document.documentElement.style
+  root.setProperty('--background', '0 0% 100%')
+  root.setProperty('--chart-1', '210 100% 45%')
+  root.setProperty('--chart-2', '214 90% 50%')
+  root.setProperty('--chart-3', '218 80% 55%')
+  root.setProperty('--chart-4', '222 70% 60%')
+  root.setProperty('--chart-5', '226 60% 65%')
+  root.setProperty('--chart-6', '230 70% 50%')
+  root.setProperty('--chart-7', '234 80% 55%')
+  root.setProperty('--chart-8', '238 90% 60%')
+  root.setProperty('--chart-9', '242 80% 65%')
+  root.setProperty('--chart-10', '246 70% 70%')
 })
 
 describe('CorrelationRippleMatrix', () => {
@@ -82,8 +98,15 @@ describe('CorrelationRippleMatrix', () => {
 
     const legend = container.querySelector('[data-testid="legend-gradient"]') as HTMLDivElement
     const bg = legend.style.background.replace(/\s/g, '')
-    expect(bg).toContain('rgb(0,68,27)')
-    expect(bg).toContain('rgb(64,0,75)')
+    const getRgb = (name: string) => {
+      const v = getComputedStyle(document.documentElement)
+        .getPropertyValue(name)
+        .trim()
+        .replace(/\s+/g, ', ')
+      return d3hsl(`hsl(${v})`).rgb().toString()
+    }
+    expect(bg).toContain(getRgb('--chart-3'))
+    expect(bg).toContain(getRgb('--chart-4'))
   })
 
   it('supports viridis palette', () => {
@@ -104,8 +127,15 @@ describe('CorrelationRippleMatrix', () => {
 
     const legend = container.querySelector('[data-testid="legend-gradient"]') as HTMLDivElement
     const bg = legend.style.background.replace(/\s/g, '')
-    expect(bg).toContain('#440154')
-    expect(bg).toContain('#fde725')
+    const getRgb = (name: string) => {
+      const v = getComputedStyle(document.documentElement)
+        .getPropertyValue(name)
+        .trim()
+        .replace(/\s+/g, ', ')
+      return d3hsl(`hsl(${v})`).rgb().toString()
+    }
+    expect(bg).toContain(getRgb('--chart-5'))
+    expect(bg).toContain(getRgb('--chart-6'))
   })
 
   it('respects displayMode for lower triangle', () => {

--- a/src/components/genre/GenreIcicle.jsx
+++ b/src/components/genre/GenreIcicle.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { hierarchy, partition } from 'd3-hierarchy';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
 import { hsl } from 'd3-color';
 import { interpolate } from 'd3-interpolate';
 import 'd3-transition';
@@ -43,12 +42,25 @@ export default function GenreIcicle({ data }) {
     partition().size([WIDTH, HEIGHT])(root);
     setCurrentNode(root);
 
-    const color = scaleOrdinal(schemeCategory10);
+    const chartColors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
+    const color = scaleOrdinal(chartColors);
+
+    const resolveHslVar = (str) => {
+      const match = str.match(/var\((--[^)]+)\)/);
+      if (match) {
+        const val = getComputedStyle(document.documentElement)
+          .getPropertyValue(match[1])
+          .trim()
+          .replace(/\s+/g, ', ');
+        return hsl(`hsl(${val})`);
+      }
+      return hsl(str);
+    };
 
     const getColor = (d) => {
       if (d.color) return d.color;
       const top = d.ancestors().find((a) => a.depth === 1) || d;
-      const base = hsl(color(top.data.name));
+      const base = resolveHslVar(color(top.data.name));
       const depth = d.depth - 1;
       base.s = Math.max(0, base.s - depth * 0.15);
       base.l = Math.min(1, base.l + depth * 0.1);

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
 import { scaleOrdinal } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
 import transitions from '@/data/kindle/genre-transitions.json';
 
 export default function GenreSankey() {
@@ -54,7 +53,8 @@ export default function GenreSankey() {
         links: links.map((d) => ({ ...d })),
       });
 
-    const color = scaleOrdinal(schemeCategory10);
+    const chartColors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
+    const color = scaleOrdinal(chartColors);
 
     svg.attr('viewBox', `0 0 ${width} ${height}`);
 

--- a/src/components/genre/__tests__/GenreSunburst.test.jsx
+++ b/src/components/genre/__tests__/GenreSunburst.test.jsx
@@ -4,10 +4,11 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import GenreSunburst from '../GenreSunburst';
 import { hsl as d3hsl } from 'd3-color';
+import { beforeAll } from 'vitest';
 
   describe('GenreSunburst', () => {
   const data = {
-    name: 'root',
+  name: 'root',
     children: [
       {
         name: 'A',
@@ -18,7 +19,21 @@ import { hsl as d3hsl } from 'd3-color';
       },
       { name: 'B', value: 1 },
     ],
-  };
+};
+
+beforeAll(() => {
+  const root = document.documentElement.style;
+  root.setProperty('--chart-1', '210 100% 45%');
+  root.setProperty('--chart-2', '214 90% 50%');
+  root.setProperty('--chart-3', '218 80% 55%');
+  root.setProperty('--chart-4', '222 70% 60%');
+  root.setProperty('--chart-5', '226 60% 65%');
+  root.setProperty('--chart-6', '230 70% 50%');
+  root.setProperty('--chart-7', '234 80% 55%');
+  root.setProperty('--chart-8', '238 90% 60%');
+  root.setProperty('--chart-9', '242 80% 65%');
+  root.setProperty('--chart-10', '246 70% 70%');
+});
 
     it('updates breadcrumb and zooms on interactions', async () => {
     const user = userEvent.setup();

--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -10,7 +10,11 @@ import highlights from '@/data/kindle/highlights.json';
 const sentimentAnalyzer = new Sentiment();
 const sentimentColor = scaleLinear()
   .domain([-5, 0, 5])
-  .range(['#d73027', '#ffffbf', '#1a9850']);
+  .range([
+    'hsl(var(--chart-1))',
+    'hsl(var(--chart-5))',
+    'hsl(var(--chart-9))',
+  ]);
 
 function getExpansions(word) {
   const counts = {};
@@ -260,13 +264,25 @@ export default function WordTree() {
       </form>
       <div className="mb-2 flex items-center gap-2 text-sm">
         <span className="flex items-center">
-          <span className="w-4 h-4 mr-1" style={{ background: '#d73027' }}></span>Negative
+          <span
+            className="w-4 h-4 mr-1"
+            style={{ background: 'hsl(var(--chart-1))' }}
+          ></span>
+          Negative
         </span>
         <span className="flex items-center">
-          <span className="w-4 h-4 mr-1 border" style={{ background: '#ffffbf' }}></span>Neutral
+          <span
+            className="w-4 h-4 mr-1 border"
+            style={{ background: 'hsl(var(--chart-5))' }}
+          ></span>
+          Neutral
         </span>
         <span className="flex items-center">
-          <span className="w-4 h-4 mr-1" style={{ background: '#1a9850' }}></span>Positive
+          <span
+            className="w-4 h-4 mr-1"
+            style={{ background: 'hsl(var(--chart-9))' }}
+          ></span>
+          Positive
         </span>
       </div>
       <svg ref={svgRef} width={layout === 'linear' ? 800 : 400} height={400}></svg>

--- a/src/components/map/ReadingMap.jsx
+++ b/src/components/map/ReadingMap.jsx
@@ -10,7 +10,8 @@ import {
 import { feature } from 'topojson-client';
 import { geoContains } from 'd3-geo';
 import { scaleSequential } from 'd3-scale';
-import { interpolateYlOrRd } from 'd3-scale-chromatic';
+import { hsl } from 'd3-color';
+import { interpolateHsl } from 'd3-interpolate';
 import locationsData from '@/data/kindle/locations.json';
 import statesTopo from '@/lib/us-states.json';
 import worldTopo from '@/lib/world-countries.json';
@@ -120,10 +121,17 @@ export default function ReadingMap() {
     [choropleth]
   );
 
-  const colorScale = useMemo(
-    () => scaleSequential(interpolateYlOrRd).domain([0, maxCount || 1]),
-    [maxCount]
-  );
+  const colorScale = useMemo(() => {
+    const style = getComputedStyle(document.documentElement);
+    const parse = (name) =>
+      hsl(`hsl(${style.getPropertyValue(name).trim().replace(/\s+/g, ', ')})`);
+    const start = parse('--chart-1');
+    const end = parse('--chart-10');
+    return scaleSequential((t) => interpolateHsl(start, end)(t)).domain([
+      0,
+      maxCount || 1,
+    ]);
+  }, [maxCount]);
 
   return (
     <div>

--- a/src/components/map/__tests__/ReadingMap.test.jsx
+++ b/src/components/map/__tests__/ReadingMap.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import ReadingMap from '../ReadingMap';
 
 vi.mock('react-leaflet', () => {
@@ -16,6 +16,12 @@ vi.mock('react-leaflet', () => {
       setView: () => {},
     }),
   };
+});
+
+beforeAll(() => {
+  const root = document.documentElement.style;
+  root.setProperty('--chart-1', '210 100% 45%');
+  root.setProperty('--chart-10', '246 70% 70%');
 });
 
 describe('ReadingMap', () => {

--- a/src/components/maps/GeoActivityExplorer.tsx
+++ b/src/components/maps/GeoActivityExplorer.tsx
@@ -11,7 +11,8 @@ import maplibregl from "maplibre-gl";
 import { feature } from "topojson-client";
 import { geoCentroid, geoBounds } from "d3-geo";
 import { scaleSequential } from "d3-scale";
-import { interpolateBlues } from "d3-scale-chromatic";
+import { hsl } from "d3-color";
+import { interpolateHsl } from "d3-interpolate";
 import { useStateVisits } from "@/hooks/useStateVisits";
 import type { StateVisit } from "@/lib/types";
 import { Skeleton } from "@/ui/skeleton";
@@ -110,14 +111,18 @@ export default function GeoActivityExplorer() {
     () => Math.max(...states.map((s) => s.totalDays), 0),
     [states],
   )
-  const colorScale = useMemo(
-    () => scaleSequential(interpolateBlues).domain([0, maxDays || 1]),
-    [maxDays],
-  )
-  const legendGradient = useMemo(
-    () => `linear-gradient(to right, ${colorScale(0)}, ${colorScale(maxDays)})`,
-    [colorScale, maxDays],
-  )
+    const colorScale = useMemo(() => {
+    const style = getComputedStyle(document.documentElement)
+    const parse = (name: string) =>
+      hsl(`hsl(${style.getPropertyValue(name).trim().replace(/\s+/g, ', ')})`)
+    const start = parse('--chart-1')
+    const end = parse('--chart-10')
+    return scaleSequential((t) => interpolateHsl(start, end)(t)).domain([0, maxDays || 1])
+    }, [maxDays])
+    const legendGradient = useMemo(
+      () => `linear-gradient(to right, ${colorScale(0)}, ${colorScale(maxDays)})`,
+      [colorScale, maxDays],
+    )
 
   const statesGeo = useMemo(() => {
     const fc = feature(

--- a/src/components/maps/__tests__/GeoActivityExplorer.test.tsx
+++ b/src/components/maps/__tests__/GeoActivityExplorer.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 
 import GeoActivityExplorer from "../GeoActivityExplorer";
-import { vi } from "vitest";
+import { vi, beforeAll } from "vitest";
 vi.mock("react-map-gl/maplibre", () => ({
   __esModule: true,
   default: ({ children, ...props }: any) => (
@@ -13,8 +13,8 @@ vi.mock("react-map-gl/maplibre", () => ({
   Layer: () => null,
   Marker: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Popup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
-import "@testing-library/jest-dom";
+  }));
+  import "@testing-library/jest-dom";
 
 vi.mock("recharts", async () => {
   const actual: any = await vi.importActual("recharts");
@@ -33,7 +33,7 @@ vi.mock("@/hooks/useStateVisits", () => ({
   useStateVisits: (...args: any[]) => mockUseStateVisits(...args),
 }));
 
-vi.mock("@/hooks/useInsights", () => ({
+  vi.mock("@/hooks/useInsights", () => ({
   __esModule: true,
   default: () => ({
     activeStreak: 5,
@@ -44,7 +44,13 @@ vi.mock("@/hooks/useInsights", () => ({
     bestPaceThisMonth: null,
     mostConsistentDay: null,
   }),
-}));
+  }));
+
+beforeAll(() => {
+  const root = document.documentElement.style;
+  root.setProperty("--chart-1", "210 100% 45%");
+  root.setProperty("--chart-10", "246 70% 70%");
+});
 
 const defaultVisits = [
   {

--- a/src/components/network/BookNetwork.jsx
+++ b/src/components/network/BookNetwork.jsx
@@ -3,7 +3,6 @@ import { select } from 'd3-selection';
 import { forceSimulation, forceLink, forceManyBody, forceCenter } from 'd3-force';
 import { drag } from 'd3-drag';
 import { scaleOrdinal, scaleLinear } from 'd3-scale';
-import { schemeTableau10 } from 'd3-scale-chromatic';
 import graphData from '@/data/kindle/book-graph.json';
 
 export default function BookNetwork({ data = graphData }) {
@@ -90,7 +89,8 @@ export default function BookNetwork({ data = graphData }) {
     const width = 600;
     const height = 400;
 
-    const color = scaleOrdinal(schemeTableau10);
+    const chartColors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
+    const color = scaleOrdinal(chartColors);
     const degrees = graph.nodes.map((n) => n.degree);
     const minDegree = Math.min(...degrees);
     const maxDegree = Math.max(...degrees);

--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -5,7 +5,6 @@ import { brushX } from 'd3-brush';
 import { axisBottom } from 'd3-axis';
 import { timeMonth } from 'd3-time';
 import { timeFormat } from 'd3-time-format';
-import { schemeTableau10 } from 'd3-scale-chromatic';
 
 const WIDTH = 600;
 const BAR_HEIGHT = 30;
@@ -50,10 +49,10 @@ export default function ReadingTimeline({ sessions = [] }) {
     () => Array.from(new Set(sessions.map((s) => s.genre || 'Unknown'))),
     [sessions],
   );
-  const colorScale = useMemo(
-    () => scaleOrdinal().domain(genres).range(schemeTableau10),
-    [genres],
-  );
+  const colorScale = useMemo(() => {
+    const chartColors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
+    return scaleOrdinal().domain(genres).range(chartColors);
+  }, [genres]);
 
   useEffect(() => {
     const svg = select(ref.current);

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -4,7 +4,6 @@ import '@testing-library/jest-dom';
 import { select } from 'd3-selection';
 import { act } from 'react';
 import { scaleOrdinal } from 'd3-scale';
-import { schemeTableau10 } from 'd3-scale-chromatic';
 import ReadingTimeline from '../ReadingTimeline.jsx';
 
 const sessions = [
@@ -124,9 +123,10 @@ describe('ReadingTimeline', () => {
     const { container } = render(<ReadingTimeline sessions={sessions} />);
     const svg = container.querySelector('svg');
     const rects = svg.querySelectorAll('rect[height="30"]');
+    const chartColors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
     const color = scaleOrdinal()
       .domain(['Mystery', 'Fantasy'])
-      .range(schemeTableau10.slice(0, 2));
+      .range(chartColors);
     expect(rects[0].getAttribute('fill')).toBe(color(sessions[0].genre));
     expect(rects[1].getAttribute('fill')).toBe(color(sessions[1].genre));
   });

--- a/src/components/trends/FocusTimeline.tsx
+++ b/src/components/trends/FocusTimeline.tsx
@@ -23,8 +23,8 @@ interface Segment {
 }
 
 const stateColors: Record<Segment["state"], string> = {
-  focus: "#d1fae5", // green-100
-  distracted: "#fee2e2", // red-100
+  focus: "hsl(var(--chart-1))",
+  distracted: "hsl(var(--chart-2))",
 };
 
 export default function FocusTimeline({ events }: FocusTimelineProps) {
@@ -77,8 +77,8 @@ export default function FocusTimeline({ events }: FocusTimelineProps) {
         <defs>
           {!lowEnd && (
             <linearGradient id="confidenceGradient" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0} />
             </linearGradient>
           )}
         </defs>
@@ -103,8 +103,8 @@ export default function FocusTimeline({ events }: FocusTimelineProps) {
         <Area
           type="monotone"
           dataKey="confidence"
-          stroke="#3b82f6"
-          fill={lowEnd ? "#3b82f6" : "url(#confidenceGradient)"}
+            stroke="hsl(var(--chart-1))"
+            fill={lowEnd ? "hsl(var(--chart-1))" : "url(#confidenceGradient)"}
           isAnimationActive={!lowEnd}
         />
         {!lowEnd &&
@@ -114,7 +114,7 @@ export default function FocusTimeline({ events }: FocusTimelineProps) {
               x={b.time}
               y={1}
               r={6}
-              fill="#ef4444"
+                fill="hsl(var(--chart-2))"
               stroke="none"
             />
           ))}


### PR DESCRIPTION
## Summary
- replace D3 palettes with CSS token colors in charts like BookNetwork, ReadingTimeline, and genre visualizations
- add token-based color scales for maps and timeline components
- rely on shared `--chart-*` tokens mirrored in Tailwind config

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689249ddb07083249c48b1a18bdd5e09