### PR TITLE
Show location details on ReadingMap markers

### DIFF
--- a/src/components/map/ReadingMap.jsx
+++ b/src/components/map/ReadingMap.jsx
@@ -6,6 +6,7 @@ import {
   CircleMarker,
   GeoJSON,
   useMap,
+  Tooltip,
 } from 'react-leaflet';
 import L from 'leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
@@ -345,7 +346,13 @@ export default function ReadingMap() {
                 center={[loc.latitude, loc.longitude]}
                 radius={5}
                 pathOptions={{ color: 'hsl(var(--chart-1))' }}
-              />
+              >
+                <Tooltip>
+                  {loc.title}
+                  <br />
+                  {new Date(loc.start).toLocaleDateString()}
+                </Tooltip>
+              </CircleMarker>
             ))}
           </MarkerClusterGroup>
         )}
@@ -356,7 +363,13 @@ export default function ReadingMap() {
               center={[loc.latitude, loc.longitude]}
               radius={5}
               pathOptions={{ color: 'hsl(var(--chart-1))' }}
-            />
+            >
+              <Tooltip>
+                {loc.title}
+                <br />
+                {new Date(loc.start).toLocaleDateString()}
+              </Tooltip>
+            </CircleMarker>
           ))}
       </MapContainer>
     </div>

--- a/src/components/map/__tests__/ReadingMap.test.jsx
+++ b/src/components/map/__tests__/ReadingMap.test.jsx
@@ -9,8 +9,9 @@ vi.mock('react-leaflet', () => {
   return {
     MapContainer: ({ children }) => <div data-testid="map">{children}</div>,
     TileLayer: () => null,
-    CircleMarker: () => null,
+    CircleMarker: ({ children }) => <div>{children}</div>,
     GeoJSON: () => null,
+    Tooltip: ({ children }) => <div>{children}</div>,
     LayersControl,
     useMap: () => ({
       setView: () => {},


### PR DESCRIPTION
## Summary
- show title and reading date in a tooltip for each ReadingMap marker
- add test mocks for Tooltip

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68926dee65388324a6bfb60fb2a76f0d