### PR TITLE
Fix daily reading stats path and add hook tests

### DIFF
--- a/data/kindle/daily-stats.json
+++ b/data/kindle/daily-stats.json
@@ -1,5 +1,0 @@
-[
-  { "date": "2025-01-01", "minutes": 30, "pages": 20 },
-  { "date": "2025-01-02", "minutes": 25, "pages": 15 },
-  { "date": "2025-01-03", "minutes": 40, "pages": 30 }
-]

--- a/src/hooks/__tests__/useDailyReading.test.ts
+++ b/src/hooks/__tests__/useDailyReading.test.ts
@@ -3,9 +3,9 @@ import { describe, it, expect } from 'vitest'
 import useDailyReading from '../useDailyReading'
 
 const sample = [
-  { date: '2025-01-01', minutes: 30, pages: 20 },
-  { date: '2025-01-02', minutes: 25, pages: 15 },
-  { date: '2025-01-03', minutes: 40, pages: 30 }
+  { date: '2018-01-09', minutes: 0.07166666666666667, pages: 3 },
+  { date: '2018-01-11', minutes: 0, pages: 0 },
+  { date: '2018-01-12', minutes: 2.0416666666666665, pages: 5 }
 ]
 
 describe('useDailyReading', () => {
@@ -13,6 +13,6 @@ describe('useDailyReading', () => {
     const { result } = renderHook(() => useDailyReading())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.error).toBeNull()
-    expect(result.current.data).toEqual(sample)
+    expect(result.current.data.slice(0, 3)).toEqual(sample)
   })
 })

--- a/src/lib/__tests__/dailyReadingStats.test.ts
+++ b/src/lib/__tests__/dailyReadingStats.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect } from 'vitest'
 import { getDailyReadingStats } from '@/lib/api'
 
-// Expected sample data
+// Expected first entries from dataset
 const sample = [
-  { date: '2025-01-01', minutes: 30, pages: 20 },
-  { date: '2025-01-02', minutes: 25, pages: 15 },
-  { date: '2025-01-03', minutes: 40, pages: 30 }
+  { date: '2018-01-09', minutes: 0.07166666666666667, pages: 3 },
+  { date: '2018-01-11', minutes: 0, pages: 0 },
+  { date: '2018-01-12', minutes: 2.0416666666666665, pages: 5 }
 ]
 
 describe('getDailyReadingStats', () => {
   it('returns daily reading stats from dataset', async () => {
     const data = await getDailyReadingStats()
-    expect(data).toEqual(sample)
+    expect(data.length).toBeGreaterThan(sample.length)
+    expect(data.slice(0, 3)).toEqual(sample)
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,7 +10,7 @@ import { computeRouteMetrics } from "./routeMetrics";
 import { getAllSessionMeta } from "./sessionStore";
 export { calculateRouteSimilarity } from "./routeMetrics";
 export type { LocationVisit } from "./locationStore";
-import dailyReadingData from "../../data/kindle/daily-stats.json";
+import dailyReadingData from "@/data/kindle/daily-stats.json";
 import sessionData from "../data/kindle/sessions.json";
 
 export type Activity = {


### PR DESCRIPTION
## Summary
- load daily reading stats from `src/data/kindle/daily-stats.json`
- verify `getDailyReadingStats` returns data from the full dataset
- test `useDailyReading` hook against the populated stats

## Testing
- `npx vitest run src/hooks/__tests__/useDailyReading.test.ts src/lib/__tests__/dailyReadingStats.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689262982d588324a32eb45de06cc47c