### PR TITLE
feat: add loading skeleton to calendar heatmap

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -8,6 +8,7 @@ import {
   TooltipContent,
   TooltipProvider,
 } from '@/ui/tooltip';
+import { Skeleton } from '@/ui/skeleton';
 import { getISOWeek, getISOWeekYear, getMonth, getYear } from 'date-fns';
 
 const monthNames = [
@@ -174,8 +175,11 @@ function YearlyHeatmap({ data, maxMinutes }) {
 }
 
 export default function CalendarHeatmap({ data: propData, multiYear }) {
-  const { data: hookData } = useDailyReading();
+  const { data: hookData, isLoading } = useDailyReading();
   const data = propData || hookData;
+  if (isLoading) {
+    return <Skeleton className="h-64" data-testid="calendar-heatmap-skeleton" />;
+  }
   if (!data || data.length === 0) return null;
 
   const maxMinutes = Math.max(...data.map((d) => d.minutes), 0);

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -9,18 +9,34 @@ const mockData = [
   { date: '2024-02-01', minutes: 20, pages: 8 },
 ];
 
-vi.mock('@/hooks/useDailyReading', () => ({
-  __esModule: true,
-  default: () => ({
+const useDailyReadingMock = vi.hoisted(() =>
+  vi.fn(() => ({
     data: mockData,
     error: null,
     isLoading: false,
-  }),
+  }))
+);
+
+vi.mock('@/hooks/useDailyReading', () => ({
+  __esModule: true,
+  default: useDailyReadingMock,
 }));
+
+import useDailyReading from '@/hooks/useDailyReading';
 
 import CalendarHeatmap from '../CalendarHeatmap';
 
 describe('CalendarHeatmap', () => {
+  it('renders a skeleton while loading', () => {
+    useDailyReading.mockReturnValueOnce({
+      data: null,
+      error: null,
+      isLoading: true,
+    });
+    render(<CalendarHeatmap />);
+    expect(screen.getByTestId('calendar-heatmap-skeleton')).not.toBeNull();
+  });
+
   it('renders heatmap cells', () => {
     const { container } = render(<CalendarHeatmap />);
     const svg = container.querySelector('svg.react-calendar-heatmap');


### PR DESCRIPTION
## Summary
- show loading skeleton in `CalendarHeatmap` while daily reading data loads
- cover loading state in `CalendarHeatmap` tests

## Testing
- `npm test src/components/calendar/__tests__/CalendarHeatmap.test.jsx`
- `npm test` *(fails: BookNetwork component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68926db902708324ac2ed60984c9cd7d