### PR TITLE
chore: color sankey links

### DIFF
--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -86,7 +86,8 @@ export default function GenreSankey() {
       { length: 10 },
       (_, i) => `hsl(var(--chart-${i + 1}))`
     );
-    const color = scaleOrdinal().range(chartColors);
+    // reuse a single ordinal scale so nodes and their outgoing links share hues
+    const color = scaleOrdinal().domain(sortedGenres).range(chartColors);
 
     svg.attr('viewBox', `0 0 ${width} ${height}`);
 

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -49,14 +49,18 @@ describe('GenreSankey', () => {
     expect(container.querySelectorAll('path').length).not.toBe(initialCount);
   });
 
-  it('renders links with non-gray strokes', async () => {
+  it('renders at least one link sharing a node color', async () => {
     const { container } = render(<GenreSankey />);
     await waitFor(() => {
       const links = container.querySelectorAll('path');
+      const nodes = container.querySelectorAll('rect');
       expect(links.length).toBeGreaterThan(0);
+      expect(nodes.length).toBeGreaterThan(0);
+
+      const nodeColors = Array.from(nodes).map((n) => n.getAttribute('fill'));
       const hasColoredLink = Array.from(links).some((link) => {
         const stroke = link.getAttribute('stroke');
-        return stroke && stroke !== '#999' && stroke !== 'var(--chart-network-link)';
+        return stroke && stroke !== '#999' && nodeColors.includes(stroke);
       });
       expect(hasColoredLink).toBe(true);
     });


### PR DESCRIPTION
## Summary
- use genre color scale for link strokes in `GenreSankey` so links share the hue of their source node
- test that at least one link renders with a non-gray stroke matching a node color

## Testing
- `npm test src/components/genre/__tests__/GenreSankey.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68926ab5dd448324ae39fc93e7e2047e