### PR TITLE
Include Leaflet CSS for map rendering

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/globals.css";
 import "maplibre-gl/dist/maplibre-gl.css";
+import "leaflet/dist/leaflet.css";
 import { InterventionPreferencesProvider } from "@/hooks/useInterventionPreferences";
 import { FocusHistoryProvider } from "@/hooks/useFocusHistory";
 


### PR DESCRIPTION
## Summary
- load `leaflet/dist/leaflet.css` in the app entry so Leaflet maps render tiles and controls correctly

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689260b9a8d88324a31db2de146c5e87