### PR TITLE
feat(calendar): stack heatmaps by year

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -173,7 +173,7 @@ function YearlyHeatmap({ data, maxMinutes }) {
   );
 }
 
-export default function CalendarHeatmap({ data: propData }) {
+export default function CalendarHeatmap({ data: propData, multiYear }) {
   const { data: hookData } = useDailyReading();
   const data = propData || hookData;
   if (!data || data.length === 0) return null;
@@ -188,6 +188,12 @@ export default function CalendarHeatmap({ data: propData }) {
   }, {});
 
   const years = Object.keys(dataByYear).sort();
+  const isMultiYear = multiYear ?? years.length > 1;
+
+  if (!isMultiYear) {
+    const year = years[0];
+    return <YearlyHeatmap data={dataByYear[year]} maxMinutes={maxMinutes} />;
+  }
 
   return (
     <div>

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -87,4 +87,18 @@ describe('CalendarHeatmap', () => {
     expect(svg2023.querySelector('rect.reading-scale-4')).not.toBeNull();
     expect(svg2024.querySelector('rect.reading-scale-1')).not.toBeNull();
   });
+
+  it('can render a single heatmap when multiYear is false', () => {
+    const twoYearData = [
+      { date: '2023-12-31', minutes: 30, pages: 10 },
+      { date: '2024-01-01', minutes: 5, pages: 2 },
+    ];
+    const { container, queryByText } = render(
+      <CalendarHeatmap data={twoYearData} multiYear={false} />
+    );
+    const svgs = container.querySelectorAll('svg.react-calendar-heatmap');
+    expect(svgs.length).toBe(1);
+    expect(queryByText('2023')).toBeNull();
+    expect(queryByText('2024')).toBeNull();
+  });
 });

--- a/src/pages/charts/ReadingCalendarHeatmap.jsx
+++ b/src/pages/charts/ReadingCalendarHeatmap.jsx
@@ -5,7 +5,7 @@ export default function ReadingCalendarHeatmapPage() {
   return (
     <div className="p-4 space-y-8">
       <h1 className="text-xl font-bold mb-4">Daily Reading Calendar</h1>
-      <CalendarHeatmap />
+      <CalendarHeatmap multiYear />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add optional `multiYear` prop to CalendarHeatmap with auto year grouping
- stack yearly heatmaps vertically and allow opting out
- document usage in ReadingCalendarHeatmap page

## Testing
- `npm test -- src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892610e88148324a2962388adbc1479