### PR TITLE
feat(ui): ensure button type default and tests

### DIFF
--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Button } from "../button";
+
+describe("Button", () => {
+  it("defaults to type button", () => {
+    render(<Button>click me</Button>);
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("type", "button");
+  });
+
+  it("uses default variant and size classes", () => {
+    render(<Button>class test</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/bg-primary/);
+    expect(button.className).toMatch(/h-10/);
+  });
+
+  it("applies variant and size classes", () => {
+    render(
+      <Button variant="outline" size="lg">
+        styled
+      </Button>,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/border-input/);
+    expect(button.className).toMatch(/h-11/);
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,23 +9,39 @@ export interface ButtonProps
 
 const baseClasses =
   "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none disabled:opacity-50";
-const variants: Record<string, string> = {
+const variants: Record<
+  NonNullable<ButtonProps["variant"]>,
+  string
+> = {
   default: "bg-primary text-primary-foreground hover:bg-primary/90",
   outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
 };
-const sizes: Record<string, string> = {
+const sizes: Record<
+  NonNullable<ButtonProps["size"]>,
+  string
+> = {
   sm: "h-8 px-3",
   default: "h-10 px-4 py-2",
   lg: "h-11 px-8",
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "default", ...props }, ref) => (
+  (
+    {
+      className,
+      variant = "default",
+      size = "default",
+      type = "button",
+      ...props
+    },
+    ref,
+  ) => (
     <button
       ref={ref}
+      type={type}
       className={cn(baseClasses, variants[variant], sizes[size], className)}
       {...props}
     />
-  )
+  ),
 );
 Button.displayName = "Button";


### PR DESCRIPTION
## Summary
- default button type="button" to prevent unintended form submissions
- type-safe variant and size maps keyed by ButtonProps
- add tests for default type and class selection

## Testing
- `npm test` (fails: BookNetwork tests failing)
- `npx vitest run src/components/ui/__tests__/button.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68926aab753083249d8453283b6a978c