### PR TITLE
test(ui): add button and input tests

### DIFF
--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -28,4 +28,16 @@ describe("Button", () => {
     expect(button.className).toMatch(/border-input/);
     expect(button.className).toMatch(/h-11/);
   });
+
+  it("merges additional classes", () => {
+    render(<Button className="custom">custom</Button>);
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/custom/);
+  });
+
+  it("forwards refs", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<Button ref={ref}>ref</Button>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
 });

--- a/src/components/ui/__tests__/input.test.tsx
+++ b/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Input } from "../input";
+
+describe("Input", () => {
+  it("renders with default classes", () => {
+    render(<Input placeholder="name" />);
+    const input = screen.getByPlaceholderText("name");
+    expect(input).toHaveClass("flex");
+    expect(input).toHaveClass("h-9");
+  });
+
+  it("merges additional classes", () => {
+    render(<Input placeholder="name" className="custom" />);
+    const input = screen.getByPlaceholderText("name");
+    expect(input.className).toMatch(/custom/);
+  });
+
+  it("forwards refs", () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Input ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+});


### PR DESCRIPTION
## Summary
- add rendering, class merging, and ref forwarding tests for Button component
- cover Input component defaults, class merging and ref forwarding

## Testing
- `npx vitest run src/components/ui/__tests__/button.test.tsx src/components/ui/__tests__/input.test.tsx`
- `npx vitest run` *(fails: BookNetwork component > highlights shortest path when searching by tag expected +0 to be 3)*

------
https://chatgpt.com/codex/tasks/task_e_68926dda9b348324a1cb6134389ec593