### PR TITLE
Add period-specific colors to ReadingSpeedViolin chart

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -5,6 +5,11 @@ import { area, curveCatmullRom } from 'd3-shape';
 import { mean, quantile } from 'd3-array';
 import readingSpeed from '@/data/kindle/reading-speed.json';
 
+export const color = {
+  morning: '#FFA500',
+  evening: '#1E90FF',
+};
+
 export default function ReadingSpeedViolin() {
   const svgRef = useRef(null);
   const [data, setData] = useState([]);
@@ -84,12 +89,13 @@ export default function ReadingSpeedViolin() {
         .append('g')
         .attr('transform', `translate(${center},0)`)
         .style('display', show ? null : 'none');
+      const fill = color[period];
 
       g
         .append('path')
         .datum(density)
         .attr('d', areaGenerator)
-        .attr('fill', 'var(--chart-network-node)');
+        .attr('fill', fill);
 
       const { q1, q3, median } = stats[period];
       const q1Y = y(q1);
@@ -106,9 +112,9 @@ export default function ReadingSpeedViolin() {
         .attr('y', q3Y)
         .attr('width', boxWidth)
         .attr('height', q1Y - q3Y)
-        .attr('fill', 'var(--chart-network-node-border)')
+        .attr('fill', fill)
         .attr('fill-opacity', 0.4)
-        .attr('stroke', 'var(--chart-network-node-border)');
+        .attr('stroke', fill);
 
       // Median line
       g
@@ -117,7 +123,7 @@ export default function ReadingSpeedViolin() {
         .attr('x2', 0)
         .attr('y1', medianY - medianHeight / 2)
         .attr('y2', medianY + medianHeight / 2)
-        .attr('stroke', 'var(--chart-network-node-border)')
+        .attr('stroke', fill)
         .attr('stroke-width', 2);
 
       // Plot individual reading speed points with slight horizontal jitter
@@ -127,7 +133,7 @@ export default function ReadingSpeedViolin() {
           .attr('cx', Math.random() * jitterWidth - jitterWidth / 2)
           .attr('cy', y(v))
           .attr('r', 3)
-          .attr('fill', 'var(--chart-network-node-border)')
+          .attr('fill', fill)
           .attr('fill-opacity', 0.6);
       });
     });

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import ReadingSpeedViolin from '../ReadingSpeedViolin';
+import ReadingSpeedViolin, { color } from '../ReadingSpeedViolin';
 import '@testing-library/jest-dom';
 
 describe('ReadingSpeedViolin', () => {
@@ -15,17 +15,33 @@ describe('ReadingSpeedViolin', () => {
     });
   });
 
-  it('applies network node border color via CSS variable', async () => {
+  it('applies period-specific colors', async () => {
     const { container } = render(<ReadingSpeedViolin />);
 
     await waitFor(() => {
       expect(container.querySelectorAll('rect').length).toBeGreaterThan(0);
     });
 
-    const usesVar = Array.from(container.querySelectorAll('rect')).some(
-      (el) => el.getAttribute('stroke') === 'var(--chart-network-node-border)'
-    );
+    const colors = Object.values(color);
 
-    expect(usesVar).toBe(true);
+    const pathFills = Array.from(container.querySelectorAll('path')).map((el) =>
+      el.getAttribute('fill')
+    );
+    colors.forEach((c) => {
+      expect(pathFills).toContain(c);
+    });
+
+    Array.from(container.querySelectorAll('rect')).forEach((el) => {
+      expect(colors).toContain(el.getAttribute('stroke'));
+      expect(colors).toContain(el.getAttribute('fill'));
+    });
+
+    Array.from(container.querySelectorAll('line')).forEach((el) => {
+      expect(colors).toContain(el.getAttribute('stroke'));
+    });
+
+    Array.from(container.querySelectorAll('circle')).forEach((el) => {
+      expect(colors).toContain(el.getAttribute('fill'));
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a color palette for morning and evening periods
- color violin fill, interquartile box, median line, and points using the period color
- update tests for the new color scale

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6892605d2d248324bdde1a8c1585989c