### PR TITLE
feat: add loading skeletons to charts

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Heatmap from 'react-calendar-heatmap';
 import 'react-calendar-heatmap/dist/styles.css';
 import useDailyReading from '@/hooks/useDailyReading';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Tooltip,
   TooltipTrigger,
@@ -171,6 +172,11 @@ function YearlyHeatmap({ data, maxMinutes }) {
 export default function CalendarHeatmap({ data: propData }) {
   const { data: hookData } = useDailyReading();
   const data = propData || hookData;
+  const [loading, setLoading] = useState(!data);
+  useEffect(() => {
+    if (data) setLoading(false);
+  }, [data]);
+  if (loading) return <Skeleton className="h-64 w-full" />;
   if (!data || data.length === 0) return null;
 
   const maxMinutes = Math.max(...data.map((d) => d.minutes), 0);

--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -2,24 +2,33 @@ import React, { useEffect, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { sankey, sankeyLinkHorizontal } from 'd3-sankey';
 import { scaleOrdinal } from 'd3-scale';
+import { Skeleton } from '@/components/ui/skeleton';
 import transitions from '@/data/kindle/genre-transitions.json';
 
 export default function GenreSankey() {
   const svgRef = useRef(null);
   const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
 
   const fetchData = async () => {
+    setLoading(true);
+    setData([]);
     const res = await fetch(
       `/api/kindle/genre-transitions?start=${start}&end=${end}`,
     );
     const json = await res.json();
     setData(json);
+    setLoading(false);
   };
 
   useEffect(() => {
-    setData(transitions);
+    const id = setTimeout(() => {
+      setData(transitions);
+      setLoading(false);
+    }, 0);
+    return () => clearTimeout(id);
   }, []);
 
   useEffect(() => {
@@ -110,7 +119,14 @@ export default function GenreSankey() {
         </label>
         <button onClick={fetchData}>Apply</button>
       </div>
-      <svg ref={svgRef} width="600" height="400" />
+      {loading ? (
+        <Skeleton
+          className="h-[400px] w-[600px]"
+          data-testid="genre-sankey-skeleton"
+        />
+      ) : (
+        <svg ref={svgRef} width="600" height="400" />
+      )}
     </div>
   );
 }

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -25,6 +25,9 @@ describe('GenreSankey', () => {
     const { container } = render(<GenreSankey />);
     expect(screen.getByLabelText('Start')).toBeInTheDocument();
     expect(screen.getByLabelText('End')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('genre-sankey-skeleton')
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
@@ -51,6 +54,9 @@ describe('GenreSankey', () => {
 
   it('renders links with non-gray strokes', async () => {
     const { container } = render(<GenreSankey />);
+    expect(
+      screen.getByTestId('genre-sankey-skeleton')
+    ).toBeInTheDocument();
     await waitFor(() => {
       const links = container.querySelectorAll('path');
       expect(links.length).toBeGreaterThan(0);

--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -3,17 +3,23 @@ import { select } from 'd3-selection';
 import { scaleLinear } from 'd3-scale';
 import { area, curveCatmullRom } from 'd3-shape';
 import { mean, quantile } from 'd3-array';
+import { Skeleton } from '@/components/ui/skeleton';
 import readingSpeed from '@/data/kindle/reading-speed.json';
 
 export default function ReadingSpeedViolin() {
   const svgRef = useRef(null);
   const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [showMorning, setShowMorning] = useState(true);
   const [showEvening, setShowEvening] = useState(true);
   const [bandwidth, setBandwidth] = useState(500);
 
   useEffect(() => {
-    setData(readingSpeed);
+    const id = setTimeout(() => {
+      setData(readingSpeed);
+      setLoading(false);
+    }, 0);
+    return () => clearTimeout(id);
   }, []);
 
   useEffect(() => {
@@ -153,7 +159,14 @@ export default function ReadingSpeedViolin() {
           Evening
         </label>
       </div>
-      <svg ref={svgRef} width="400" height="300" />
+      {loading ? (
+        <Skeleton
+          className="h-[300px] w-[400px]"
+          data-testid="reading-speed-skeleton"
+        />
+      ) : (
+        <svg ref={svgRef} width="400" height="300" />
+      )}
       <div>
         <label>
           Bandwidth

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -4,11 +4,14 @@ import ReadingSpeedViolin from '../ReadingSpeedViolin';
 import '@testing-library/jest-dom';
 
 describe('ReadingSpeedViolin', () => {
-  it('renders controls and chart', async () => {
+  it('renders skeleton then chart', async () => {
     render(<ReadingSpeedViolin />);
     expect(screen.getByLabelText('Morning')).toBeInTheDocument();
     expect(screen.getByLabelText('Evening')).toBeInTheDocument();
     expect(screen.getByLabelText('Bandwidth')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('reading-speed-skeleton')
+    ).toBeInTheDocument();
     await waitFor(() => {
       const paths = document.querySelectorAll('path');
       expect(paths.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- show skeleton placeholder while loading ReadingSpeedViolin chart
- add loading state to GenreSankey and calendar heatmap to avoid blank screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892570770f0832483740f9bb2a5947b