### PR TITLE
Refactor calendar tooltip with weekly sparkline

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -114,18 +114,16 @@ function YearlyHeatmap({ data, maxMinutes }) {
     });
     const dayRect = React.cloneElement(element, { 'data-date': dateKey });
     const cell = (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>{dayRect}</TooltipTrigger>
-          <TooltipContent>
-            <div className="flex flex-col">
-              <span>{formatted}</span>
-              <span>{minutes} min</span>
-              <Sparkline series={series} />
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{dayRect}</TooltipTrigger>
+        <TooltipContent>
+          <div className="flex flex-col">
+            <span>{formatted}</span>
+            <span>{minutes} min</span>
+            <Sparkline series={series} />
+          </div>
+        </TooltipContent>
+      </Tooltip>
     );
     if (date.getDate() === 1) {
       const key = `${date.getFullYear()}-${date.getMonth()}`;
@@ -150,26 +148,28 @@ function YearlyHeatmap({ data, maxMinutes }) {
   const legendScale = [0, 1, 2, 3, 4];
 
   return (
-    <div>
-      <Heatmap
-        startDate={startDate}
-        endDate={endDate}
-        values={values}
-        classForValue={classForValue}
-        transformDayElement={transformDayElement}
-        showMonthLabels={false}
-      />
-      <div
-        className="flex items-center gap-1 mt-2 text-xs"
-        data-testid="reading-legend"
-      >
-        <span>Less</span>
-        {legendScale.map((level) => (
-          <div key={level} className={`w-3 h-3 reading-scale-${level}`} />
-        ))}
-        <span>More</span>
+    <TooltipProvider>
+      <div>
+        <Heatmap
+          startDate={startDate}
+          endDate={endDate}
+          values={values}
+          classForValue={classForValue}
+          transformDayElement={transformDayElement}
+          showMonthLabels={false}
+        />
+        <div
+          className="flex items-center gap-1 mt-2 text-xs"
+          data-testid="reading-legend"
+        >
+          <span>Less</span>
+          {legendScale.map((level) => (
+            <div key={level} className={`w-3 h-3 reading-scale-${level}`} />
+          ))}
+          <span>More</span>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }
 

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
@@ -64,11 +64,10 @@ describe('CalendarHeatmap', () => {
     const day = container.querySelector('rect[data-date="2024-01-02"]');
     expect(day).not.toBeNull();
     await user.hover(day);
-    const dateTexts = await screen.findAllByText('Jan 2, 2024');
-    expect(dateTexts.length).toBeGreaterThan(0);
-    const minuteTexts = await screen.findAllByText('10 min');
-    expect(minuteTexts.length).toBeGreaterThan(0);
-    expect(screen.getAllByTestId('sparkline').length).toBeGreaterThan(0);
+    const tooltip = await screen.findByRole('tooltip');
+    within(tooltip).getByText('Jan 2, 2024');
+    within(tooltip).getByText('10 min');
+    within(tooltip).getByTestId('sparkline');
   });
 
   it('renders separate heatmaps for each year', () => {


### PR DESCRIPTION
## Summary
- wrap calendar heatmap in TooltipProvider and use Tooltip/Trigger/Content for each day
- compute ISO week-based minute series for sparkline in tooltip
- add tooltip interaction test verifying date, minutes, and sparkline

## Testing
- `npx vitest run src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68925b6bd7208324bdad4dfbbe608417