### PR TITLE
Add skeleton loaders for genre charts

### DIFF
--- a/src/components/genre/GenreIcicle.jsx
+++ b/src/components/genre/GenreIcicle.jsx
@@ -5,6 +5,7 @@ import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { hsl } from 'd3-color';
 import { interpolate } from 'd3-interpolate';
 import 'd3-transition';
+import { Skeleton } from '@/ui/skeleton';
 
 const WIDTH = 600;
 const HEIGHT = 400;
@@ -89,6 +90,15 @@ export default function GenreIcicle({ data }) {
       .append('title')
       .text((d) => d.data.name);
   }, [data, zoomTo]);
+
+  if (!data) {
+    return (
+      <Skeleton
+        className="h-[400px] w-full"
+        data-testid="genre-icicle-skeleton"
+      />
+    );
+  }
 
   const ancestors = currentNode ? currentNode.ancestors().reverse() : [];
 

--- a/src/components/genre/GenreSunburst.jsx
+++ b/src/components/genre/GenreSunburst.jsx
@@ -6,6 +6,7 @@ import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { hsl } from 'd3-color';
 import { interpolate } from 'd3-interpolate';
 import 'd3-transition';
+import { Skeleton } from '@/ui/skeleton';
 
 const SIZE = 400;
 const RADIUS = SIZE / 2;
@@ -90,6 +91,16 @@ export default function GenreSunburst({ data }) {
       .append('title')
       .text((d) => d.data.name);
   }, [data, zoomTo]);
+
+  if (!data) {
+    return (
+      <Skeleton
+        className="h-[400px] w-full"
+        data-testid="genre-sunburst-skeleton"
+      />
+    );
+  }
+
   const ancestors = currentNode ? currentNode.ancestors().reverse() : [];
 
   return (

--- a/src/components/genre/__tests__/GenreIcicle.test.jsx
+++ b/src/components/genre/__tests__/GenreIcicle.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import GenreIcicle from '../GenreIcicle';
+
+describe('GenreIcicle', () => {
+  const data = {
+    name: 'root',
+    children: [{ name: 'A', value: 1 }],
+  };
+
+  beforeEach(() => {
+    const root = document.documentElement;
+    root.style.setProperty('--chart-1', '210 100% 45%');
+    root.style.setProperty('--chart-2', '214 90% 50%');
+  });
+
+  it('renders a skeleton before data resolves', async () => {
+    function Wrapper() {
+      const [d, setD] = React.useState(null);
+      React.useEffect(() => {
+        setTimeout(() => setD(data), 0);
+      }, []);
+      return <GenreIcicle data={d} />;
+    }
+
+    render(<Wrapper />);
+
+    expect(
+      screen.getByTestId('genre-icicle-skeleton')
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('genre-icicle-skeleton')
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+

--- a/src/components/genre/__tests__/GenreSunburst.test.jsx
+++ b/src/components/genre/__tests__/GenreSunburst.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -24,6 +24,28 @@ import { hsl as d3hsl } from 'd3-color';
     const root = document.documentElement;
     root.style.setProperty('--chart-1', '210 100% 45%');
     root.style.setProperty('--chart-2', '214 90% 50%');
+  });
+
+    it('renders a skeleton before data resolves', async () => {
+    function Wrapper() {
+      const [d, setD] = React.useState(null);
+      React.useEffect(() => {
+        setTimeout(() => setD(data), 0);
+      }, []);
+      return <GenreSunburst data={d} />;
+    }
+
+    render(<Wrapper />);
+
+    expect(
+      screen.getByTestId('genre-sunburst-skeleton')
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('genre-sunburst-skeleton')
+      ).not.toBeInTheDocument();
+    });
   });
 
     it('updates breadcrumb and zooms on interactions', async () => {

--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -1,10 +1,25 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
 import GenreIcicle from '@/components/genre/GenreIcicle.jsx';
-import genreHierarchy from '@/data/kindle/genre-hierarchy.json';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function GenreSunburstPage() {
   const [view, setView] = useState('sunburst');
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    import('@/data/kindle/genre-hierarchy.json').then((module) => {
+      if (isMounted) {
+        setData(module.default);
+        setIsLoading(false);
+      }
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return (
     <div className="p-4">
@@ -25,10 +40,15 @@ export default function GenreSunburstPage() {
           Icicle
         </button>
       </div>
-      {view === 'sunburst' ? (
-        <GenreSunburst data={genreHierarchy} />
+      {isLoading ? (
+        <Skeleton
+          className="h-[400px] w-full"
+          data-testid="genre-hierarchy-skeleton"
+        />
+      ) : view === 'sunburst' ? (
+        <GenreSunburst data={data} />
       ) : (
-        <GenreIcicle data={genreHierarchy} />
+        <GenreIcicle data={data} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Load genre hierarchy JSON asynchronously and show skeleton placeholder
- Add skeleton fallbacks to GenreSunburst and GenreIcicle components
- Test that skeletons render before async data resolves

## Testing
- `npm test src/components/genre/__tests__/GenreSunburst.test.jsx src/components/genre/__tests__/GenreIcicle.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68925735d4f483249cc0aedf75a3bf66