### PR TITLE
feat: add reading intensity tokens

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -94,11 +94,11 @@ function YearlyHeatmap({ data, maxMinutes }) {
     weekSeries[weekKey][dayIdx] = d.minutes;
   });
 
-  const classForValue = (value) => {
-    if (!value || !value.count || maxMinutes === 0) return 'reading-scale-0';
-    const level = Math.ceil((value.count / maxMinutes) * 4);
-    return `reading-scale-${level}`;
-  };
+    const classForValue = (value) => {
+      if (!value || !value.count || maxMinutes === 0) return 'reading-scale-0';
+      const level = Math.ceil((value.count / maxMinutes) * 5);
+      return `reading-scale-${level}`;
+    };
 
   const transformDayElement = (element, value, index) => {
     const date = new Date(startWithEmptyDays);
@@ -145,7 +145,7 @@ function YearlyHeatmap({ data, maxMinutes }) {
     return <g key={dateKey}>{cell}</g>;
   };
 
-  const legendScale = [0, 1, 2, 3, 4];
+    const legendScale = [1, 2, 3, 4, 5];
 
   return (
     <TooltipProvider>

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -32,15 +32,15 @@ describe('CalendarHeatmap', () => {
     const legend = getByTestId('reading-legend');
     expect(legend).not.toBeNull();
 
-    const rects = container.querySelectorAll('svg.react-calendar-heatmap rect');
-    expect(container.querySelector('rect.reading-scale-1')).not.toBeNull();
-    expect(container.querySelector('rect.reading-scale-2')).not.toBeNull();
-    expect(container.querySelector('rect.reading-scale-4')).not.toBeNull();
+      const rects = container.querySelectorAll('svg.react-calendar-heatmap rect');
+      expect(container.querySelector('rect.reading-scale-2')).not.toBeNull();
+      expect(container.querySelector('rect.reading-scale-3')).not.toBeNull();
+      expect(container.querySelector('rect.reading-scale-5')).not.toBeNull();
 
-    const swatches = legend.querySelectorAll('div');
-    expect(swatches.length).toBe(5);
-    expect(swatches[0].classList.contains('reading-scale-0')).toBe(true);
-    expect(swatches[4].classList.contains('reading-scale-4')).toBe(true);
+      const swatches = legend.querySelectorAll('div');
+      expect(swatches.length).toBe(5);
+      expect(swatches[0].classList.contains('reading-scale-1')).toBe(true);
+      expect(swatches[4].classList.contains('reading-scale-5')).toBe(true);
   });
 
   it('renders month labels and totals', () => {
@@ -84,8 +84,8 @@ describe('CalendarHeatmap', () => {
     getByText('2024');
 
     const [svg2023, svg2024] = svgs;
-    expect(svg2023.querySelector('rect.reading-scale-4')).not.toBeNull();
-    expect(svg2024.querySelector('rect.reading-scale-1')).not.toBeNull();
+      expect(svg2023.querySelector('rect.reading-scale-5')).not.toBeNull();
+      expect(svg2024.querySelector('rect.reading-scale-1')).not.toBeNull();
   });
 
   it('can render a single heatmap when multiYear is false', () => {

--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -12,14 +12,18 @@ import { Skeleton } from '@/ui/skeleton';
 const sentimentAnalyzer = new Sentiment();
 const sentimentColor = scaleLinear()
   .domain([-5, 0, 5])
-  .range(['#d73027', '#ffffbf', '#1a9850']);
+  .range([
+    'hsl(var(--destructive))',
+    'hsl(var(--muted))',
+    'hsl(var(--reading-5))',
+  ]);
 
 const posColors = {
-  Noun: '#1f77b4',
-  Verb: '#ff7f0e',
-  Adjective: '#2ca02c',
-  Adverb: '#d62728',
-  Unknown: '#7f7f7f',
+  Noun: 'hsl(var(--chart-1))',
+  Verb: 'hsl(var(--chart-5))',
+  Adjective: 'hsl(var(--chart-3))',
+  Adverb: 'hsl(var(--chart-4))',
+  Unknown: 'hsl(var(--muted-foreground))',
 };
 
 function analyzeWord(word) {
@@ -306,15 +310,15 @@ export default function WordTree() {
       {mode === 'sentiment' ? (
         <div className="mb-2 flex items-center gap-2 text-sm">
           <span className="flex items-center">
-            <span className="w-4 h-4 mr-1" style={{ background: '#d73027' }}></span>
+            <span className="w-4 h-4 mr-1" style={{ background: 'hsl(var(--destructive))' }}></span>
             Negative
           </span>
           <span className="flex items-center">
-            <span className="w-4 h-4 mr-1 border" style={{ background: '#ffffbf' }}></span>
+            <span className="w-4 h-4 mr-1 border" style={{ background: 'hsl(var(--muted))' }}></span>
             Neutral
           </span>
           <span className="flex items-center">
-            <span className="w-4 h-4 mr-1" style={{ background: '#1a9850' }}></span>
+            <span className="w-4 h-4 mr-1" style={{ background: 'hsl(var(--reading-5))' }}></span>
             Positive
           </span>
         </div>

--- a/src/components/maps/BehavioralCharterMap.tsx
+++ b/src/components/maps/BehavioralCharterMap.tsx
@@ -29,12 +29,12 @@ interface BehavioralCharterMapProps {
   riskThresholds?: number[];
 }
 
-// Updated palette with modern hues
+// Updated palette using theme tokens
 const stateColors: Record<string, string> = {
-  reading: "#14b8a6", // teal
-  writing: "#8b5cf6", // violet
-  idle: "#f59e0b", // amber
-  other: "#a1a1aa",
+  reading: "hsl(var(--reading-5))",
+  writing: "hsl(var(--chart-5))",
+  idle: "hsl(var(--chart-3))",
+  other: "hsl(var(--muted))",
 };
 
 export default function BehavioralCharterMap({
@@ -51,7 +51,9 @@ export default function BehavioralCharterMap({
   const svgHeight = riskHeight + overlayHeight + height;
   const segmentWidth = width / segments.length;
 
-  const probColor = scaleLinear<string>().domain([0, 1]).range(["#e0f2fe", "#1e3a8a"]);
+const probColor = scaleLinear<string>()
+  .domain([0, 1])
+  .range(["hsl(var(--reading-1))", "hsl(var(--reading-5))"]);
   const riskScale = scaleLinear().domain([0, 1]).range([riskHeight, 0]);
 
   const riskLine = d3Line<Segment>()
@@ -109,7 +111,7 @@ export default function BehavioralCharterMap({
     <div key={s} className="flex items-center gap-1 text-xs">
       <span
         className="w-3 h-3 inline-block rounded-sm"
-        style={{ background: stateColors[s] || "#ccc" }}
+        style={{ background: stateColors[s] || "hsl(var(--muted))" }}
       />
       {s}
     </div>
@@ -183,7 +185,7 @@ export default function BehavioralCharterMap({
             x2={width}
             y1={riskHeight + overlayHeight - (i * overlayHeight) / 4}
             y2={riskHeight + overlayHeight - (i * overlayHeight) / 4}
-            stroke="#e5e7eb"
+            stroke="hsl(var(--border))"
             strokeWidth={0.5}
           />
         ))}
@@ -191,7 +193,7 @@ export default function BehavioralCharterMap({
         {riskArea(segments) && (
           <path
             d={riskArea(segments)!}
-            fill="rgba(30,64,175,0.2)"
+            fill="hsl(var(--reading-5) / 0.2)"
             style={{ transition: "d 0.3s" }}
           />
         )}
@@ -199,7 +201,7 @@ export default function BehavioralCharterMap({
         {riskLine(segments) && (
           <path
             d={riskLine(segments)!}
-            stroke="#1e40af"
+            stroke="hsl(var(--reading-5))"
             strokeWidth={2}
             fill="none"
             style={{ transition: "d 0.3s" }}
@@ -210,7 +212,7 @@ export default function BehavioralCharterMap({
           cx={maxRiskIdx * segmentWidth + segmentWidth / 2}
           cy={riskScale(segments[maxRiskIdx].risk)}
           r={3}
-          fill="#ef4444"
+          fill="hsl(var(--destructive))"
         />
         {/* threshold markers */}
         {riskThresholds?.map((t, i) => (
@@ -220,7 +222,7 @@ export default function BehavioralCharterMap({
             x2={width}
             y1={riskScale(t)}
             y2={riskScale(t)}
-            stroke="#ef4444"
+            stroke="hsl(var(--destructive))"
             strokeDasharray="4 2"
           />
         ))}
@@ -232,7 +234,7 @@ export default function BehavioralCharterMap({
               width={segmentWidth}
               height={height}
               fill={stateColors[seg.state] || stateColors.other}
-              stroke="#fff"
+              stroke="hsl(var(--background))"
               strokeWidth={0.5}
               style={{ transition: "fill 0.3s" }}
               onMouseEnter={(e) => handleHover(i, e)}
@@ -244,7 +246,7 @@ export default function BehavioralCharterMap({
               width={segmentWidth}
               height={overlayHeight}
               fill={probColor(seg.probability)}
-              stroke="#fff"
+              stroke="hsl(var(--background))"
               strokeWidth={0.5}
               style={{ transition: "fill 0.3s" }}
             />
@@ -253,7 +255,7 @@ export default function BehavioralCharterMap({
         </svg>
         {/* peak risk callout */}
         <div
-          className="absolute bg-white border text-xs p-1 rounded shadow"
+          className="absolute bg-card border text-xs p-1 rounded shadow"
           style={{ left: peakX + 5, top: peakY - 40 }}
         >
           <div className="font-semibold">
@@ -268,7 +270,7 @@ export default function BehavioralCharterMap({
         </div>
         {tooltip && (
           <div
-            className="absolute bg-white border p-2 text-xs rounded shadow"
+            className="absolute bg-card border p-2 text-xs rounded shadow"
             style={{ left: tooltip.x + 10, top: tooltip.y + 10 }}
           >
             <div className="flex items-center justify-between gap-2">
@@ -279,12 +281,12 @@ export default function BehavioralCharterMap({
                 <div
                   className="absolute inset-0 rounded-full"
                   style={{
-                    background: `conic-gradient(#1e3a8a ${
+                    background: `conic-gradient(hsl(var(--reading-5)) ${
                       tooltip.segment.probability * 360
-                    }deg, #e5e7eb 0deg)`,
+                    }deg, hsl(var(--muted)) 0deg)`,
                   }}
                 />
-                <div className="absolute inset-1 bg-white rounded-full text-[10px] flex items-center justify-center">
+                <div className="absolute inset-1 bg-background rounded-full text-[10px] flex items-center justify-center">
                   {(tooltip.segment.probability * 100).toFixed(0)}%
                 </div>
               </div>
@@ -293,9 +295,9 @@ export default function BehavioralCharterMap({
               <div className="mt-1">
                 <div>Risk: {tooltip.meta.risk?.toFixed(2)}</div>
                 {tooltip.meta.ciLow !== undefined && tooltip.meta.ciHigh !== undefined && (
-                  <div className="relative w-32 h-2 bg-gray-200 mt-1">
+                  <div className="relative w-32 h-2 bg-muted mt-1">
                     <div
-                      className="absolute h-full bg-red-300"
+                      className="absolute h-full bg-destructive/30"
                       style={{
                         left: `${(tooltip.meta.ciLow || 0) * 100}%`,
                         width: `${((tooltip.meta.ciHigh || 0) - (tooltip.meta.ciLow || 0)) * 100}%`,
@@ -303,7 +305,7 @@ export default function BehavioralCharterMap({
                     />
                     {tooltip.meta.risk !== undefined && (
                       <div
-                        className="absolute h-full bg-red-600"
+                        className="absolute h-full bg-destructive"
                         style={{ left: `${tooltip.meta.risk * 100}%`, width: "2%" }}
                       />
                     )}

--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -7,8 +7,8 @@ import { axisLeft, axisBottom } from 'd3-axis';
 import readingSpeed from '@/data/kindle/reading-speed.json';
 
 export const color = {
-  morning: '#FFA500',
-  evening: '#1E90FF',
+  morning: 'hsl(var(--chart-5))',
+  evening: 'hsl(var(--chart-8))',
 };
 
 export default function ReadingSpeedViolin() {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,11 +33,17 @@
     --chart-5: 226 60% 65%;
     --chart-6: 230 70% 50%;
     --chart-7: 234 80% 55%;
-    --chart-8: 238 90% 60%;
-    --chart-9: 242 80% 65%;
-    --chart-10: 246 70% 70%;
-    --sidebar: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
+      --chart-8: 238 90% 60%;
+      --chart-9: 242 80% 65%;
+      --chart-10: 246 70% 70%;
+      /* Reading intensity tokens */
+      --reading-1: 210 100% 90%;
+      --reading-2: 210 100% 80%;
+      --reading-3: 210 100% 70%;
+      --reading-4: 210 100% 60%;
+      --reading-5: 210 100% 50%;
+      --sidebar: 0 0% 98%;
+      --sidebar-foreground: 240 5.3% 26.1%;
     --sidebar-primary: 240 5.9% 10%;
     --sidebar-primary-foreground: 0 0% 98%;
     --sidebar-accent: 240 4.8% 95.9%;
@@ -84,6 +90,12 @@
     --chart-8: 238 90% 70%;
     --chart-9: 242 80% 75%;
     --chart-10: 246 70% 80%;
+    /* Reading intensity tokens */
+    --reading-1: 210 60% 20%;
+    --reading-2: 210 70% 30%;
+    --reading-3: 210 80% 40%;
+    --reading-4: 210 90% 50%;
+    --reading-5: 210 100% 60%;
     --sidebar: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
@@ -132,6 +144,12 @@
     --chart-8: 210 100% 50%;
     --chart-9: 270 100% 50%;
     --chart-10: 330 100% 50%;
+    /* Reading intensity tokens */
+    --reading-1: 210 100% 90%;
+    --reading-2: 210 100% 70%;
+    --reading-3: 210 100% 50%;
+    --reading-4: 210 100% 30%;
+    --reading-5: 210 100% 10%;
     --sidebar: 0 0% 0%;
     --sidebar-foreground: 0 0% 100%;
     --sidebar-primary: 60 100% 50%;
@@ -156,23 +174,27 @@ html, body {
 
 @layer utilities {
   .reading-scale-0 {
-    background-color: hsl(var(--chart-1) / 0.1);
-    fill: hsl(var(--chart-1) / 0.1);
+    background-color: hsl(var(--muted));
+    fill: hsl(var(--muted));
   }
   .reading-scale-1 {
-    background-color: hsl(var(--chart-1) / 0.25);
-    fill: hsl(var(--chart-1) / 0.25);
+    background-color: hsl(var(--reading-1));
+    fill: hsl(var(--reading-1));
   }
   .reading-scale-2 {
-    background-color: hsl(var(--chart-1) / 0.5);
-    fill: hsl(var(--chart-1) / 0.5);
+    background-color: hsl(var(--reading-2));
+    fill: hsl(var(--reading-2));
   }
   .reading-scale-3 {
-    background-color: hsl(var(--chart-1) / 0.75);
-    fill: hsl(var(--chart-1) / 0.75);
+    background-color: hsl(var(--reading-3));
+    fill: hsl(var(--reading-3));
   }
   .reading-scale-4 {
-    background-color: hsl(var(--chart-1));
-    fill: hsl(var(--chart-1));
+    background-color: hsl(var(--reading-4));
+    fill: hsl(var(--reading-4));
+  }
+  .reading-scale-5 {
+    background-color: hsl(var(--reading-5));
+    fill: hsl(var(--reading-5));
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,7 +41,14 @@ export default {
           8: "hsl(var(--chart-8))",
           9: "hsl(var(--chart-9))",
           10: "hsl(var(--chart-10))",
-        }
+        },
+        reading: {
+          1: "hsl(var(--reading-1))",
+          2: "hsl(var(--reading-2))",
+          3: "hsl(var(--reading-3))",
+          4: "hsl(var(--reading-4))",
+          5: "hsl(var(--reading-5))",
+        },
       },
       fontFamily: {
         sans: ["Inter", ...fontFamily.sans],


### PR DESCRIPTION
## Summary
- add `--reading-1`..`--reading-5` color tokens with dark variants and utilities
- expose `colors.reading` in Tailwind and update heatmap legend/classes
- replace hard-coded chart colors with theme tokens across components

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689264da67808324b47f4ecece4fbfd9