### PR TITLE
Add loading skeletons for data-driven charts

### DIFF
--- a/src/components/examples/MileageGlobe.tsx
+++ b/src/components/examples/MileageGlobe.tsx
@@ -4,6 +4,7 @@ import { feature } from 'topojson-client'
 import { geoInterpolate } from 'd3-geo'
 import useMileageTimeline, { CumulativeMileagePoint } from '@/hooks/useMileageTimeline'
 import GlobeRenderer from '@/components/GlobeRenderer'
+import { Skeleton } from '@/ui/skeleton'
 
 interface MileageGlobeProps {
   weekRange?: [number, number]
@@ -34,11 +35,7 @@ export default function MileageGlobe({ weekRange, autoRotate = false }: MileageG
   }, [])
 
   if (!data) {
-    return (
-      <div className='flex items-center justify-center h-96 w-full bg-muted text-muted-foreground rounded'>
-        Loading mileage globe...
-      </div>
-    )
+    return <Skeleton data-testid='loading' className='h-96 w-full' />
   }
   if (worldError) {
     return (

--- a/src/components/examples/__tests__/MileageGlobe.test.tsx
+++ b/src/components/examples/__tests__/MileageGlobe.test.tsx
@@ -29,9 +29,7 @@ describe("MileageGlobe", () => {
   it("renders loading placeholder when no data", () => {
     mockUseMileageTimeline.mockReturnValue(null);
     render(<MileageGlobe />);
-    expect(
-      screen.getByText(/Loading mileage globe.../i)
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
   });
 
   it("renders mileage path when data is available", async () => {

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -3,23 +3,28 @@ import { select } from 'd3-selection';
 import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
 import { scaleOrdinal } from 'd3-scale';
 import transitions from '@/data/kindle/genre-transitions.json';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function GenreSankey() {
   const svgRef = useRef(null);
   const [data, setData] = useState([]);
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
+  const [loading, setLoading] = useState(true);
 
   const fetchData = async () => {
+    setLoading(true);
     const res = await fetch(
       `/api/kindle/genre-transitions?start=${start}&end=${end}`,
     );
     const json = await res.json();
     setData(json);
+    setLoading(false);
   };
 
   useEffect(() => {
     setData(transitions);
+    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -110,7 +115,11 @@ export default function GenreSankey() {
         </label>
         <button onClick={fetchData}>Apply</button>
       </div>
-      <svg ref={svgRef} width="600" height="400" />
+      {loading ? (
+        <Skeleton className="h-[400px] w-[600px]" />
+      ) : (
+        <svg ref={svgRef} width="600" height="400" />
+      )}
     </div>
   );
 }

--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -4,6 +4,7 @@ import { scaleLinear } from 'd3-scale';
 import { area, curveCatmullRom } from 'd3-shape';
 import { mean, quantile } from 'd3-array';
 import readingSpeed from '@/data/kindle/reading-speed.json';
+import { Skeleton } from '@/ui/skeleton';
 
 export default function ReadingSpeedViolin() {
   const svgRef = useRef(null);
@@ -11,9 +12,11 @@ export default function ReadingSpeedViolin() {
   const [showMorning, setShowMorning] = useState(true);
   const [showEvening, setShowEvening] = useState(true);
   const [bandwidth, setBandwidth] = useState(500);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setData(readingSpeed);
+    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -153,7 +156,11 @@ export default function ReadingSpeedViolin() {
           Evening
         </label>
       </div>
-      <svg ref={svgRef} width="400" height="300" />
+      {loading ? (
+        <Skeleton className="h-[300px] w-[400px]" />
+      ) : (
+        <svg ref={svgRef} width="400" height="300" />
+      )}
       <div>
         <label>
           Bandwidth


### PR DESCRIPTION
## Summary
- show a skeleton in the ReadingSpeedViolin until data loads
- add loading placeholders to GenreSankey and MileageGlobe

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925852ced48324a57383c64444c79d