### PR TITLE
Add clustering and heatmap modes to reading map

### DIFF
--- a/src/components/map/HeatmapLayer.jsx
+++ b/src/components/map/HeatmapLayer.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet.heat';
+
+export default function HeatmapLayer({ points }) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+    const layer = L.heatLayer(points, { radius: 25 });
+    layer.addTo(map);
+    return () => {
+      map.removeLayer(layer);
+    };
+  }, [map, points]);
+
+  return null;
+}

--- a/src/components/map/__tests__/ReadingMap.test.jsx
+++ b/src/components/map/__tests__/ReadingMap.test.jsx
@@ -14,9 +14,22 @@ vi.mock('react-leaflet', () => {
     LayersControl,
     useMap: () => ({
       setView: () => {},
+      on: () => {},
+      off: () => {},
+      getZoom: () => 5,
     }),
   };
 });
+
+vi.mock('react-leaflet-markercluster', () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('../HeatmapLayer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
 
 describe('ReadingMap', () => {
   it('renders map with controls', async () => {


### PR DESCRIPTION
## Summary
- add Leaflet heatmap layer component
- switch between markers, clusters, and heatmap based on zoom with manual mode control

## Testing
- `npm test -- --run src/components/map/__tests__/ReadingMap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892571ba540832494ad83159849f1bd