### PR TITLE
feat: add reading timeline legend

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -165,6 +165,37 @@ export default function ReadingTimeline({ sessions = [] }) {
         ref={ref}
         style={{ width: '100%', height: height + BRUSH_HEIGHT + AXIS_HEIGHT }}
       />
+      {genres.length > 0 && (
+        <ul
+          aria-label="Genres"
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '0.5rem',
+            listStyle: 'none',
+            padding: 0,
+            margin: '0.5rem 0',
+          }}
+        >
+          {genres.map((g) => (
+            <li
+              key={g}
+              style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 12,
+                  height: 12,
+                  backgroundColor: colorScale(g),
+                  display: 'inline-block',
+                }}
+              />
+              <span>{g}</span>
+            </li>
+          ))}
+        </ul>
+      )}
       <button onClick={reset} disabled={!zoomed} aria-label="Reset zoom">
         Reset
       </button>

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { select } from 'd3-selection';
 import { act } from 'react';
@@ -124,5 +124,15 @@ describe('ReadingTimeline', () => {
     const rects = svg.querySelectorAll('rect[height="30"]');
     expect(rects[0].getAttribute('fill')).toBe('hsl(var(--chart-1))');
     expect(rects[1].getAttribute('fill')).toBe('hsl(var(--chart-2))');
+  });
+
+  it('renders a legend for genres with matching colors', () => {
+    const { getByRole } = render(<ReadingTimeline sessions={sessions} />);
+    const list = getByRole('list', { name: /genres/i });
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toContain('Mystery');
+    const swatch = items[0].querySelector('span[aria-hidden="true"]');
+    expect(swatch).toHaveStyle({ backgroundColor: 'hsl(var(--chart-1))' });
   });
 });


### PR DESCRIPTION
## Summary
- show accessible genre legend for ReadingTimeline with color swatches
- test legend rendering and color mapping

## Testing
- `npm test` *(fails: BookNetwork component > renders higher-degree nodes with larger radii)*

------
https://chatgpt.com/codex/tasks/task_e_68926e1a35fc8324b7e8947e1508b839