### PR TITLE
Use skeleton placeholders for timeline pages

### DIFF
--- a/src/components/timeline/TimelineSkeleton.jsx
+++ b/src/components/timeline/TimelineSkeleton.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function TimelineSkeleton({ className = 'h-40 w-full', ...props }) {
+  return <Skeleton className={className} data-testid="timeline-skeleton" {...props} />;
+}

--- a/src/pages/TimelinePage.jsx
+++ b/src/pages/TimelinePage.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import useReadingSessions from '@/hooks/useReadingSessions';
 import ReadingTimeline from '@/components/timeline/ReadingTimeline.jsx';
-import { Skeleton } from '@/ui/skeleton';
+import TimelineSkeleton from '@/components/timeline/TimelineSkeleton.jsx';
 
 export default function TimelinePage() {
   const { data, error, isLoading } = useReadingSessions();
 
   if (error) return <div>Failed to load sessions</div>;
-  if (isLoading) return <Skeleton className="h-64 w-full" />;
+  if (isLoading) return <TimelineSkeleton className="h-64 w-full" />;
   return <ReadingTimeline sessions={data || []} />;
 }

--- a/src/pages/__tests__/TimelinePage.test.jsx
+++ b/src/pages/__tests__/TimelinePage.test.jsx
@@ -8,6 +8,12 @@ import useReadingSessions from '@/hooks/useReadingSessions';
 vi.mock('@/hooks/useReadingSessions');
 
 describe('TimelinePage', () => {
+  it('renders skeleton while loading', () => {
+    useReadingSessions.mockReturnValue({ data: null, error: null, isLoading: true });
+    const { getByTestId } = render(<TimelinePage />);
+    expect(getByTestId('timeline-skeleton')).toBeInTheDocument();
+  });
+
   it('renders timeline when data is loaded', () => {
     useReadingSessions.mockReturnValue({
       data: [

--- a/src/pages/charts/ReadingTimeline.jsx
+++ b/src/pages/charts/ReadingTimeline.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useReadingSessions from '@/hooks/useReadingSessions';
 import ReadingTimeline from '@/components/timeline/ReadingTimeline.jsx';
-import { Skeleton } from '@/ui/skeleton';
+import TimelineSkeleton from '@/components/timeline/TimelineSkeleton.jsx';
 
 export default function ReadingTimelinePage() {
   const { data, error, isLoading } = useReadingSessions();
@@ -12,7 +12,7 @@ export default function ReadingTimelinePage() {
       {error ? (
         <div>Failed to load sessions</div>
       ) : isLoading ? (
-        <Skeleton className="h-64 w-full" />
+        <TimelineSkeleton className="h-64 w-full" />
       ) : (
         <ReadingTimeline sessions={data || []} />
       )}

--- a/src/pages/charts/__tests__/ReadingTimelinePage.test.jsx
+++ b/src/pages/charts/__tests__/ReadingTimelinePage.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import ReadingTimelinePage from '../ReadingTimeline.jsx';
+import useReadingSessions from '@/hooks/useReadingSessions';
+
+vi.mock('@/hooks/useReadingSessions');
+vi.mock('@/components/timeline/ReadingTimeline.jsx', () => ({
+  default: () => <div data-testid="timeline" />,
+}));
+
+describe('ReadingTimelinePage', () => {
+  it('shows skeleton while loading', () => {
+    useReadingSessions.mockReturnValue({ data: null, error: null, isLoading: true });
+    const { getByTestId } = render(<ReadingTimelinePage />);
+    expect(getByTestId('timeline-skeleton')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `TimelineSkeleton` component
- show skeleton in reading timeline pages while loading
- test that skeleton appears during loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925741a67c83248d5a25e3f86457da