### PR TITLE
Add chord diagram option for book network

### DIFF
--- a/src/components/network/BookChordDiagram.jsx
+++ b/src/components/network/BookChordDiagram.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from 'react';
+import { select } from 'd3-selection';
+import { chord, ribbon } from 'd3-chord';
+import { arc } from 'd3-shape';
+import { scaleOrdinal } from 'd3-scale';
+import { schemeTableau10 } from 'd3-scale-chromatic';
+import graphData from '@/data/kindle/book-graph.json';
+
+function buildMatrix(nodes, links) {
+  const index = new Map(nodes.map((n, i) => [n.id, i]));
+  const size = nodes.length;
+  const matrix = Array.from({ length: size }, () => Array(size).fill(0));
+  links.forEach((l) => {
+    const i = index.get(l.source);
+    const j = index.get(l.target);
+    if (i != null && j != null) {
+      const w = l.weight || 1;
+      matrix[i][j] = w;
+      matrix[j][i] = w;
+    }
+  });
+  return matrix;
+}
+
+export default function BookChordDiagram({ data = graphData }) {
+  const svgRef = useRef(null);
+
+  useEffect(() => {
+    const svg = select(svgRef.current);
+    svg.selectAll('*').remove();
+    const width = 600;
+    const height = 400;
+    const outerRadius = Math.min(width, height) / 2 - 30;
+    const innerRadius = outerRadius - 20;
+
+    const matrix = buildMatrix(data.nodes, data.links);
+    const chords = chord().padAngle(0.05)(matrix);
+    const color = scaleOrdinal(schemeTableau10);
+
+    const g = svg
+      .append('g')
+      .attr('transform', `translate(${width / 2},${height / 2})`);
+
+    g.append('g')
+      .selectAll('path')
+      .data(chords.groups)
+      .join('path')
+      .attr('fill', (d) => color(d.index))
+      .attr('stroke', (d) => color(d.index))
+      .attr('d', arc().innerRadius(innerRadius).outerRadius(outerRadius));
+
+    g.append('g')
+      .selectAll('path')
+      .data(chords)
+      .join('path')
+      .attr('fill', (d) => color(d.target.index))
+      .attr('stroke', (d) => color(d.target.index))
+      .attr('d', ribbon().radius(innerRadius))
+      .attr('opacity', 0.7)
+      .attr('data-testid', 'chord');
+  }, [data]);
+
+  return <svg ref={svgRef} width={600} height={400}></svg>;
+}
+

--- a/src/components/network/__tests__/BookChordDiagram.test.jsx
+++ b/src/components/network/__tests__/BookChordDiagram.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import BookChordDiagram from '../BookChordDiagram.jsx';
+import graphData from '@/data/kindle/book-graph.json';
+
+describe('BookChordDiagram', () => {
+  it('renders the expected number of chords', async () => {
+    render(<BookChordDiagram data={graphData} />);
+    const expected = graphData.links.length;
+    await waitFor(() => {
+      expect(screen.getAllByTestId('chord').length).toBe(expected);
+    });
+  });
+});
+

--- a/src/pages/charts/BookNetwork.jsx
+++ b/src/pages/charts/BookNetwork.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import BookNetwork from '@/components/network/BookNetwork.jsx';
+import BookChordDiagram from '@/components/network/BookChordDiagram.jsx';
 import { Skeleton } from '@/ui/skeleton';
 
 export default function BookNetworkPage() {
   const [data, setData] = useState(null);
+  const [view, setView] = useState('network');
 
   useEffect(() => {
     import('@/data/kindle/book-graph.json').then((mod) => {
@@ -11,14 +13,28 @@ export default function BookNetworkPage() {
     });
   }, []);
 
+  const toggleView = () => {
+    setView((v) => (v === 'network' ? 'chord' : 'network'));
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Related Books Network</h1>
       {data ? (
-        <BookNetwork />
+        <div>
+          <button onClick={toggleView} data-testid="toggle-view">
+            {view === 'network' ? 'Show Chord Diagram' : 'Show Network'}
+          </button>
+          {view === 'network' ? (
+            <BookNetwork data={data} />
+          ) : (
+            <BookChordDiagram data={data} />
+          )}
+        </div>
       ) : (
         <Skeleton className="h-96 w-full" data-testid="book-network-skeleton" />
       )}
     </div>
   );
 }
+

--- a/src/pages/charts/__tests__/BookNetworkPage.test.jsx
+++ b/src/pages/charts/__tests__/BookNetworkPage.test.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import BookNetworkPage from '../BookNetwork.jsx';
 
 vi.mock('@/components/network/BookNetwork.jsx', () => ({
   default: () => <div data-testid="book-network" />,
+}));
+
+vi.mock('@/components/network/BookChordDiagram.jsx', () => ({
+  default: () => <div data-testid="book-chord" />,
 }));
 
 describe('BookNetworkPage', () => {
@@ -18,6 +23,17 @@ describe('BookNetworkPage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('book-network')).toBeInTheDocument();
+    });
+  });
+
+  it('toggles between network and chord views', async () => {
+    render(<BookNetworkPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('book-network')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByTestId('toggle-view'));
+    await waitFor(() => {
+      expect(screen.getByTestId('book-chord')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- visualize book tag/author relationships with a new `BookChordDiagram`
- allow switching between force-directed and chord views on the book network page
- test chord diagram rendering and page toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689246f1917c8324ac1ca4e5063bf14e