### PR TITLE
test: assert network chart tokens

### DIFF
--- a/src/components/__tests__/BookNetwork.test.jsx
+++ b/src/components/__tests__/BookNetwork.test.jsx
@@ -54,4 +54,24 @@ describe('BookNetwork component', () => {
     expect(radiusB).toBeGreaterThan(radiusA);
     expect(radiusA).toBeCloseTo(radiusC);
   });
+
+  it('uses chart CSS variables for node and link styles', async () => {
+    const { container } = render(<BookNetwork data={createMockGraph()} />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="node"]').length).toBe(3);
+      expect(container.querySelectorAll('line').length).toBe(2);
+    });
+
+    const nodeUsesVar = Array.from(
+      container.querySelectorAll('[data-testid="node"]')
+    ).some((el) => el.getAttribute('stroke') === 'var(--chart-network-node-border)');
+
+    const linkUsesVar = Array.from(container.querySelectorAll('line')).some(
+      (el) => el.getAttribute('stroke') === 'var(--chart-network-link)'
+    );
+
+    expect(nodeUsesVar).toBe(true);
+    expect(linkUsesVar).toBe(true);
+  });
 });

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -14,4 +14,18 @@ describe('ReadingSpeedViolin', () => {
       expect(paths.length).toBeGreaterThan(0);
     });
   });
+
+  it('applies network node border color via CSS variable', async () => {
+    const { container } = render(<ReadingSpeedViolin />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('rect').length).toBeGreaterThan(0);
+    });
+
+    const usesVar = Array.from(container.querySelectorAll('rect')).some(
+      (el) => el.getAttribute('stroke') === 'var(--chart-network-node-border)'
+    );
+
+    expect(usesVar).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- verify BookNetwork renders links and nodes with expected CSS token variables
- check ReadingSpeedViolin applies network node border color variable

## Testing
- `npm test -- --run src/components/__tests__/BookNetwork.test.jsx src/components/stats/__tests__/ReadingSpeedViolin.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689256fd108c8324834bddb911de3d48