### PR TITLE
feat: add loading skeleton to WordTree

### DIFF
--- a/src/pages/charts/WordTree.jsx
+++ b/src/pages/charts/WordTree.jsx
@@ -1,11 +1,14 @@
-import React from 'react';
-import WordTree from '@/components/highlights/WordTree.jsx';
+import React, { Suspense } from 'react';
+import { Skeleton } from '@/ui/skeleton';
+const WordTree = React.lazy(() => import('@/components/highlights/WordTree.jsx'));
 
 export default function WordTreePage() {
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Highlight Word Tree</h1>
-      <WordTree />
+      <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+        <WordTree />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show loading skeleton for WordTree component until data is ready
- lazy load chart page with skeleton fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689260ca05b483248b4c1353d83e7eab