### PR TITLE
Filter short reading sessions and cap speed outliers

### DIFF
--- a/src/data/kindle/reading-speed.json
+++ b/src/data/kindle/reading-speed.json
@@ -1,44 +1,14 @@
 [
   {
-    "start": "2018-01-09T22:49:43Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 10465.116279069767,
-    "period": "evening"
-  },
-  {
     "start": "2018-01-12T04:36:39Z",
     "asin": "B01A4AXM3W",
     "wpm": 612.2448979591837,
     "period": "morning"
   },
   {
-    "start": "2018-01-13T03:49:45Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 2542.3728813559323,
-    "period": "morning"
-  },
-  {
     "start": "2018-01-13T03:49:54Z",
     "asin": "B01A4AXM3W",
     "wpm": 1198.4021304926764,
-    "period": "morning"
-  },
-  {
-    "start": "2018-01-16T20:39:06Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 3260.8695652173915,
-    "period": "evening"
-  },
-  {
-    "start": "2018-01-18T01:27:44Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 2142.8571428571427,
-    "period": "morning"
-  },
-  {
-    "start": "2018-01-18T01:27:57Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 1282.051282051282,
     "period": "morning"
   },
   {
@@ -54,33 +24,9 @@
     "period": "morning"
   },
   {
-    "start": "2018-01-19T03:28:53Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 1785.7142857142856,
-    "period": "morning"
-  },
-  {
     "start": "2018-01-20T19:46:13Z",
     "asin": "B01A4AXM3W",
     "wpm": 958.4664536741215,
-    "period": "evening"
-  },
-  {
-    "start": "2018-01-20T19:47:56Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 5487.804878048781,
-    "period": "evening"
-  },
-  {
-    "start": "2018-01-20T19:48:07Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 40909.09090909091,
-    "period": "evening"
-  },
-  {
-    "start": "2018-01-21T19:25:23Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 1906.7796610169491,
     "period": "evening"
   },
   {
@@ -162,75 +108,9 @@
     "period": "morning"
   },
   {
-    "start": "2018-02-13T22:08:36Z",
-    "asin": "B01MAWT2MO",
-    "wpm": 1376.1467889908256,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-13T22:08:59Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJTMFYwMEhJUktPR1MmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMU1BV1QyTU8mZW5kdGltZT0xNTE4NTU2MzcwNzk3",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-19T03:15:33Z",
-    "asin": "B00NLLYN4Y",
-    "wpm": 579.1505791505792,
-    "period": "morning"
-  },
-  {
     "start": "2018-02-19T03:16:28Z",
     "asin": "B00NLLYN4Y",
     "wpm": 467.2558678643871,
-    "period": "morning"
-  },
-  {
-    "start": "2018-02-19T14:43:15Z",
-    "asin": "B00NLLYN4Y",
-    "wpm": 2941.176470588235,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-19T14:56:46Z",
-    "asin": "B00NLLYN4Y",
-    "wpm": 1923.076923076923,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-19T16:33:25Z",
-    "asin": "B00NLLYN4Y",
-    "wpm": 5000,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-19T17:04:27Z",
-    "asin": "B00NLLYN4Y",
-    "wpm": 1685.3932584269662,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-20T18:54:59Z",
-    "asin": "B00NLLYN4Y",
-    "wpm": 3260.8695652173915,
-    "period": "evening"
-  },
-  {
-    "start": "2018-02-20T18:56:09Z",
-    "asin": "B01KE61LPW",
-    "wpm": 19060.77348066298,
-    "period": "evening"
-  },
-  {
-    "start": "2018-03-09T18:27:48Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJIVUFEWUYyRkc3WlgmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMUtFNjFMUFcmZW5kdGltZT0xNTE5MTUzMDMyNjQ2",
-    "wpm": 3488.3720930232557,
-    "period": "evening"
-  },
-  {
-    "start": "2018-03-18T03:27:56Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QU9KUjBXMFRHVUJLQiZtYXJrZXRwbGFjZT1BVFZQREtJS1gwREVSJmFzaW49QjAxMjA4TzAwSyZlbmR0aW1lPTE1MjEyMjc1MjIyNzQ",
-    "wpm": 2112.676056338028,
     "period": "morning"
   },
   {
@@ -252,18 +132,6 @@
     "period": "morning"
   },
   {
-    "start": "2018-03-21T01:44:08Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 5263.157894736842,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-21T02:06:48Z",
-    "asin": "B079ZLBXV6",
-    "wpm": 2205.8823529411766,
-    "period": "morning"
-  },
-  {
     "start": "2018-03-21T02:08:32Z",
     "asin": "B074ST9DGK",
     "wpm": 246.0697197539303,
@@ -276,21 +144,9 @@
     "period": "morning"
   },
   {
-    "start": "2018-03-22T02:28:54Z",
-    "asin": "B071Y385Q1",
-    "wpm": 781.25,
-    "period": "morning"
-  },
-  {
     "start": "2018-03-22T02:29:15Z",
     "asin": "B071Y385Q1",
-    "wpm": 6779.661016949152,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-22T02:30:45Z",
-    "asin": "B071Y385Q1",
-    "wpm": 449.10179640718565,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -306,76 +162,10 @@
     "period": "morning"
   },
   {
-    "start": "2018-03-23T09:54:27Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 3529.4117647058824,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T09:55:22Z",
-    "asin": "B071Y385Q1",
-    "wpm": 2000,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T10:12:19Z",
-    "asin": "B071Y385Q1",
-    "wpm": 10150.375939849624,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T10:12:45Z",
-    "asin": "B071Y385Q1",
-    "wpm": 3061.2244897959185,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T10:13:04Z",
-    "asin": "B071Y385Q1",
-    "wpm": 828.7292817679557,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T10:18:55Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 6000,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T10:19:05Z",
-    "asin": "B01A4AXM3W",
-    "wpm": 6976.7441860465115,
-    "period": "morning"
-  },
-  {
-    "start": "2018-03-23T20:08:19Z",
-    "asin": "B071Y385Q1",
-    "wpm": 2054.794520547945,
-    "period": "evening"
-  },
-  {
-    "start": "2018-03-23T20:08:29Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 1973.6842105263156,
-    "period": "evening"
-  },
-  {
     "start": "2018-03-24T23:34:01Z",
     "asin": "B071Y385Q1",
-    "wpm": 3872.8897715988087,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2018-03-24T23:35:48Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 3125,
-    "period": "evening"
-  },
-  {
-    "start": "2018-03-25T03:52:07Z",
-    "asin": "B071Y385Q1",
-    "wpm": 3061.2244897959185,
-    "period": "morning"
   },
   {
     "start": "2018-03-25T21:15:09Z",
@@ -402,12 +192,6 @@
     "period": "evening"
   },
   {
-    "start": "2018-03-25T21:49:43Z",
-    "asin": "B079ZQBV4H",
-    "wpm": 304.25963488843814,
-    "period": "evening"
-  },
-  {
     "start": "2018-03-25T21:50:38Z",
     "asin": "B07B9GK76Z",
     "wpm": 57.78120184899846,
@@ -420,34 +204,10 @@
     "period": "evening"
   },
   {
-    "start": "2018-03-26T04:00:22Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 1209.6774193548388,
-    "period": "morning"
-  },
-  {
     "start": "2018-03-26T04:02:12Z",
     "asin": "B01LXZZ1L5",
     "wpm": 1261.1097766034109,
     "period": "morning"
-  },
-  {
-    "start": "2018-03-26T13:48:37Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 630.2521008403361,
-    "period": "evening"
-  },
-  {
-    "start": "2018-03-26T13:49:01Z",
-    "asin": "B071Y385Q1",
-    "wpm": 3157.8947368421054,
-    "period": "evening"
-  },
-  {
-    "start": "2018-03-26T13:49:18Z",
-    "asin": "B071Y385Q1",
-    "wpm": 1000,
-    "period": "evening"
   },
   {
     "start": "2018-03-26T13:49:28Z",
@@ -456,28 +216,10 @@
     "period": "evening"
   },
   {
-    "start": "2018-03-26T13:50:39Z",
-    "asin": "B071Y385Q1",
-    "wpm": 2941.176470588235,
-    "period": "evening"
-  },
-  {
-    "start": "2018-04-03T03:17:09Z",
-    "asin": "B071Y385Q1",
-    "wpm": 2542.3728813559323,
-    "period": "morning"
-  },
-  {
     "start": "2018-04-03T03:17:20Z",
     "asin": "B01LXZZ1L5",
     "wpm": 844.9936398328184,
     "period": "morning"
-  },
-  {
-    "start": "2018-04-03T19:40:16Z",
-    "asin": "B01LXZZ1L5",
-    "wpm": 3947.368421052631,
-    "period": "evening"
   },
   {
     "start": "2018-04-05T03:26:37Z",
@@ -488,7 +230,7 @@
   {
     "start": "2018-04-12T02:07:11Z",
     "asin": "B00280LYIM",
-    "wpm": 5847.953216374269,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -540,18 +282,6 @@
     "period": "morning"
   },
   {
-    "start": "2018-04-19T21:13:49Z",
-    "asin": "B06W2J89PV",
-    "wpm": 4347.826086956522,
-    "period": "evening"
-  },
-  {
-    "start": "2018-04-21T02:57:38Z",
-    "asin": "B06W2J89PV",
-    "wpm": 395.77836411609496,
-    "period": "morning"
-  },
-  {
     "start": "2018-04-21T02:58:21Z",
     "asin": "B06W2J89PV",
     "wpm": 248.45406360424028,
@@ -588,28 +318,10 @@
     "period": "morning"
   },
   {
-    "start": "2018-04-23T16:17:11Z",
-    "asin": "B06W2J89PV",
-    "wpm": 498.33887043189367,
-    "period": "evening"
-  },
-  {
-    "start": "2018-04-24T01:57:44Z",
-    "asin": "B06W2J89PV",
-    "wpm": 802.1390374331552,
-    "period": "morning"
-  },
-  {
     "start": "2018-04-24T02:28:33Z",
     "asin": "B06W2J89PV",
     "wpm": 364.8700550505697,
     "period": "morning"
-  },
-  {
-    "start": "2018-04-24T21:25:39Z",
-    "asin": "B06W2J89PV",
-    "wpm": 9615.384615384615,
-    "period": "evening"
   },
   {
     "start": "2018-04-25T01:50:34Z",
@@ -624,63 +336,9 @@
     "period": "morning"
   },
   {
-    "start": "2018-05-06T18:42:04Z",
-    "asin": "B06W2J89PV",
-    "wpm": 10606.060606060606,
-    "period": "evening"
-  },
-  {
     "start": "2018-06-13T03:23:30Z",
     "asin": "B009UW5X4C",
     "wpm": 633.2931242460796,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:29:19Z",
-    "asin": "B009UW5X4C",
-    "wpm": 3376.2057877813504,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:29:53Z",
-    "asin": "B009UW5X4C",
-    "wpm": 4285.714285714285,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:30:26Z",
-    "asin": "B009UW5X4C",
-    "wpm": 10227.272727272728,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:30:52Z",
-    "asin": "B009UW5X4C",
-    "wpm": 8522.727272727272,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:33:11Z",
-    "asin": "B009UW5X4C",
-    "wpm": 6521.739130434782,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:33:19Z",
-    "asin": "B009UW5X4C",
-    "wpm": 3000,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:33:31Z",
-    "asin": "B009UW5X4C",
-    "wpm": 5000,
-    "period": "morning"
-  },
-  {
-    "start": "2018-06-13T03:33:36Z",
-    "asin": "B009UW5X4C",
-    "wpm": 3947.368421052631,
     "period": "morning"
   },
   {
@@ -694,12 +352,6 @@
     "asin": "B009UW5X4C",
     "wpm": 1098.4699882306788,
     "period": "morning"
-  },
-  {
-    "start": "2018-09-21T15:29:25Z",
-    "asin": "B07192GP7F",
-    "wpm": 1327.4336283185842,
-    "period": "evening"
   },
   {
     "start": "2018-09-21T16:17:38Z",
@@ -744,18 +396,6 @@
     "period": "morning"
   },
   {
-    "start": "2018-09-26T11:04:22Z",
-    "asin": "B07192GP7F",
-    "wpm": 1271.1864406779662,
-    "period": "morning"
-  },
-  {
-    "start": "2018-09-26T18:21:15Z",
-    "asin": "B07192GP7F",
-    "wpm": 1775.1479289940828,
-    "period": "evening"
-  },
-  {
     "start": "2018-09-27T02:01:45Z",
     "asin": "B07192GP7F",
     "wpm": 215.51724137931038,
@@ -768,51 +408,15 @@
     "period": "morning"
   },
   {
-    "start": "2018-09-27T09:31:11Z",
-    "asin": "B07192GP7F",
-    "wpm": 1376.1467889908256,
-    "period": "morning"
-  },
-  {
     "start": "2018-09-28T01:23:28Z",
     "asin": "B07192GP7F",
     "wpm": 242.44684819097353,
     "period": "morning"
   },
   {
-    "start": "2018-09-28T08:31:28Z",
-    "asin": "B07192GP7F",
-    "wpm": 3658.536585365854,
-    "period": "morning"
-  },
-  {
-    "start": "2018-09-28T08:50:15Z",
-    "asin": "B06W2J89PV",
-    "wpm": 903.6144578313252,
-    "period": "morning"
-  },
-  {
-    "start": "2018-09-29T03:51:58Z",
-    "asin": "B07192GP7F",
-    "wpm": 3000,
-    "period": "morning"
-  },
-  {
     "start": "2018-10-06T03:25:34Z",
     "asin": "B07192GP7F",
     "wpm": 388.39979285344384,
-    "period": "morning"
-  },
-  {
-    "start": "2018-11-04T03:49:20Z",
-    "asin": "B0143V938Q",
-    "wpm": 7054.455445544554,
-    "period": "morning"
-  },
-  {
-    "start": "2018-11-05T04:00:36Z",
-    "asin": "B00KFEK0I8",
-    "wpm": 1510.0671140939598,
     "period": "morning"
   },
   {
@@ -846,21 +450,9 @@
     "period": "morning"
   },
   {
-    "start": "2018-11-06T12:00:55Z",
-    "asin": "B07BDKJVWS",
-    "wpm": 1369.86301369863,
-    "period": "evening"
-  },
-  {
     "start": "2018-11-07T02:36:41Z",
     "asin": "B07BDKJVWS",
     "wpm": 387.5968992248062,
-    "period": "morning"
-  },
-  {
-    "start": "2018-11-07T02:38:03Z",
-    "asin": "B07BDKJVWS",
-    "wpm": 1304.3478260869565,
     "period": "morning"
   },
   {
@@ -873,12 +465,6 @@
     "start": "2018-11-07T08:54:51Z",
     "asin": "B07BDKJVWS",
     "wpm": 389.4755063181582,
-    "period": "morning"
-  },
-  {
-    "start": "2018-11-07T09:47:25Z",
-    "asin": "B07BDKJVWS",
-    "wpm": 5940.59405940594,
     "period": "morning"
   },
   {
@@ -906,12 +492,6 @@
     "period": "evening"
   },
   {
-    "start": "2018-11-09T12:18:42Z",
-    "asin": "B07BDKJVWS",
-    "wpm": 1875,
-    "period": "evening"
-  },
-  {
     "start": "2019-01-06T13:42:41Z",
     "asin": "B00O2RPEE4",
     "wpm": 625.3722453841573,
@@ -926,7 +506,7 @@
   {
     "start": "2019-01-06T14:10:18Z",
     "asin": "B00O2RPEE4",
-    "wpm": 3943.9088518843123,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -936,21 +516,9 @@
     "period": "morning"
   },
   {
-    "start": "2019-02-07T15:52:12Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
     "start": "2019-02-08T23:05:52Z",
     "asin": "B074ZDRGBC",
     "wpm": 791.3961038961039,
-    "period": "evening"
-  },
-  {
-    "start": "2019-02-08T23:10:29Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 1395.3488372093022,
     "period": "evening"
   },
   {
@@ -966,52 +534,10 @@
     "period": "morning"
   },
   {
-    "start": "2019-02-11T02:22:05Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 1935.4838709677417,
-    "period": "morning"
-  },
-  {
-    "start": "2019-02-13T15:45:56Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 1293.103448275862,
-    "period": "evening"
-  },
-  {
-    "start": "2019-02-13T22:01:14Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 1435.4066985645934,
-    "period": "evening"
-  },
-  {
-    "start": "2019-02-14T21:51:57Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 2255.6390977443607,
-    "period": "evening"
-  },
-  {
-    "start": "2019-02-16T13:39:41Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 914.6341463414635,
-    "period": "evening"
-  },
-  {
-    "start": "2019-02-20T04:28:05Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 773.1958762886599,
-    "period": "morning"
-  },
-  {
     "start": "2019-02-20T04:30:18Z",
     "asin": "B074ZDRGBC",
     "wpm": 626.1927480916031,
     "period": "morning"
-  },
-  {
-    "start": "2019-02-20T12:19:33Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 2279.6352583586627,
-    "period": "evening"
   },
   {
     "start": "2019-02-26T05:11:48Z",
@@ -1026,39 +552,9 @@
     "period": "morning"
   },
   {
-    "start": "2019-02-26T21:55:27Z",
-    "asin": "B074ZDRGBC",
-    "wpm": 1530.6122448979593,
-    "period": "evening"
-  },
-  {
-    "start": "2019-02-28T20:15:16Z",
-    "asin": "B078W5XGZD",
-    "wpm": 1882.8451882845188,
-    "period": "evening"
-  },
-  {
-    "start": "2019-03-03T18:37:00Z",
-    "asin": "B078W5XGZD",
-    "wpm": 2205.8823529411766,
-    "period": "evening"
-  },
-  {
     "start": "2019-11-13T15:16:36Z",
     "asin": "B07BZ4F75T",
     "wpm": 703.125,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-13T15:33:40Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 6521.739130434783,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-21T22:36:50Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 2631.578947368421,
     "period": "evening"
   },
   {
@@ -1068,27 +564,9 @@
     "period": "evening"
   },
   {
-    "start": "2019-11-21T23:00:11Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 8955.223880597016,
-    "period": "evening"
-  },
-  {
     "start": "2019-11-22T00:09:06Z",
     "asin": "B07BZ4F75T",
     "wpm": 461.8226600985222,
-    "period": "morning"
-  },
-  {
-    "start": "2019-11-22T03:02:07Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 1136.3636363636363,
-    "period": "morning"
-  },
-  {
-    "start": "2019-11-22T03:02:22Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 691.2442396313363,
     "period": "morning"
   },
   {
@@ -1098,33 +576,9 @@
     "period": "morning"
   },
   {
-    "start": "2019-11-22T11:01:41Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 508.4745762711865,
-    "period": "morning"
-  },
-  {
-    "start": "2019-11-22T11:02:36Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 505.0505050505051,
-    "period": "morning"
-  },
-  {
     "start": "2019-11-22T21:15:32Z",
     "asin": "B07BZ4F75T",
     "wpm": 140.6050276949297,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-22T21:56:05Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 9375,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-22T21:56:11Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 9375,
     "period": "evening"
   },
   {
@@ -1140,51 +594,15 @@
     "period": "evening"
   },
   {
-    "start": "2019-11-24T04:31:47Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 1079.136690647482,
-    "period": "morning"
-  },
-  {
     "start": "2019-11-24T04:34:31Z",
     "asin": "B07BZ4F75T",
     "wpm": 382.9461322440643,
     "period": "morning"
   },
   {
-    "start": "2019-11-25T04:00:11Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 1785.7142857142856,
-    "period": "morning"
-  },
-  {
     "start": "2019-11-25T20:44:42Z",
     "asin": "B07BZ4F75T",
     "wpm": 206.3273727647868,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-25T20:48:32Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 30000,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-25T20:48:39Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 21428.571428571428,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-25T21:16:22Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-25T21:16:39Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 12500,
     "period": "evening"
   },
   {
@@ -1197,12 +615,6 @@
     "start": "2019-11-25T21:24:41Z",
     "asin": "B07BZ4F75T",
     "wpm": 156.1822125813449,
-    "period": "evening"
-  },
-  {
-    "start": "2019-11-25T21:43:59Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 10000,
     "period": "evening"
   },
   {
@@ -1230,33 +642,9 @@
     "period": "morning"
   },
   {
-    "start": "2019-11-27T17:43:01Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 4166.666666666667,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-10T19:56:27Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 5106.382978723404,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-10T20:04:26Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 6818.181818181819,
-    "period": "evening"
-  },
-  {
     "start": "2020-01-10T21:28:55Z",
     "asin": "B000OZ0NXA",
     "wpm": 107.3020414901227,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-10T22:56:31Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 3813.5593220338983,
     "period": "evening"
   },
   {
@@ -1270,12 +658,6 @@
     "asin": "B000OZ0NXA",
     "wpm": 340.522133938706,
     "period": "evening"
-  },
-  {
-    "start": "2020-01-11T03:02:00Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 555.5555555555555,
-    "period": "morning"
   },
   {
     "start": "2020-01-11T03:06:35Z",
@@ -1302,39 +684,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-01-11T15:15:31Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-11T15:46:28Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 5882.35294117647,
-    "period": "evening"
-  },
-  {
     "start": "2020-01-12T03:52:30Z",
     "asin": "B000OZ0NXA",
     "wpm": 185.5687899188676,
     "period": "morning"
   },
   {
-    "start": "2020-01-15T01:17:39Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 1219.5121951219512,
-    "period": "morning"
-  },
-  {
     "start": "2020-01-15T01:18:14Z",
     "asin": "B000OZ0NXA",
     "wpm": 191.0828025477707,
-    "period": "morning"
-  },
-  {
-    "start": "2020-01-15T01:18:51Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 2068.965517241379,
     "period": "morning"
   },
   {
@@ -1386,33 +744,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-01-18T14:10:10Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 1276.595744680851,
-    "period": "evening"
-  },
-  {
     "start": "2020-01-19T04:13:26Z",
     "asin": "B000OZ0NXA",
     "wpm": 505.3908355795149,
     "period": "morning"
   },
   {
-    "start": "2020-01-19T04:20:15Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 10344.827586206897,
-    "period": "morning"
-  },
-  {
     "start": "2020-01-20T03:05:09Z",
     "asin": "B000OZ0NXA",
     "wpm": 489.4962267999184,
-    "period": "morning"
-  },
-  {
-    "start": "2020-01-20T03:14:09Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 12244.897959183674,
     "period": "morning"
   },
   {
@@ -1426,24 +766,6 @@
     "asin": "B000OZ0NXA",
     "wpm": 387.0043000477783,
     "period": "morning"
-  },
-  {
-    "start": "2020-01-20T13:23:20Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 815.2173913043479,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-21T03:51:52Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 773.1958762886599,
-    "period": "morning"
-  },
-  {
-    "start": "2020-01-21T22:14:46Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 1315.7894736842104,
-    "period": "evening"
   },
   {
     "start": "2020-01-22T02:03:07Z",
@@ -1470,12 +792,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-01-22T22:21:15Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 4477.611940298508,
-    "period": "evening"
-  },
-  {
     "start": "2020-01-22T22:27:35Z",
     "asin": "B000OZ0NXA",
     "wpm": 407.4161549362305,
@@ -1486,12 +802,6 @@
     "asin": "B000OZ0NXA",
     "wpm": 337.62057877813504,
     "period": "morning"
-  },
-  {
-    "start": "2020-01-23T22:21:02Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 4545.454545454545,
-    "period": "evening"
   },
   {
     "start": "2020-01-23T22:21:58Z",
@@ -1512,27 +822,9 @@
     "period": "morning"
   },
   {
-    "start": "2020-01-24T22:19:22Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 3211.0091743119265,
-    "period": "evening"
-  },
-  {
     "start": "2020-01-24T22:25:08Z",
     "asin": "B000OZ0NXA",
     "wpm": 416.4096236890808,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-24T23:38:29Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QVpZVlgyNFVKSk1ZQSZtYXJrZXRwbGFjZT1BVFZQREtJS1gwREVSJmFzaW49QjA3Qlo0Rjc1VCZlbmR0aW1lPTE1NzQ4ODQ2Mzg2ODg",
-    "wpm": 657.8947368421052,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-24T23:39:36Z",
-    "asin": "B00II6SY4W",
-    "wpm": 643.7768240343348,
     "period": "evening"
   },
   {
@@ -1554,57 +846,15 @@
     "period": "evening"
   },
   {
-    "start": "2020-01-25T21:28:59Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 1304.3478260869565,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-25T21:31:38Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 761.4213197969543,
-    "period": "evening"
-  },
-  {
     "start": "2020-01-26T04:33:14Z",
     "asin": "B000OZ0NXA",
     "wpm": 336.322869955157,
     "period": "morning"
   },
   {
-    "start": "2020-01-26T12:31:31Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 2419.3548387096776,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-26T12:34:39Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 9677.41935483871,
-    "period": "evening"
-  },
-  {
-    "start": "2020-01-27T03:46:51Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 7792.207792207792,
-    "period": "morning"
-  },
-  {
-    "start": "2020-01-27T03:50:30Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 2031.602708803612,
-    "period": "morning"
-  },
-  {
-    "start": "2020-01-27T03:52:30Z",
-    "asin": "B000OZ0NXA",
-    "wpm": 4838.709677419355,
-    "period": "morning"
-  },
-  {
     "start": "2020-02-07T02:51:12Z",
     "asin": "B000QCS932",
-    "wpm": 6132.075471698113,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -1632,12 +882,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-02-07T21:07:37Z",
-    "asin": "B000QCS932",
-    "wpm": 2238.805970149254,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-07T21:08:16Z",
     "asin": "B001FXK8XU",
     "wpm": 557.6208178438662,
@@ -1656,27 +900,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-07T21:48:56Z",
-    "asin": "B001FXK8XU",
-    "wpm": 857.1428571428571,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-07T22:02:06Z",
-    "asin": "B001FXK8XU",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-07T22:02:14Z",
     "asin": "B001FXK8XU",
     "wpm": 110.02200440088018,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-07T22:27:32Z",
-    "asin": "B001FXK8XU",
-    "wpm": 18750,
     "period": "evening"
   },
   {
@@ -1686,27 +912,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-08T00:56:52Z",
-    "asin": "B001FXK8XU",
-    "wpm": 1554.4041450777202,
-    "period": "morning"
-  },
-  {
-    "start": "2020-02-08T00:57:15Z",
-    "asin": "B001FXK8XU",
-    "wpm": 12012.320328542095,
-    "period": "morning"
-  },
-  {
     "start": "2020-02-08T00:59:10Z",
     "asin": "B001FXK8XU",
     "wpm": 386.4680183712333,
-    "period": "morning"
-  },
-  {
-    "start": "2020-02-08T04:14:49Z",
-    "asin": "B001FXK8XU",
-    "wpm": 6382.978723404255,
     "period": "morning"
   },
   {
@@ -1716,21 +924,9 @@
     "period": "morning"
   },
   {
-    "start": "2020-02-08T12:14:35Z",
-    "asin": "B001FXK8XU",
-    "wpm": 815.2173913043479,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-08T12:14:57Z",
-    "asin": "B001FXK8XU",
-    "wpm": 2571.428571428571,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-08T19:33:19Z",
     "asin": "B000QCS932",
-    "wpm": 2396.1661341853037,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -1738,12 +934,6 @@
     "asin": "B001FXK8XU",
     "wpm": 169.8162501088566,
     "period": "morning"
-  },
-  {
-    "start": "2020-02-09T14:22:47Z",
-    "asin": "B001FXK8XU",
-    "wpm": 1171.875,
-    "period": "evening"
   },
   {
     "start": "2020-02-09T14:54:56Z",
@@ -1767,12 +957,6 @@
     "start": "2020-02-09T16:09:53Z",
     "asin": "B001FXK8XU",
     "wpm": 517.3099880620772,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-09T16:23:31Z",
-    "asin": "B001FXK8XU",
-    "wpm": 8571.42857142857,
     "period": "evening"
   },
   {
@@ -1812,12 +996,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-02-12T01:06:18Z",
-    "asin": "B001FXK8XU",
-    "wpm": 385.60411311053986,
-    "period": "morning"
-  },
-  {
     "start": "2020-02-12T01:08:56Z",
     "asin": "B001FXK8XU",
     "wpm": 420.4821528686227,
@@ -1842,12 +1020,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-13T02:57:28Z",
-    "asin": "B001FXK8XU",
-    "wpm": 1744.1860465116279,
-    "period": "morning"
-  },
-  {
     "start": "2020-02-13T03:18:54Z",
     "asin": "B001FXK8XU",
     "wpm": 763.6237417563347,
@@ -1866,51 +1038,15 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-14T16:37:50Z",
-    "asin": "B001FXK8XU",
-    "wpm": 6000,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-14T16:37:59Z",
-    "asin": "B001FXK8XU",
-    "wpm": 1388.888888888889,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-14T16:38:24Z",
     "asin": "B001FXK8XU",
-    "wpm": 10606.060606060606,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-15T14:58:20Z",
     "asin": "B001FXK8XU",
     "wpm": 526.207181180355,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-15T20:17:52Z",
-    "asin": "B001FXK8XU",
-    "wpm": 1327.4336283185842,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-15T20:18:05Z",
-    "asin": "B001FXK8XU",
-    "wpm": 714.2857142857143,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-15T22:37:09Z",
-    "asin": "B001FXK8XU",
-    "wpm": 627.6150627615064,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-15T22:38:04Z",
-    "asin": "B001FXK8XU",
-    "wpm": 10714.285714285714,
     "period": "evening"
   },
   {
@@ -1944,15 +1080,9 @@
     "period": "morning"
   },
   {
-    "start": "2020-02-16T02:37:44Z",
-    "asin": "B001FXK8XU",
-    "wpm": 2631.578947368421,
-    "period": "morning"
-  },
-  {
     "start": "2020-02-16T02:38:13Z",
     "asin": "B004DI7JNG",
-    "wpm": 7473.684210526316,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -2004,18 +1134,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-16T17:10:08Z",
-    "asin": "B004DI7JNG",
-    "wpm": 974.025974025974,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-16T17:18:02Z",
-    "asin": "B004DI7JNG",
-    "wpm": 4285.714285714285,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-16T18:28:43Z",
     "asin": "B004DI7JNG",
     "wpm": 878.3344176968119,
@@ -2024,7 +1142,7 @@
   {
     "start": "2020-02-17T02:23:02Z",
     "asin": "B004DI7JNG",
-    "wpm": 3391.1077618688773,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -2036,13 +1154,7 @@
   {
     "start": "2020-02-17T17:39:16Z",
     "asin": "B004DI7JNG",
-    "wpm": 3690.303907380608,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T17:43:49Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1310.0436681222707,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2052,45 +1164,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-17T17:55:13Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1822.9166666666667,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T18:12:35Z",
-    "asin": "B004DI7JNG",
-    "wpm": 8069.620253164558,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T18:19:39Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1559.2515592515592,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T18:33:09Z",
-    "asin": "B004DI7JNG",
-    "wpm": 4797.979797979798,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T18:34:16Z",
-    "asin": "B004DI7JNG",
-    "wpm": 18750,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T18:57:08Z",
-    "asin": "B004DI7JNG",
-    "wpm": 21428.57142857143,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-17T19:06:39Z",
     "asin": "B004DI7JNG",
-    "wpm": 8577.712609970675,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2100,93 +1176,15 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-17T19:31:40Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1750.9727626459144,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-17T19:32:41Z",
     "asin": "B004DI7JNG",
     "wpm": 444.44444444444446,
     "period": "evening"
   },
   {
-    "start": "2020-02-17T19:44:48Z",
-    "asin": "B004DI7JNG",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T19:49:04Z",
-    "asin": "B004DI7JNG",
-    "wpm": 528.169014084507,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T19:51:05Z",
-    "asin": "B004DI7JNG",
-    "wpm": 4054.054054054054,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T19:56:13Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7142.857142857142,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:04:19Z",
-    "asin": "B004DI7JNG",
-    "wpm": 8823.529411764706,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:04:23Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1530.6122448979593,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:08:09Z",
-    "asin": "B004DI7JNG",
-    "wpm": 4411.764705882353,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:39:35Z",
-    "asin": "B004DI7JNG",
-    "wpm": 346.4203233256351,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:48:37Z",
-    "asin": "B004DI7JNG",
-    "wpm": 21428.571428571428,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-17T20:48:47Z",
     "asin": "B004DI7JNG",
     "wpm": 37.11034141514102,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:56:39Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7894.736842105262,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T20:56:45Z",
-    "asin": "B004DI7JNG",
-    "wpm": 3114.1868512110727,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T21:08:26Z",
-    "asin": "B004DI7JNG",
-    "wpm": 3348.214285714286,
     "period": "evening"
   },
   {
@@ -2202,46 +1200,16 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-17T21:36:38Z",
-    "asin": "B004DI7JNG",
-    "wpm": 13636.363636363636,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-17T21:43:40Z",
-    "asin": "B004DI7JNG",
-    "wpm": 15789.473684210525,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-17T21:56:22Z",
     "asin": "B004DI7JNG",
     "wpm": 86.93132425383946,
     "period": "evening"
   },
   {
-    "start": "2020-02-17T22:02:09Z",
-    "asin": "B004DI7JNG",
-    "wpm": 15000,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-17T23:56:46Z",
     "asin": "B004DI7JNG",
-    "wpm": 5345.394736842105,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2020-02-18T00:03:01Z",
-    "asin": "B004DI7JNG",
-    "wpm": 3024.1935483870966,
-    "period": "morning"
-  },
-  {
-    "start": "2020-02-18T00:04:46Z",
-    "asin": "B004DI7JNG",
-    "wpm": 2166.0649819494583,
-    "period": "morning"
   },
   {
     "start": "2020-02-18T03:01:38Z",
@@ -2252,7 +1220,7 @@
   {
     "start": "2020-02-18T16:26:32Z",
     "asin": "B004DI7JNG",
-    "wpm": 2162.7188465499485,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2262,45 +1230,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-18T16:51:54Z",
-    "asin": "B004DI7JNG",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T16:56:32Z",
-    "asin": "B004DI7JNG",
-    "wpm": 903.6144578313254,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T17:34:02Z",
-    "asin": "B004DI7JNG",
-    "wpm": 16666.666666666668,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T18:56:53Z",
-    "asin": "B004DI7JNG",
-    "wpm": 3383.458646616541,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-18T19:10:43Z",
     "asin": "B004DI7JNG",
     "wpm": 1642.7104722792608,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T19:23:36Z",
-    "asin": "B004DI7JNG",
-    "wpm": 15000,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T19:36:00Z",
-    "asin": "B004DI7JNG",
-    "wpm": 21428.571428571428,
     "period": "evening"
   },
   {
@@ -2312,19 +1244,7 @@
   {
     "start": "2020-02-18T19:58:02Z",
     "asin": "B004DI7JNG",
-    "wpm": 4212.16848673947,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T20:00:02Z",
-    "asin": "B004DI7JNG",
-    "wpm": 3071.6723549488056,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-18T20:01:23Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1666.6666666666667,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2334,69 +1254,15 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-19T03:40:02Z",
-    "asin": "B004DI7JNG",
-    "wpm": 12078.651685393259,
-    "period": "morning"
-  },
-  {
-    "start": "2020-02-19T03:46:04Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7912.087912087913,
-    "period": "morning"
-  },
-  {
-    "start": "2020-02-19T03:48:16Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1838.879159369527,
-    "period": "morning"
-  },
-  {
     "start": "2020-02-19T14:16:07Z",
     "asin": "B004DI7JNG",
     "wpm": 1161.9718309859154,
     "period": "evening"
   },
   {
-    "start": "2020-02-19T14:23:52Z",
-    "asin": "B004DI7JNG",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-19T15:01:24Z",
     "asin": "B004DI7JNG",
-    "wpm": 2346.5703971119133,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T15:03:43Z",
-    "asin": "B004DI7JNG",
-    "wpm": 6818.181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T15:04:11Z",
-    "asin": "B004DI7JNG",
-    "wpm": 632.9113924050632,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T15:05:03Z",
-    "asin": "B004DI7JNG",
-    "wpm": 2380.952380952381,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T15:05:30Z",
-    "asin": "B004DI7JNG",
-    "wpm": 386.59793814432993,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T15:06:29Z",
-    "asin": "B004DI7JNG",
-    "wpm": 319.8294243070363,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2406,21 +1272,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-19T16:32:04Z",
-    "asin": "B004DI7JNG",
-    "wpm": 13636.363636363638,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-19T16:50:18Z",
     "asin": "B004DI7JNG",
     "wpm": 1856.0179977502812,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T16:54:31Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7276.119402985075,
     "period": "evening"
   },
   {
@@ -2436,147 +1290,45 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-19T19:22:42Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1304.3478260869565,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-19T19:32:55Z",
     "asin": "B004DI7JNG",
     "wpm": 616.5590135055784,
     "period": "evening"
   },
   {
-    "start": "2020-02-19T20:16:25Z",
-    "asin": "B004DI7JNG",
-    "wpm": 18750,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T20:16:45Z",
-    "asin": "B004DI7JNG",
-    "wpm": 10000,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-19T22:59:07Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1363.6363636363637,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-19T22:59:25Z",
     "asin": "B004DI7JNG",
-    "wpm": 3345.7249070631974,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-20T12:30:53Z",
     "asin": "B004DI7JNG",
-    "wpm": 2614.678899082569,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T12:32:52Z",
-    "asin": "B004DI7JNG",
-    "wpm": 3260.8695652173915,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T15:44:16Z",
-    "asin": "B004DI7JNG",
-    "wpm": 5084.745762711865,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T16:21:28Z",
-    "asin": "B004DI7JNG",
-    "wpm": 13221.884498480244,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T18:56:45Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1973.6842105263156,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-20T20:05:26Z",
     "asin": "B004DI7JNG",
-    "wpm": 13573.61963190184,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:29:28Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7350.2722323049,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-20T20:36:02Z",
     "asin": "B004DI7JNG",
-    "wpm": 2687.5699888017916,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:39:21Z",
-    "asin": "B004DI7JNG",
-    "wpm": 649.3506493506493,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:42:30Z",
-    "asin": "B004DI7JNG",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:42:38Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7317.073170731708,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-20T20:44:48Z",
     "asin": "B004DI7JNG",
-    "wpm": 2176.5417170495766,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:48:31Z",
-    "asin": "B004DI7JNG",
-    "wpm": 4054.054054054054,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:50:45Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1785.7142857142856,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:52:11Z",
-    "asin": "B004DI7JNG",
-    "wpm": 660.7929515418501,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-20T20:53:03Z",
     "asin": "B004DI7JNG",
     "wpm": 372.67080745341616,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:56:33Z",
-    "asin": "B004DI7JNG",
-    "wpm": 6818.181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T20:59:56Z",
-    "asin": "B004DI7JNG",
-    "wpm": 25000,
     "period": "evening"
   },
   {
@@ -2588,31 +1340,13 @@
   {
     "start": "2020-02-20T21:17:01Z",
     "asin": "B004DI7JNG",
-    "wpm": 3990.1477832512314,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T21:19:05Z",
-    "asin": "B004DI7JNG",
-    "wpm": 993.3774834437087,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-20T21:21:37Z",
     "asin": "B004DI7JNG",
     "wpm": 462.67735965453426,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T21:24:46Z",
-    "asin": "B004DI7JNG",
-    "wpm": 607.2874493927126,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-20T21:50:11Z",
-    "asin": "B004DI7JNG",
-    "wpm": 8823.529411764706,
     "period": "evening"
   },
   {
@@ -2630,13 +1364,7 @@
   {
     "start": "2020-02-21T17:54:38Z",
     "asin": "B004DI7JNG",
-    "wpm": 3846.1538461538457,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T17:56:48Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1829.268292682927,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2646,69 +1374,15 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-21T18:24:25Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7894.736842105262,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:24:44Z",
-    "asin": "B004DI7JNG",
-    "wpm": 30000,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-21T18:32:58Z",
     "asin": "B004DI7JNG",
-    "wpm": 2330.6401491609695,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:36:33Z",
-    "asin": "B004DI7JNG",
-    "wpm": 2808.9887640449438,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:37:01Z",
-    "asin": "B004DI7JNG",
-    "wpm": 18750,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:38:11Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1535.8361774744028,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:39:39Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1923.076923076923,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-21T18:43:34Z",
     "asin": "B004DI7JNG",
-    "wpm": 3532.182103610675,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:44:39Z",
-    "asin": "B004DI7JNG",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:44:39Z",
-    "asin": "B004DI7JNG",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T18:48:53Z",
-    "asin": "B004DI7JNG",
-    "wpm": 0,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -2724,105 +1398,51 @@
     "period": "evening"
   },
   {
-    "start": "2020-02-21T20:14:39Z",
-    "asin": "B004DI7JNG",
-    "wpm": 7500,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T20:24:07Z",
-    "asin": "B004DI7JNG",
-    "wpm": 10714.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T20:24:32Z",
-    "asin": "B004DI7JNG",
-    "wpm": 1415.0943396226414,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T20:48:29Z",
-    "asin": "B004DI7JNG",
-    "wpm": 10714.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T20:57:59Z",
-    "asin": "B004DI7JNG",
-    "wpm": 13636.363636363636,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-21T20:59:21Z",
     "asin": "B004DI7JNG",
     "wpm": 238.09523809523807,
     "period": "evening"
   },
   {
-    "start": "2020-02-21T21:23:32Z",
-    "asin": "B004DI7JNG",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-21T21:51:55Z",
-    "asin": "B004DI7JNG",
-    "wpm": 30000,
-    "period": "evening"
-  },
-  {
     "start": "2020-02-23T20:42:03Z",
     "asin": "B004DI7JNG",
-    "wpm": 4401.408450704225,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-24T00:56:49Z",
     "asin": "B004DI7JNG",
-    "wpm": 3922.052294030587,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2020-02-24T17:36:17Z",
     "asin": "B004DI7JNG",
-    "wpm": 12029.459901800328,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-24T17:42:34Z",
     "asin": "B004DI7JNG",
-    "wpm": 7078.039927404719,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-24T18:05:30Z",
     "asin": "B004DI7JNG",
-    "wpm": 11603.37552742616,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-26T19:59:04Z",
     "asin": "B004DI7JNG",
-    "wpm": 5483.490566037736,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-02-28T17:36:12Z",
     "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QUozNk1KS0pFTk5LJm1hcmtldHBsYWNlPUFUVlBES0lLWDBERVImYXNpbj1CMDA0REk3Sk5HJmVuZHRpbWU9MTU4Mjc0NzI0MDA5OQ",
     "wpm": 34.932463903120635,
-    "period": "evening"
-  },
-  {
-    "start": "2020-02-28T17:43:28Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QUozNk1KS0pFTk5LJm1hcmtldHBsYWNlPUFUVlBES0lLWDBERVImYXNpbj1CMDA0REk3Sk5HJmVuZHRpbWU9MTU4Mjc0NzI0MDA5OQ",
-    "wpm": 2272.7272727272725,
-    "period": "evening"
-  },
-  {
-    "start": "2020-03-02T23:52:42Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 826.4462809917355,
     "period": "evening"
   },
   {
@@ -2862,27 +1482,9 @@
     "period": "morning"
   },
   {
-    "start": "2020-03-06T03:49:31Z",
-    "asin": "B077WWXZ41",
-    "wpm": 2777.777777777778,
-    "period": "morning"
-  },
-  {
     "start": "2020-03-06T03:53:41Z",
     "asin": "B07BZ4F75T",
     "wpm": 194.64720194647202,
-    "period": "morning"
-  },
-  {
-    "start": "2020-03-06T21:19:23Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 2941.176470588235,
-    "period": "evening"
-  },
-  {
-    "start": "2020-03-07T01:51:40Z",
-    "asin": "B077WWXZ41",
-    "wpm": 4285.714285714285,
     "period": "morning"
   },
   {
@@ -2916,12 +1518,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-03-10T04:10:21Z",
-    "asin": "B07BZ4F75T",
-    "wpm": 1041.6666666666667,
-    "period": "morning"
-  },
-  {
     "start": "2020-03-10T04:32:51Z",
     "asin": "B07BZ4F75T",
     "wpm": 652.3407521105142,
@@ -2936,7 +1532,7 @@
   {
     "start": "2020-03-16T03:18:14Z",
     "asin": "B07BZ4F75T",
-    "wpm": 3082.706766917293,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -3000,24 +1596,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-03-24T12:36:05Z",
-    "asin": "B000FBJDF2",
-    "wpm": 1851.8518518518517,
-    "period": "evening"
-  },
-  {
-    "start": "2020-03-24T12:37:12Z",
-    "asin": "B000FBJDF2",
-    "wpm": 7627.118644067797,
-    "period": "evening"
-  },
-  {
-    "start": "2020-03-24T21:01:38Z",
-    "asin": "B000FBJDF2",
-    "wpm": 378.78787878787875,
-    "period": "evening"
-  },
-  {
     "start": "2020-03-24T21:05:10Z",
     "asin": "B000FBJDF2",
     "wpm": 287.91678276214355,
@@ -3030,22 +1608,10 @@
     "period": "morning"
   },
   {
-    "start": "2020-03-25T21:46:59Z",
-    "asin": "B000FC1MBO",
-    "wpm": 646.551724137931,
-    "period": "evening"
-  },
-  {
     "start": "2020-03-25T21:47:33Z",
     "asin": "B000FBJDF2",
     "wpm": 183.87986515476555,
     "period": "evening"
-  },
-  {
-    "start": "2020-03-28T02:42:49Z",
-    "asin": "B000FC1MBO",
-    "wpm": 1363.6363636363637,
-    "period": "morning"
   },
   {
     "start": "2020-03-28T02:43:06Z",
@@ -3090,21 +1656,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-04-02T00:53:17Z",
-    "asin": "B000FBJDF2",
-    "wpm": 6000,
-    "period": "morning"
-  },
-  {
     "start": "2020-04-02T01:24:39Z",
     "asin": "B000FBJDF2",
     "wpm": 898.4753146176186,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-02T01:54:34Z",
-    "asin": "B000FC1MBO",
-    "wpm": 393.7007874015748,
     "period": "morning"
   },
   {
@@ -3168,12 +1722,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-04-07T20:36:06Z",
-    "asin": "B000FC1MBO",
-    "wpm": 781.25,
-    "period": "evening"
-  },
-  {
     "start": "2020-04-08T02:48:51Z",
     "asin": "B000FC1MBO",
     "wpm": 408.74684608915055,
@@ -3234,76 +1782,10 @@
     "period": "morning"
   },
   {
-    "start": "2020-04-15T13:36:13Z",
-    "asin": "B000FCK5PI",
-    "wpm": 1376.1467889908256,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-15T13:36:26Z",
-    "asin": "B000FCK5PI",
-    "wpm": 3082.1917808219177,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-15T19:51:17Z",
-    "asin": "B000FCK5PI",
-    "wpm": 2112.676056338028,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-15T19:51:25Z",
-    "asin": "B000FCK5PI",
-    "wpm": 3846.153846153846,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-15T19:51:41Z",
-    "asin": "B07L2J8P4S",
-    "wpm": 1219.5121951219512,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-16T02:56:48Z",
-    "asin": "B000FCK5PI",
-    "wpm": 3409.090909090909,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-16T03:02:11Z",
-    "asin": "B000FCK5PI",
-    "wpm": 4128.440366972477,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-16T17:00:44Z",
-    "asin": "B000FCK5PI",
-    "wpm": 3409.090909090909,
-    "period": "evening"
-  },
-  {
     "start": "2020-04-16T17:01:25Z",
     "asin": "B000FCK5PI",
-    "wpm": 5513.307984790875,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2020-04-20T03:14:00Z",
-    "asin": "B000GCFG7E",
-    "wpm": 997.7827050997782,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-20T03:15:26Z",
-    "asin": "B000GCFG7E",
-    "wpm": 3947.368421052631,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-20T03:15:32Z",
-    "asin": "B07L2J8P4S",
-    "wpm": 7500,
-    "period": "morning"
   },
   {
     "start": "2020-04-20T03:15:51Z",
@@ -3318,33 +1800,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-04-22T01:33:36Z",
-    "asin": "B000GCFG7E",
-    "wpm": 862.0689655172414,
-    "period": "morning"
-  },
-  {
     "start": "2020-04-22T01:59:56Z",
     "asin": "B000GCFG7E",
-    "wpm": 4615.384615384616,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2020-04-22T02:09:54Z",
     "asin": "B000GCFG7E",
     "wpm": 435.0089232599643,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-22T13:27:07Z",
-    "asin": "B000GCFG7E",
-    "wpm": 6122.448979591837,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-23T02:28:28Z",
-    "asin": "B000GCFG7E",
-    "wpm": 2142.8571428571427,
     "period": "morning"
   },
   {
@@ -3360,30 +1824,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-04-23T16:23:51Z",
-    "asin": "B000GCFG7E",
-    "wpm": 1485.148514851485,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-24T01:21:57Z",
-    "asin": "B000GCFG7E",
-    "wpm": 5555.555555555556,
-    "period": "morning"
-  },
-  {
-    "start": "2020-04-24T19:31:58Z",
-    "asin": "B000GCFG7E",
-    "wpm": 16666.666666666668,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-24T21:06:30Z",
-    "asin": "B000GCFG7E",
-    "wpm": 2205.8823529411766,
-    "period": "evening"
-  },
-  {
     "start": "2020-04-25T19:36:03Z",
     "asin": "B000GCFG7E",
     "wpm": 623.7006237006237,
@@ -3396,51 +1836,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-04-28T02:00:21Z",
-    "asin": "B000GCFG7E",
-    "wpm": 1027.3972602739725,
-    "period": "morning"
-  },
-  {
     "start": "2020-04-28T02:05:18Z",
     "asin": "B000GCFG7E",
     "wpm": 143.95393474088291,
     "period": "morning"
   },
   {
-    "start": "2020-04-29T15:05:18Z",
-    "asin": "B000GCFG7E",
-    "wpm": 2830.188679245283,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-29T17:34:43Z",
-    "asin": "B000GCFG7E",
-    "wpm": 2216.7487684729067,
-    "period": "evening"
-  },
-  {
-    "start": "2020-04-30T10:48:31Z",
-    "asin": "B000GCFG7E",
-    "wpm": 1500,
-    "period": "morning"
-  },
-  {
     "start": "2020-05-01T03:14:11Z",
     "asin": "B000GCFG7E",
     "wpm": 1736.1543248288735,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-10T23:47:57Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 2319.5876288659797,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-11T00:22:58Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 2710.843373493976,
     "period": "morning"
   },
   {
@@ -3462,94 +1866,10 @@
     "period": "morning"
   },
   {
-    "start": "2020-05-12T23:50:06Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 1079.136690647482,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-12T23:55:59Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 1485.148514851485,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-13T00:09:02Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 3658.536585365854,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-13T00:46:27Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 2272.7272727272725,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-13T02:47:07Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 1931.3304721030045,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-13T02:58:23Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 2830.188679245283,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-13T03:31:26Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 3061.2244897959185,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-13T04:18:45Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 2054.794520547945,
-    "period": "morning"
-  },
-  {
     "start": "2020-05-13T04:27:28Z",
     "asin": "B07TRVW6VX",
     "wpm": 661.6939364773821,
     "period": "morning"
-  },
-  {
-    "start": "2020-05-15T00:25:24Z",
-    "asin": "B07TRVW6VX",
-    "wpm": 5882.35294117647,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-15T00:26:11Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 11264.822134387352,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-15T00:44:42Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 3797.4683544303803,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-15T02:18:34Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 3781.5126050420167,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-18T21:15:31Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 3435.1145038167942,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-18T22:50:48Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 2960.5263157894733,
-    "period": "evening"
   },
   {
     "start": "2020-05-20T13:46:12Z",
@@ -3558,58 +1878,10 @@
     "period": "evening"
   },
   {
-    "start": "2020-05-20T19:49:42Z",
-    "asin": "B077WWXZ41",
-    "wpm": 4054.054054054054,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-20T19:49:48Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 2760.7361963190183,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-20T20:12:45Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 3383.458646616541,
-    "period": "evening"
-  },
-  {
     "start": "2020-05-22T02:34:06Z",
     "asin": "B000QCQ8Y4",
     "wpm": 1638.5302879841113,
     "period": "morning"
-  },
-  {
-    "start": "2020-05-22T03:07:37Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 10645.16129032258,
-    "period": "morning"
-  },
-  {
-    "start": "2020-05-22T15:46:40Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 2542.3728813559323,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-22T15:51:06Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-22T17:21:34Z",
-    "asin": "B000QCQ8Y4",
-    "wpm": 2542.3728813559323,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-22T20:35:42Z",
-    "asin": "B000YJ54DU",
-    "wpm": 3191.489361702128,
-    "period": "evening"
   },
   {
     "start": "2020-05-25T03:42:17Z",
@@ -3630,33 +1902,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-05-25T17:11:26Z",
-    "asin": "B000YJ54DU",
-    "wpm": 2205.8823529411766,
-    "period": "evening"
-  },
-  {
     "start": "2020-05-25T18:50:48Z",
     "asin": "B000YJ54DU",
-    "wpm": 2707.581227436823,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-05-29T22:13:27Z",
     "asin": "B000YJ54DU",
-    "wpm": 6009.244992295839,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-29T22:44:38Z",
-    "asin": "B001NLL8LA",
-    "wpm": 553.5055350553506,
-    "period": "evening"
-  },
-  {
-    "start": "2020-05-29T22:45:07Z",
-    "asin": "B001NLL8LA",
-    "wpm": 7205.240174672489,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -3669,12 +1923,6 @@
     "start": "2020-06-01T08:51:37Z",
     "asin": "B001NLL8LA",
     "wpm": 286.47822765469823,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-02T02:51:29Z",
-    "asin": "B000GCFG7E",
-    "wpm": 3448.2758620689656,
     "period": "morning"
   },
   {
@@ -3732,34 +1980,16 @@
     "period": "morning"
   },
   {
-    "start": "2020-06-05T03:42:52Z",
-    "asin": "B001NLL8LA",
-    "wpm": 1239.6694214876034,
-    "period": "morning"
-  },
-  {
     "start": "2020-06-05T03:47:07Z",
     "asin": "B001NLL8LA",
     "wpm": 325.02708559046584,
     "period": "morning"
   },
   {
-    "start": "2020-06-05T17:44:57Z",
-    "asin": "B001NLL8LA",
-    "wpm": 3571.428571428571,
-    "period": "evening"
-  },
-  {
     "start": "2020-06-06T03:32:35Z",
     "asin": "B001NLL8LA",
     "wpm": 319.7893152746426,
     "period": "morning"
-  },
-  {
-    "start": "2020-06-06T15:17:58Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 2980.132450331126,
-    "period": "evening"
   },
   {
     "start": "2020-06-06T15:30:33Z",
@@ -3778,30 +2008,6 @@
     "asin": "B07QBNKJTZ",
     "wpm": 577.039886616724,
     "period": "evening"
-  },
-  {
-    "start": "2020-06-06T17:06:10Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 646.551724137931,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-06T17:06:35Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-06T17:09:08Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 1595.7446808510638,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-07T03:58:49Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 3296.7032967032965,
-    "period": "morning"
   },
   {
     "start": "2020-06-07T03:59:04Z",
@@ -3828,39 +2034,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-06-07T17:38:30Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 3571.428571428571,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-07T17:38:36Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 1278.409090909091,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-07T17:40:56Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 535.7142857142857,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-08T09:44:52Z",
-    "asin": "B001NLL8LA",
-    "wpm": 2803.738317757009,
-    "period": "morning"
-  },
-  {
     "start": "2020-06-09T01:06:37Z",
     "asin": "B001NLL8LA",
     "wpm": 197.5070224719101,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-09T01:50:29Z",
-    "asin": "B001NLL8LA",
-    "wpm": 2142.8571428571427,
     "period": "morning"
   },
   {
@@ -3894,12 +2070,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-06-10T17:03:05Z",
-    "asin": "B07QBNKJTZ",
-    "wpm": 6521.739130434783,
-    "period": "evening"
-  },
-  {
     "start": "2020-06-11T00:19:18Z",
     "asin": "B001NLL8LA",
     "wpm": 555.5555555555555,
@@ -3909,12 +2079,6 @@
     "start": "2020-06-11T00:34:03Z",
     "asin": "B001NLL8LA",
     "wpm": 260.81458454080826,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-11T08:10:27Z",
-    "asin": "B001NLL8LA",
-    "wpm": 1662.0498614958449,
     "period": "morning"
   },
   {
@@ -3936,18 +2100,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-06-11T23:37:23Z",
-    "asin": "B001NLL8LA",
-    "wpm": 2777.777777777778,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-11T23:43:32Z",
-    "asin": "B001NLL8LA",
-    "wpm": 1554.4041450777202,
-    "period": "evening"
-  },
-  {
     "start": "2020-06-11T23:45:10Z",
     "asin": "B001NLL8LA",
     "wpm": 266.5277862876049,
@@ -3957,12 +2109,6 @@
     "start": "2020-06-13T15:59:11Z",
     "asin": "B001NLL8LA",
     "wpm": 121.83235867446395,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-13T21:24:06Z",
-    "asin": "B001NLL8LA",
-    "wpm": 6976.7441860465115,
     "period": "evening"
   },
   {
@@ -3996,24 +2142,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-06-15T03:11:11Z",
-    "asin": "B001NLL8LA",
-    "wpm": 3529.4117647058824,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-15T03:11:33Z",
-    "asin": "B0036S4CWA",
-    "wpm": 761.4213197969543,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-15T03:11:55Z",
-    "asin": "B0036S4CWA",
-    "wpm": 2290.0763358778627,
-    "period": "morning"
-  },
-  {
     "start": "2020-06-15T03:12:11Z",
     "asin": "B0036S4CWA",
     "wpm": 446.8718967229394,
@@ -4032,99 +2160,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-06-17T19:58:55Z",
-    "asin": "B0036S4CWA",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-17T19:59:05Z",
-    "asin": "B003EY7IWC",
-    "wpm": 1937.984496124031,
-    "period": "evening"
-  },
-  {
-    "start": "2020-06-18T02:25:01Z",
-    "asin": "B003EY7IWC",
-    "wpm": 7142.857142857142,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-18T02:25:16Z",
-    "asin": "B003EY7IWC",
-    "wpm": 6000,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-18T02:25:21Z",
-    "asin": "B003EY7IWC",
-    "wpm": 409.8360655737705,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-18T02:26:36Z",
-    "asin": "B003EY7IWC",
-    "wpm": 585.9375,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-18T11:18:20Z",
-    "asin": "B07THBZ4VD",
-    "wpm": 3813.5593220338983,
-    "period": "morning"
-  },
-  {
-    "start": "2020-06-18T20:32:46Z",
-    "asin": "B07THBZ4VD",
-    "wpm": 3750,
-    "period": "evening"
-  },
-  {
     "start": "2020-06-19T11:09:16Z",
     "asin": "B004P8JPS6",
-    "wpm": 2255.6390977443607,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2020-08-04T03:15:11Z",
     "asin": "B07NCNVZ5P",
     "wpm": 630.7031669350511,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T00:39:01Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 2542.3728813559323,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T00:48:24Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 4639.175257731959,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T02:33:13Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 1914.8936170212767,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T02:36:10Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 2419.3548387096776,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T02:42:51Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 2238.805970149254,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T02:47:05Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 2803.738317757009,
     "period": "morning"
   },
   {
@@ -4138,24 +2182,6 @@
     "asin": "B07NCNVZ5P",
     "wpm": 337.9103196738897,
     "period": "morning"
-  },
-  {
-    "start": "2020-08-05T11:07:31Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 1071.4285714285713,
-    "period": "morning"
-  },
-  {
-    "start": "2020-08-05T14:36:14Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 1181.1023622047244,
-    "period": "evening"
-  },
-  {
-    "start": "2020-08-05T16:00:42Z",
-    "asin": "B07NCNVZ5P",
-    "wpm": 3278.688524590164,
-    "period": "evening"
   },
   {
     "start": "2020-08-06T03:25:38Z",
@@ -4176,15 +2202,9 @@
     "period": "morning"
   },
   {
-    "start": "2020-08-28T19:59:59Z",
-    "asin": "B07GNX99VJ",
-    "wpm": 1048.951048951049,
-    "period": "evening"
-  },
-  {
     "start": "2020-09-12T19:55:52Z",
     "asin": "B00U27BMT4",
-    "wpm": 3949.934980494148,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -4194,51 +2214,21 @@
     "period": "evening"
   },
   {
-    "start": "2020-09-12T20:01:05Z",
-    "asin": "B00U27BMT4",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2020-09-12T20:02:07Z",
-    "asin": "B00U27BMT4",
-    "wpm": 2586.206896551724,
-    "period": "evening"
-  },
-  {
-    "start": "2020-09-12T20:02:19Z",
-    "asin": "B00U27BMT4",
-    "wpm": 3846.153846153846,
-    "period": "evening"
-  },
-  {
     "start": "2020-09-12T20:02:26Z",
     "asin": "B00U27BMT4",
     "wpm": 1178.0104712041884,
     "period": "evening"
   },
   {
-    "start": "2020-09-13T15:58:42Z",
-    "asin": "B00U27BMT4",
-    "wpm": 2050.78125,
-    "period": "evening"
-  },
-  {
     "start": "2020-09-13T21:45:47Z",
     "asin": "B00U27BMT4",
-    "wpm": 3000,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2020-09-13T21:51:28Z",
     "asin": "B00U27BMT4",
-    "wpm": 4481.132075471698,
-    "period": "evening"
-  },
-  {
-    "start": "2020-09-13T22:23:02Z",
-    "asin": "B00U27BMT4",
-    "wpm": 541.5162454873646,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -4246,30 +2236,6 @@
     "asin": "B00U27BMT4",
     "wpm": 1407.7163712200208,
     "period": "evening"
-  },
-  {
-    "start": "2020-09-16T16:36:40Z",
-    "asin": "B086JN68M6",
-    "wpm": 4687.5,
-    "period": "evening"
-  },
-  {
-    "start": "2020-09-17T00:48:33Z",
-    "asin": "B086JN68M6",
-    "wpm": 3947.368421052631,
-    "period": "morning"
-  },
-  {
-    "start": "2020-09-17T01:33:44Z",
-    "asin": "B086JN68M6",
-    "wpm": 3409.090909090909,
-    "period": "morning"
-  },
-  {
-    "start": "2020-09-17T01:33:56Z",
-    "asin": "B086JN68M6",
-    "wpm": 3191.489361702128,
-    "period": "morning"
   },
   {
     "start": "2020-09-17T02:03:22Z",
@@ -4332,40 +2298,10 @@
     "period": "evening"
   },
   {
-    "start": "2020-09-21T02:42:45Z",
-    "asin": "B0084B57VO",
-    "wpm": 585.9375,
-    "period": "morning"
-  },
-  {
-    "start": "2020-09-21T02:46:12Z",
-    "asin": "B085GKR5BL",
-    "wpm": 11729.857819905214,
-    "period": "morning"
-  },
-  {
-    "start": "2020-09-25T03:28:36Z",
-    "asin": "B0084B57VO",
-    "wpm": 1754.3859649122808,
-    "period": "morning"
-  },
-  {
-    "start": "2020-09-25T03:28:56Z",
-    "asin": "B0084B57VO",
-    "wpm": 404.3126684636119,
-    "period": "morning"
-  },
-  {
     "start": "2020-09-25T03:30:05Z",
     "asin": "B0084B57VO",
     "wpm": 354.05192761605036,
     "period": "morning"
-  },
-  {
-    "start": "2020-09-28T14:42:24Z",
-    "asin": "B07ZN51NL3",
-    "wpm": 1419.5583596214512,
-    "period": "evening"
   },
   {
     "start": "2020-09-29T03:30:19Z",
@@ -4398,12 +2334,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-10-12T18:42:18Z",
-    "asin": "B081NHX6LN",
-    "wpm": 3191.4893617021276,
-    "period": "evening"
-  },
-  {
     "start": "2020-10-12T18:42:33Z",
     "asin": "B081NHX6LN",
     "wpm": 240.09603841536614,
@@ -4426,12 +2356,6 @@
     "asin": "B081NHX6LN",
     "wpm": 312.89111389236547,
     "period": "evening"
-  },
-  {
-    "start": "2020-10-14T03:55:27Z",
-    "asin": "B07ZG57WBH",
-    "wpm": 1162.7906976744187,
-    "period": "morning"
   },
   {
     "start": "2020-10-14T03:55:48Z",
@@ -4464,12 +2388,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-10-28T04:46:44Z",
-    "asin": "B089T77W63",
-    "wpm": 6194.690265486726,
-    "period": "morning"
-  },
-  {
     "start": "2020-10-28T05:04:56Z",
     "asin": "B07THQLGBT",
     "wpm": 488.3186518575259,
@@ -4488,51 +2406,15 @@
     "period": "morning"
   },
   {
-    "start": "2020-11-18T05:58:15Z",
-    "asin": "B08NHG3PKK",
-    "wpm": 8727.272727272728,
-    "period": "morning"
-  },
-  {
-    "start": "2020-11-18T06:30:58Z",
-    "asin": "B08NHG3PKK",
-    "wpm": 2654.8672566371683,
-    "period": "morning"
-  },
-  {
-    "start": "2020-11-27T16:22:07Z",
-    "asin": "B089T77W63",
-    "wpm": 2941.176470588235,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-27T16:22:17Z",
-    "asin": "B089T77W63",
-    "wpm": 2884.6153846153843,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T04:33:37Z",
-    "asin": "B08NHG3PKK",
-    "wpm": 4545.454545454545,
-    "period": "morning"
-  },
-  {
-    "start": "2020-11-30T04:35:35Z",
-    "asin": "B08NHG3PKK",
-    "wpm": 9090.90909090909,
-    "period": "morning"
-  },
-  {
     "start": "2020-11-30T04:35:47Z",
     "asin": "B081ZXQB52",
-    "wpm": 2074.235807860262,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2020-11-30T04:39:54Z",
     "asin": "B081ZXQB52",
-    "wpm": 2220.1665124884366,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -4544,26 +2426,14 @@
   {
     "start": "2020-11-30T04:47:16Z",
     "asin": "B081ZXQB52",
-    "wpm": 2215.088282504013,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2020-11-30T04:58:04Z",
     "asin": "B081ZXQB52",
-    "wpm": 2209.0407036203724,
+    "wpm": 2000,
     "period": "morning"
-  },
-  {
-    "start": "2020-11-30T13:10:18Z",
-    "asin": "B081ZXQB52",
-    "wpm": 1111.111111111111,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T13:32:31Z",
-    "asin": "B081ZXQB52",
-    "wpm": 4477.611940298508,
-    "period": "evening"
   },
   {
     "start": "2020-11-30T20:02:52Z",
@@ -4584,12 +2454,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-11-30T20:33:09Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 3132.2505800464037,
-    "period": "evening"
-  },
-  {
     "start": "2020-11-30T20:36:57Z",
     "asin": "B07RL58ZDG",
     "wpm": 318.41255191509,
@@ -4599,54 +2463,6 @@
     "start": "2020-11-30T22:33:19Z",
     "asin": "B07RL58ZDG",
     "wpm": 313.9717425431711,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T22:43:51Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T22:45:43Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 595.2380952380953,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T23:00:29Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T23:03:07Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T23:03:08Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 1630.4347826086957,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T23:04:09Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 1704.5454545454545,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T23:04:14Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2020-11-30T23:04:15Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 0,
     "period": "evening"
   },
   {
@@ -4662,75 +2478,21 @@
     "period": "evening"
   },
   {
-    "start": "2020-11-30T23:35:26Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2020-12-01T00:03:44Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 2000,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-01T00:33:30Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 3409.090909090909,
-    "period": "morning"
-  },
-  {
     "start": "2020-12-01T04:24:19Z",
     "asin": "B07RL58ZDG",
     "wpm": 167.0843776106934,
     "period": "morning"
   },
   {
-    "start": "2020-12-01T05:40:01Z",
-    "asin": "B081ZXQB52",
-    "wpm": 1256.9832402234636,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-01T05:40:42Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 1363.6363636363637,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-01T05:40:56Z",
-    "asin": "B081ZXQB52",
-    "wpm": 2459.0163934426228,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-01T05:42:47Z",
+    "start": "2020-12-01T05:43:34Z",
     "asin": "B081ZXQB52",
     "wpm": 2000,
     "period": "morning"
   },
   {
-    "start": "2020-12-01T05:42:57Z",
-    "asin": "B081ZXQB52",
-    "wpm": 1079.136690647482,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-01T05:43:14Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 2795.031055900621,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-01T05:43:34Z",
-    "asin": "B081ZXQB52",
-    "wpm": 2852.614896988907,
-    "period": "morning"
-  },
-  {
     "start": "2020-12-01T05:47:44Z",
     "asin": "B081ZXQB52",
-    "wpm": 2149.3212669683257,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -4764,51 +2526,9 @@
     "period": "evening"
   },
   {
-    "start": "2020-12-01T23:32:49Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 7500,
-    "period": "evening"
-  },
-  {
-    "start": "2020-12-01T23:33:53Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2020-12-01T23:36:46Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 10714.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2020-12-01T23:38:40Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 11538.461538461537,
-    "period": "evening"
-  },
-  {
-    "start": "2020-12-02T00:15:41Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 0,
-    "period": "morning"
-  },
-  {
     "start": "2020-12-02T04:22:26Z",
     "asin": "B07RL58ZDG",
     "wpm": 73.74631268436578,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-02T04:23:46Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 0,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-02T04:30:10Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 646.551724137931,
     "period": "morning"
   },
   {
@@ -4824,88 +2544,10 @@
     "period": "evening"
   },
   {
-    "start": "2020-12-02T23:36:51Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 2205.8823529411766,
-    "period": "evening"
-  },
-  {
     "start": "2020-12-02T23:59:53Z",
     "asin": "B07RL58ZDG",
     "wpm": 165.380374862183,
     "period": "evening"
-  },
-  {
-    "start": "2020-12-03T00:14:20Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 10000,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:19:13Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 11538.461538461537,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:20:18Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 25000,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:22:51Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 1415.0943396226414,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:23:22Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 6818.181818181818,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:24:35Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 10000,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:24:44Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 8823.529411764706,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:28:20Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 1456.3106796116506,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:31:34Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 8823.529411764706,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:32:34Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 18750,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:38:37Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 2678.5714285714284,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-03T00:38:44Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 5555.555555555556,
-    "period": "morning"
   },
   {
     "start": "2020-12-03T02:58:44Z",
@@ -4944,12 +2586,6 @@
     "period": "morning"
   },
   {
-    "start": "2020-12-03T08:35:43Z",
-    "asin": "B07RL58ZDG",
-    "wpm": 1363.6363636363637,
-    "period": "morning"
-  },
-  {
     "start": "2020-12-05T05:44:01Z",
     "asin": "B07N2X3ST6",
     "wpm": 1458.198314970836,
@@ -4958,25 +2594,7 @@
   {
     "start": "2020-12-05T05:49:03Z",
     "asin": "B0764BV94D",
-    "wpm": 3832.116788321168,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-05T06:45:49Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 0,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-05T06:46:02Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 3501.9455252918287,
-    "period": "morning"
-  },
-  {
-    "start": "2020-12-06T01:44:26Z",
-    "asin": "B07YXS82KD",
-    "wpm": 6382.978723404256,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -4992,15 +2610,9 @@
     "period": "morning"
   },
   {
-    "start": "2020-12-08T04:46:56Z",
-    "asin": "B07YXSLVX7",
-    "wpm": 1973.6842105263156,
-    "period": "morning"
-  },
-  {
     "start": "2020-12-08T04:48:02Z",
     "asin": "B07YXSLVX7",
-    "wpm": 10362.400906002265,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -5052,12 +2664,6 @@
     "period": "evening"
   },
   {
-    "start": "2020-12-31T04:30:07Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 1875,
-    "period": "morning"
-  },
-  {
     "start": "2020-12-31T05:02:18Z",
     "asin": "B00CH3DBNQ",
     "wpm": 484.698726477856,
@@ -5074,12 +2680,6 @@
     "asin": "B00CH3DBNQ",
     "wpm": 371.3838936669273,
     "period": "morning"
-  },
-  {
-    "start": "2021-01-04T18:00:31Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 1578.9473684210527,
-    "period": "evening"
   },
   {
     "start": "2021-01-05T04:12:39Z",
@@ -5112,45 +2712,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-01-07T04:18:30Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 1807.2289156626505,
-    "period": "morning"
-  },
-  {
-    "start": "2021-01-07T04:18:35Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 0,
-    "period": "morning"
-  },
-  {
-    "start": "2021-01-07T05:44:40Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 996.6777408637873,
-    "period": "morning"
-  },
-  {
-    "start": "2021-01-07T05:45:12Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 810.8108108108107,
-    "period": "morning"
-  },
-  {
-    "start": "2021-01-07T05:49:02Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 1648.3516483516482,
-    "period": "morning"
-  },
-  {
     "start": "2021-01-07T05:49:30Z",
     "asin": "B00CH3DBNQ",
-    "wpm": 5202.312138728324,
-    "period": "morning"
-  },
-  {
-    "start": "2021-01-07T05:51:14Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 1512.0967741935483,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -5160,57 +2724,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-01-11T20:53:43Z",
-    "asin": "B00CH3DBNQ",
-    "wpm": 3125,
-    "period": "evening"
-  },
-  {
-    "start": "2021-01-11T20:56:06Z",
-    "asin": "B00O2RPEE4",
-    "wpm": 10194.174757281553,
-    "period": "evening"
-  },
-  {
-    "start": "2021-01-18T05:01:20Z",
-    "asin": "B00O2RPEE4",
-    "wpm": 3333.3333333333335,
-    "period": "morning"
-  },
-  {
     "start": "2021-01-18T05:01:45Z",
     "asin": "B00CH3DBNQ",
     "wpm": 1998.3347210657787,
-    "period": "morning"
-  },
-  {
-    "start": "2021-01-29T22:31:03Z",
-    "asin": "B089T77W63",
-    "wpm": 3896.103896103896,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-10T05:15:33Z",
-    "asin": "B089T77W63",
-    "wpm": 2343.75,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-10T05:16:43Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 3112.033195020747,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-10T05:24:37Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 2760.7361963190183,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-10T05:25:12Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 949.3670886075951,
     "period": "morning"
   },
   {
@@ -5218,18 +2734,6 @@
     "asin": "B07YRWHGYD",
     "wpm": 774.633340218963,
     "period": "morning"
-  },
-  {
-    "start": "2021-02-10T18:35:58Z",
-    "asin": "B001NLL8LA",
-    "wpm": 3260.8695652173915,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-10T18:36:40Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 3947.368421052631,
-    "period": "evening"
   },
   {
     "start": "2021-02-10T19:55:54Z",
@@ -5250,33 +2754,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-02-11T05:12:25Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 2400,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-11T05:12:40Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 2112.676056338028,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-11T05:12:51Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 3191.4893617021276,
-    "period": "morning"
-  },
-  {
     "start": "2021-02-11T05:13:19Z",
     "asin": "B07YRWHGYD",
     "wpm": 285.3850688675706,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-11T05:13:33Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 2941.176470588235,
     "period": "morning"
   },
   {
@@ -5284,12 +2764,6 @@
     "asin": "B07YRWHGYD",
     "wpm": 302.9690971520905,
     "period": "morning"
-  },
-  {
-    "start": "2021-02-12T18:51:13Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 2521.0084033613443,
-    "period": "evening"
   },
   {
     "start": "2021-02-13T05:28:02Z",
@@ -5302,24 +2776,6 @@
     "asin": "B07YRWHGYD",
     "wpm": 326.92125461953947,
     "period": "morning"
-  },
-  {
-    "start": "2021-02-13T06:13:55Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 6521.739130434783,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-14T12:28:19Z",
-    "asin": "B07YRWHGYD",
-    "wpm": 2777.777777777778,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-14T12:28:33Z",
-    "asin": "B08478T2CK",
-    "wpm": 2727.2727272727275,
-    "period": "evening"
   },
   {
     "start": "2021-02-14T17:42:59Z",
@@ -5382,18 +2838,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-02-19T04:18:13Z",
-    "asin": "B08478T2CK",
-    "wpm": 2922.0779220779223,
-    "period": "morning"
-  },
-  {
-    "start": "2021-02-19T04:23:04Z",
-    "asin": "B08478T2CK",
-    "wpm": 1546.3917525773197,
-    "period": "morning"
-  },
-  {
     "start": "2021-02-19T04:39:06Z",
     "asin": "B08478T2CK",
     "wpm": 330.6198019220031,
@@ -5412,28 +2856,10 @@
     "period": "morning"
   },
   {
-    "start": "2021-02-19T12:49:42Z",
-    "asin": "B08478T2CK",
-    "wpm": 1324.5033112582782,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-22T04:46:43Z",
-    "asin": "B08478T2CK",
-    "wpm": 2678.5714285714284,
-    "period": "morning"
-  },
-  {
     "start": "2021-02-22T21:15:17Z",
     "asin": "B08478T2CK",
     "wpm": 600,
     "period": "evening"
-  },
-  {
-    "start": "2021-02-28T04:57:07Z",
-    "asin": "B07R5KC59C",
-    "wpm": 7178.841309823678,
-    "period": "morning"
   },
   {
     "start": "2021-02-28T04:58:00Z",
@@ -5454,24 +2880,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-02-28T16:08:31Z",
-    "asin": "B07R5KC59C",
-    "wpm": 268.81720430107526,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:09:48Z",
-    "asin": "B07R5KC59C",
-    "wpm": 777.2020725388601,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:12:18Z",
-    "asin": "B07R5KC59C",
-    "wpm": 925.9259259259259,
-    "period": "evening"
-  },
-  {
     "start": "2021-02-28T16:13:07Z",
     "asin": "B07R5KC59C",
     "wpm": 249.16943521594683,
@@ -5484,30 +2892,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-02-28T16:17:40Z",
-    "asin": "B07R5KC59C",
-    "wpm": 1744.1860465116279,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:19:20Z",
-    "asin": "B07R5KC59C",
-    "wpm": 293.5420743639922,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:20:48Z",
-    "asin": "B07R5KC59C",
-    "wpm": 355.4502369668246,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:21:45Z",
-    "asin": "B07R5KC59C",
-    "wpm": 1039.8613518197574,
-    "period": "evening"
-  },
-  {
     "start": "2021-02-28T16:24:54Z",
     "asin": "B07R5KC59C",
     "wpm": 240.3846153846154,
@@ -5517,18 +2901,6 @@
     "start": "2021-02-28T16:29:13Z",
     "asin": "B07R5KC59C",
     "wpm": 769.8887938408897,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:36:58Z",
-    "asin": "B07R5KC59C",
-    "wpm": 721.1538461538461,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T16:38:29Z",
-    "asin": "B07R5KC59C",
-    "wpm": 1094.890510948905,
     "period": "evening"
   },
   {
@@ -5550,30 +2922,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-02-28T17:25:19Z",
-    "asin": "B07R5KC59C",
-    "wpm": 650.7592190889371,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T17:26:56Z",
-    "asin": "B07R5KC59C",
-    "wpm": 735.2941176470588,
-    "period": "evening"
-  },
-  {
-    "start": "2021-02-28T17:30:28Z",
-    "asin": "B07R5KC59C",
-    "wpm": 8333.333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-01T00:38:34Z",
-    "asin": "B08478T2CK",
-    "wpm": 1630.4347826086957,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-01T00:39:06Z",
     "asin": "B07R5KC59C",
     "wpm": 840.6725380304243,
@@ -5592,27 +2940,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-03-01T03:42:15Z",
-    "asin": "B07R5KC59C",
-    "wpm": 2884.6153846153843,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-01T03:42:23Z",
     "asin": "B07R5KC59C",
     "wpm": 207.4688796680498,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-01T03:43:48Z",
-    "asin": "B07R5KC59C",
-    "wpm": 1785.7142857142856,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-01T03:44:56Z",
-    "asin": "B07ZTTH5VD",
-    "wpm": 728.1553398058253,
     "period": "morning"
   },
   {
@@ -5664,45 +2994,15 @@
     "period": "morning"
   },
   {
-    "start": "2021-03-03T04:37:19Z",
-    "asin": "B003ODIZL6",
-    "wpm": 678.7330316742082,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-03T04:38:04Z",
     "asin": "B07ZTTH5VD",
     "wpm": 323.45013477088946,
     "period": "morning"
   },
   {
-    "start": "2021-03-03T04:52:52Z",
-    "asin": "B083JKGK15",
-    "wpm": 1376.1467889908256,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-03T04:53:16Z",
-    "asin": "B083JKGK15",
-    "wpm": 1973.6842105263156,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-03T04:57:30Z",
-    "asin": "B07ZTTH5VD",
-    "wpm": 2884.6153846153843,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-03T04:58:02Z",
     "asin": "B083JKGK15",
     "wpm": 349.65034965034965,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-03T04:59:29Z",
-    "asin": "B003ODIZL6",
-    "wpm": 3260.8695652173915,
     "period": "morning"
   },
   {
@@ -5730,22 +3030,10 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-03T23:29:18Z",
-    "asin": "B083JKGK15",
-    "wpm": 2500,
-    "period": "evening"
-  },
-  {
     "start": "2021-03-03T23:55:36Z",
     "asin": "B083JKGK15",
     "wpm": 488.599348534202,
     "period": "evening"
-  },
-  {
-    "start": "2021-03-04T00:09:12Z",
-    "asin": "B083JKGK15",
-    "wpm": 4724.4094488188975,
-    "period": "morning"
   },
   {
     "start": "2021-03-04T05:27:47Z",
@@ -5820,12 +3108,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-10T22:35:27Z",
-    "asin": "B083JKGK15",
-    "wpm": 2180.232558139535,
-    "period": "evening"
-  },
-  {
     "start": "2021-03-10T22:36:11Z",
     "asin": "B083JKGK15",
     "wpm": 126.6891891891892,
@@ -5838,39 +3120,15 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-11T20:19:23Z",
-    "asin": "B084V823SR",
-    "wpm": 1176.4705882352941,
-    "period": "evening"
-  },
-  {
     "start": "2021-03-12T04:29:00Z",
     "asin": "B084V823SR",
     "wpm": 426.42566191446025,
     "period": "morning"
   },
   {
-    "start": "2021-03-12T13:00:15Z",
-    "asin": "B084V823SR",
-    "wpm": 2343.75,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-12T13:00:26Z",
-    "asin": "B08478T2CK",
-    "wpm": 1442.3076923076922,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-13T03:42:18Z",
-    "asin": "B08478T2CK",
-    "wpm": 2054.794520547945,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-13T03:42:30Z",
     "asin": "B084V823SR",
-    "wpm": 4411.764705882353,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -5928,18 +3186,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-03-19T01:07:08Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 1153.8461538461538,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-19T01:35:11Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 7317.073170731708,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-19T01:39:47Z",
     "asin": "B07TPFTG1S",
     "wpm": 1263.0930375847197,
@@ -5960,7 +3206,7 @@
   {
     "start": "2021-03-19T02:16:48Z",
     "asin": "B07TPFTG1S",
-    "wpm": 3795.1807228915663,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -5976,21 +3222,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-03-19T04:06:09Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 7894.736842105262,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-19T21:08:09Z",
     "asin": "B07TPFTG1S",
     "wpm": 733.9104252916823,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-19T21:09:08Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 3125,
     "period": "evening"
   },
   {
@@ -6000,39 +3234,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-19T21:20:35Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 4411.764705882353,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-19T21:30:49Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 3947.368421052631,
-    "period": "evening"
-  },
-  {
     "start": "2021-03-19T21:31:09Z",
     "asin": "B07TPFTG1S",
     "wpm": 115.62921564848719,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-19T21:40:05Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 6000,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-19T21:40:52Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2021-03-19T21:42:10Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 1562.5,
     "period": "evening"
   },
   {
@@ -6048,12 +3252,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-19T22:01:18Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 3260.8695652173915,
-    "period": "evening"
-  },
-  {
     "start": "2021-03-19T22:22:02Z",
     "asin": "B07TPFTG1S",
     "wpm": 199.8667554963358,
@@ -6066,21 +3264,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-19T23:38:57Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 11820.652173913044,
-    "period": "evening"
-  },
-  {
     "start": "2021-03-20T03:10:14Z",
     "asin": "B07TPFTG1S",
     "wpm": 440.94894275399685,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-21T02:35:47Z",
-    "asin": "B084V823SR",
-    "wpm": 4477.611940298508,
     "period": "morning"
   },
   {
@@ -6092,19 +3278,13 @@
   {
     "start": "2021-03-21T02:38:07Z",
     "asin": "B07TPFTG1S",
-    "wpm": 4969.879518072289,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2021-03-21T02:52:56Z",
     "asin": "B07TPFTG1S",
     "wpm": 435.35045711798,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-21T03:04:36Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 1685.3932584269662,
     "period": "morning"
   },
   {
@@ -6138,27 +3318,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-03-27T03:21:05Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 563.9097744360902,
-    "period": "morning"
-  },
-  {
     "start": "2021-03-27T03:21:33Z",
     "asin": "B07TPFTG1S",
-    "wpm": 6132.518796992481,
-    "period": "morning"
-  },
-  {
-    "start": "2021-03-27T03:38:45Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 649.3506493506493,
-    "period": "morning"
-  },
-  {
-    "start": "2021-04-06T03:17:01Z",
-    "asin": "B07TPFTG1S",
-    "wpm": 3781.512605042017,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -6168,58 +3330,10 @@
     "period": "evening"
   },
   {
-    "start": "2021-04-20T15:15:47Z",
-    "asin": "B086HB336Y",
-    "wpm": 4411.764705882353,
-    "period": "evening"
-  },
-  {
-    "start": "2021-04-20T15:20:08Z",
-    "asin": "B086HB336Y",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2021-04-20T16:31:33Z",
-    "asin": "B086HB336Y",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2021-04-20T16:51:54Z",
-    "asin": "B086HB336Y",
-    "wpm": 510.2040816326531,
-    "period": "evening"
-  },
-  {
     "start": "2021-04-20T16:52:26Z",
     "asin": "B086HB336Y",
     "wpm": 336.322869955157,
     "period": "evening"
-  },
-  {
-    "start": "2021-04-20T17:03:28Z",
-    "asin": "B086HB336Y",
-    "wpm": 872.0930232558139,
-    "period": "evening"
-  },
-  {
-    "start": "2021-04-20T17:04:35Z",
-    "asin": "B086HB336Y",
-    "wpm": 2380.952380952381,
-    "period": "evening"
-  },
-  {
-    "start": "2021-04-29T18:50:03Z",
-    "asin": "B086HB336Y",
-    "wpm": 4213.483146067415,
-    "period": "evening"
-  },
-  {
-    "start": "2021-05-19T03:12:22Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 1694.9152542372883,
-    "period": "morning"
   },
   {
     "start": "2021-05-19T20:12:42Z",
@@ -6237,12 +3351,6 @@
     "start": "2021-05-19T20:28:13Z",
     "asin": "B07ZC6W6SV",
     "wpm": 313.24157570004746,
-    "period": "evening"
-  },
-  {
-    "start": "2021-05-19T21:54:45Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 1129.9435028248588,
     "period": "evening"
   },
   {
@@ -6270,33 +3378,15 @@
     "period": "morning"
   },
   {
-    "start": "2021-05-20T21:52:58Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 2112.676056338028,
-    "period": "evening"
-  },
-  {
     "start": "2021-05-21T02:38:51Z",
     "asin": "B07ZC6W6SV",
     "wpm": 466.7703934207602,
     "period": "morning"
   },
   {
-    "start": "2021-05-24T20:28:46Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 445.1038575667656,
-    "period": "evening"
-  },
-  {
     "start": "2021-05-24T20:33:03Z",
     "asin": "B07ZC6W6SV",
     "wpm": 590.4736911166514,
-    "period": "evening"
-  },
-  {
-    "start": "2021-05-24T20:33:47Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 0,
     "period": "evening"
   },
   {
@@ -6340,12 +3430,6 @@
     "asin": "B07ZC6W6SV",
     "wpm": 477.7070063694268,
     "period": "morning"
-  },
-  {
-    "start": "2021-05-27T21:27:33Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 2459.0163934426228,
-    "period": "evening"
   },
   {
     "start": "2021-05-27T22:18:10Z",
@@ -6396,40 +3480,10 @@
     "period": "morning"
   },
   {
-    "start": "2021-05-29T04:33:52Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 2631.578947368421,
-    "period": "morning"
-  },
-  {
-    "start": "2021-05-29T04:34:02Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 1265.8227848101264,
-    "period": "morning"
-  },
-  {
-    "start": "2021-05-29T04:35:49Z",
-    "asin": "B07ZC6W6SV",
-    "wpm": 842.6966292134831,
-    "period": "morning"
-  },
-  {
     "start": "2021-06-02T13:00:39Z",
     "asin": "B08DHSFM4Q",
-    "wpm": 3420.1954397394134,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2021-06-06T12:02:44Z",
-    "asin": "B08DHSFM4Q",
-    "wpm": 2777.777777777778,
-    "period": "evening"
-  },
-  {
-    "start": "2021-06-20T00:43:16Z",
-    "asin": "B081Y4J7LD",
-    "wpm": 882.3529411764706,
-    "period": "morning"
   },
   {
     "start": "2021-06-20T03:52:11Z",
@@ -6498,12 +3552,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-06-22T21:13:38Z",
-    "asin": "B081Y4J7LD",
-    "wpm": 1500,
-    "period": "evening"
-  },
-  {
     "start": "2021-06-23T00:48:36Z",
     "asin": "B081Y4J7LD",
     "wpm": 759.7684515195369,
@@ -6537,12 +3585,6 @@
     "start": "2021-06-24T02:58:05Z",
     "asin": "B081Y4J7LD",
     "wpm": 724.0547063555913,
-    "period": "morning"
-  },
-  {
-    "start": "2021-06-24T03:04:46Z",
-    "asin": "B081Y4J7LD",
-    "wpm": 548.4460694698355,
     "period": "morning"
   },
   {
@@ -6624,12 +3666,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-06-26T22:31:16Z",
-    "asin": "B081Y4J7LD",
-    "wpm": 860.4206500956022,
-    "period": "evening"
-  },
-  {
     "start": "2021-06-26T22:32:54Z",
     "asin": "B081Y4J7LD",
     "wpm": 536.1305361305361,
@@ -6639,12 +3675,6 @@
     "start": "2021-06-26T22:53:30Z",
     "asin": "B081Y4J7LD",
     "wpm": 415.24181729360043,
-    "period": "evening"
-  },
-  {
-    "start": "2021-06-26T23:10:54Z",
-    "asin": "B081Y4J7LD",
-    "wpm": 323.2758620689655,
     "period": "evening"
   },
   {
@@ -6666,12 +3696,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-07-17T17:11:44Z",
-    "asin": "B00C8S9VKM",
-    "wpm": 1086.9565217391305,
-    "period": "evening"
-  },
-  {
     "start": "2021-07-18T03:41:37Z",
     "asin": "B00C8S9VKM",
     "wpm": 748.704165866769,
@@ -6680,7 +3704,7 @@
   {
     "start": "2021-07-18T19:19:37Z",
     "asin": "B00C8S9VKM",
-    "wpm": 2041.7602748777588,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -6708,12 +3732,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-07-19T03:26:34Z",
-    "asin": "B009U9S6FI",
-    "wpm": 2173.913043478261,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-19T03:26:44Z",
     "asin": "B008TY8BQ4",
     "wpm": 459.4792568422455,
@@ -6735,12 +3753,6 @@
     "start": "2021-07-20T23:11:27Z",
     "asin": "B08BLMJ576",
     "wpm": 632.7900287631832,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-20T23:20:19Z",
-    "asin": "B08BLMJ576",
-    "wpm": 3000,
     "period": "evening"
   },
   {
@@ -6798,18 +3810,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-07-22T01:39:03Z",
-    "asin": "B008TY8BQ4",
-    "wpm": 1785.7142857142856,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-22T01:39:14Z",
-    "asin": "B08BLMJ576",
-    "wpm": 6302.5210084033615,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-22T03:05:32Z",
     "asin": "B008TY8BQ4",
     "wpm": 263.3889376646181,
@@ -6858,21 +3858,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-07-23T04:50:56Z",
-    "asin": "B008TY8BQ4",
-    "wpm": 2586.206896551724,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-23T05:07:11Z",
     "asin": "B08BLMJ576",
     "wpm": 415.38461538461536,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T00:44:53Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 1442.3076923076922,
     "period": "morning"
   },
   {
@@ -6890,55 +3878,13 @@
   {
     "start": "2021-07-24T00:49:28Z",
     "asin": "B07VGYRGH4",
-    "wpm": 2890.204520990312,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T01:18:53Z",
-    "asin": "",
-    "wpm": 1562.5,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2021-07-24T01:22:24Z",
     "asin": "B08BLMJ576",
     "wpm": 960.1181683899557,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T01:27:16Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 746.2686567164179,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T02:12:22Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 887.5739644970414,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T03:14:41Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 1006.7114093959732,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T03:17:43Z",
-    "asin": "B08BLMJ576",
-    "wpm": 1562.5,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T03:18:15Z",
-    "asin": "B08BLMJ576",
-    "wpm": 1546.3917525773197,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T03:34:16Z",
-    "asin": "B003EI2EH2",
-    "wpm": 3742.2037422037424,
     "period": "morning"
   },
   {
@@ -6951,12 +3897,6 @@
     "start": "2021-07-24T03:42:31Z",
     "asin": "B07CL5ZLHX",
     "wpm": 649.6173231286168,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-24T04:27:31Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 2777.777777777778,
     "period": "morning"
   },
   {
@@ -6984,46 +3924,22 @@
     "period": "evening"
   },
   {
-    "start": "2021-07-24T23:39:30Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 663.7168141592921,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-24T23:48:57Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 1485.148514851485,
-    "period": "evening"
-  },
-  {
     "start": "2021-07-24T23:51:26Z",
     "asin": "B098GBS3BH",
-    "wpm": 2971.576227390181,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2021-07-24T23:53:31Z",
     "asin": "B098GBS3BH",
-    "wpm": 8933.518005540165,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2021-07-24T23:57:18Z",
     "asin": "B095YHMBSL",
-    "wpm": 4861.660079051383,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2021-07-25T02:36:12Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 5208.333333333334,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-25T03:19:42Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 2500,
-    "period": "morning"
   },
   {
     "start": "2021-07-25T03:43:54Z",
@@ -7032,28 +3948,10 @@
     "period": "morning"
   },
   {
-    "start": "2021-07-25T10:02:00Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 933.6099585062241,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-26T03:05:26Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 3896.103896103896,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-26T03:34:11Z",
     "asin": "B07CL5ZLHX",
     "wpm": 514.2744115513945,
     "period": "morning"
-  },
-  {
-    "start": "2021-07-26T23:44:59Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 657.8947368421052,
-    "period": "evening"
   },
   {
     "start": "2021-07-26T23:52:36Z",
@@ -7104,12 +4002,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-07-29T04:14:17Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 2222.222222222222,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-29T04:18:38Z",
     "asin": "B07CL5ZLHX",
     "wpm": 463.46361810597864,
@@ -7122,22 +4014,10 @@
     "period": "morning"
   },
   {
-    "start": "2021-07-30T03:43:29Z",
-    "asin": "B07MYXB26N",
-    "wpm": 1204.8192771084339,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-30T04:31:35Z",
     "asin": "B07CL5ZLHX",
     "wpm": 462.7249357326478,
     "period": "morning"
-  },
-  {
-    "start": "2021-07-30T18:59:14Z",
-    "asin": "B07CL5ZLHX",
-    "wpm": 3045.6852791878173,
-    "period": "evening"
   },
   {
     "start": "2021-07-30T19:01:01Z",
@@ -7164,54 +4044,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-07-30T22:27:04Z",
-    "asin": "B009U9S6FI",
-    "wpm": 1956.5217391304348,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-30T22:28:14Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2542.3728813559323,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-30T22:28:51Z",
-    "asin": "B07MYXB26N",
-    "wpm": 1612.9032258064517,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T03:27:08Z",
-    "asin": "B07MYXB26N",
-    "wpm": 557.6208178438662,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-31T03:27:41Z",
-    "asin": "B07MYXB26N",
-    "wpm": 1363.6363636363637,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-31T03:28:29Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2631.578947368421,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-31T03:29:11Z",
-    "asin": "B07MYXB26N",
-    "wpm": 1775.1479289940828,
-    "period": "morning"
-  },
-  {
-    "start": "2021-07-31T03:30:16Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 506.7567567567568,
-    "period": "morning"
-  },
-  {
     "start": "2021-07-31T03:30:54Z",
     "asin": "B07MYXB26N",
     "wpm": 393.1236673773987,
@@ -7224,12 +4056,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-07-31T18:22:07Z",
-    "asin": "B07MYXB26N",
-    "wpm": 750,
-    "period": "evening"
-  },
-  {
     "start": "2021-07-31T18:34:27Z",
     "asin": "B07MYXB26N",
     "wpm": 516.6255633982481,
@@ -7239,54 +4065,6 @@
     "start": "2021-07-31T19:44:29Z",
     "asin": "B07MYXB26N",
     "wpm": 654.0697674418604,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T20:20:58Z",
-    "asin": "B07MYXB26N",
-    "wpm": 797.8723404255319,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T20:21:25Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2830.188679245283,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T20:22:24Z",
-    "asin": "B07MYXB26N",
-    "wpm": 833.3333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T20:44:41Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2613.240418118467,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T21:18:46Z",
-    "asin": "B07MYXB26N",
-    "wpm": 5668.60465116279,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T21:19:24Z",
-    "asin": "B07MYXB26N",
-    "wpm": 6097.5609756097565,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T21:20:29Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2631.578947368421,
-    "period": "evening"
-  },
-  {
-    "start": "2021-07-31T23:27:57Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2445.6521739130435,
     "period": "evening"
   },
   {
@@ -7302,57 +4080,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-08-01T12:56:20Z",
-    "asin": "B07MYXB26N",
-    "wpm": 765.3061224489796,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-01T13:37:13Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2173.913043478261,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-01T14:38:20Z",
-    "asin": "B07MYXB26N",
-    "wpm": 3169.0140845070423,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-01T14:39:25Z",
-    "asin": "B07MYXB26N",
-    "wpm": 1818.181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-01T21:51:13Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2513.966480446927,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-02T02:42:20Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2777.777777777778,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-02T02:42:29Z",
-    "asin": "B07MYXB26N",
-    "wpm": 2307.6923076923076,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-02T02:51:38Z",
-    "asin": "B07MYXB26N",
-    "wpm": 1190.4761904761906,
-    "period": "morning"
-  },
-  {
     "start": "2021-08-02T04:20:06Z",
     "asin": "B0987XFGZF",
-    "wpm": 3287.1198568872987,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -7365,42 +4095,6 @@
     "start": "2021-08-02T04:33:57Z",
     "asin": "B07SKWFVYW",
     "wpm": 453.0581424616159,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-02T19:03:57Z",
-    "asin": "B009U9S6FI",
-    "wpm": 2777.777777777778,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-02T19:28:11Z",
-    "asin": "B009U9S6FI",
-    "wpm": 2158.273381294964,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-02T19:28:31Z",
-    "asin": "B009U9S6FI",
-    "wpm": 2884.6153846153843,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-02T19:54:14Z",
-    "asin": "B009U9S6FI",
-    "wpm": 1376.1467889908256,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-02T20:47:29Z",
-    "asin": "B009U9S6FI",
-    "wpm": 1363.6363636363637,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-03T03:44:48Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 967.7419354838709,
     "period": "morning"
   },
   {
@@ -7420,12 +4114,6 @@
     "asin": "B07SKWFVYW",
     "wpm": 25.016677785190126,
     "period": "morning"
-  },
-  {
-    "start": "2021-08-03T21:35:21Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 470.21943573667716,
-    "period": "evening"
   },
   {
     "start": "2021-08-03T21:37:06Z",
@@ -7470,30 +4158,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-08-04T22:03:48Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 1102.9411764705883,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-04T22:04:50Z",
-    "asin": "B07C3XLBHG",
-    "wpm": 537.6344086021505,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-04T23:19:12Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 1517.7065767284992,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-04T23:20:15Z",
-    "asin": "B08681BNKV",
-    "wpm": 2000,
-    "period": "evening"
-  },
-  {
     "start": "2021-08-04T23:21:45Z",
     "asin": "B07C3XLBHG",
     "wpm": 542.9650613786591,
@@ -7504,18 +4168,6 @@
     "asin": "B07C3XLBHG",
     "wpm": 602.6257263792238,
     "period": "morning"
-  },
-  {
-    "start": "2021-08-05T12:21:10Z",
-    "asin": "B098GBS3BH",
-    "wpm": 5928.853754940711,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-05T12:21:47Z",
-    "asin": "B098GBS3BH",
-    "wpm": 3571.428571428571,
-    "period": "evening"
   },
   {
     "start": "2021-08-05T23:22:00Z",
@@ -7539,12 +4191,6 @@
     "start": "2021-08-06T01:02:52Z",
     "asin": "B07C3XLBHG",
     "wpm": 427.9335152567601,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-06T02:55:19Z",
-    "asin": "B07C3XLBHG",
-    "wpm": 710.9004739336492,
     "period": "morning"
   },
   {
@@ -7576,18 +4222,6 @@
     "asin": "B07SKWFVYW",
     "wpm": 689.607132906102,
     "period": "morning"
-  },
-  {
-    "start": "2021-08-08T11:40:14Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 769.2307692307692,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-08T12:14:39Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 1036.2694300518135,
-    "period": "evening"
   },
   {
     "start": "2021-08-09T03:07:46Z",
@@ -7638,27 +4272,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-08-12T15:03:07Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 449.10179640718565,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-12T15:04:39Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 7142.857142857142,
-    "period": "evening"
-  },
-  {
     "start": "2021-08-12T19:54:07Z",
     "asin": "B07SKWFVYW",
     "wpm": 288.95547945205476,
-    "period": "evening"
-  },
-  {
-    "start": "2021-08-12T20:02:10Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 2343.75,
     "period": "evening"
   },
   {
@@ -7686,27 +4302,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-08-14T02:16:13Z",
-    "asin": "B08681BNKV",
-    "wpm": 980.3921568627451,
-    "period": "morning"
-  },
-  {
     "start": "2021-08-14T02:16:32Z",
     "asin": "B07SKWFVYW",
     "wpm": 150,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-14T02:51:08Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 1171.875,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-14T02:51:24Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 362.3188405797102,
     "period": "morning"
   },
   {
@@ -7782,18 +4380,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-08-15T01:40:50Z",
-    "asin": "B08681BNKV",
-    "wpm": 833.3333333333334,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-15T01:45:19Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 877.1929824561404,
-    "period": "morning"
-  },
-  {
     "start": "2021-08-15T03:29:06Z",
     "asin": "B08681BNKV",
     "wpm": 195.18542615484708,
@@ -7854,12 +4440,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-08-21T22:23:23Z",
-    "asin": "B07SKWFVYW",
-    "wpm": 1875,
-    "period": "evening"
-  },
-  {
     "start": "2021-08-22T04:06:26Z",
     "asin": "B0893YWV5Q",
     "wpm": 662.1187800963082,
@@ -7874,19 +4454,13 @@
   {
     "start": "2021-08-23T04:01:34Z",
     "asin": "B09D3K2MCY",
-    "wpm": 2027.0270270270269,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2021-08-25T02:46:43Z",
     "asin": "B083SN8RF7",
     "wpm": 1751.4270887389725,
-    "period": "morning"
-  },
-  {
-    "start": "2021-08-25T03:27:08Z",
-    "asin": "B072KZWHW4",
-    "wpm": 4477.611940298507,
     "period": "morning"
   },
   {
@@ -7914,33 +4488,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-09-05T14:24:42Z",
-    "asin": "B000FC0R7O",
-    "wpm": 773.1958762886599,
-    "period": "evening"
-  },
-  {
-    "start": "2021-09-05T14:25:10Z",
-    "asin": "B000FC0R7O",
-    "wpm": 2027.027027027027,
-    "period": "evening"
-  },
-  {
-    "start": "2021-09-05T22:54:51Z",
-    "asin": "B000FC0R7O",
-    "wpm": 3846.153846153846,
-    "period": "evening"
-  },
-  {
     "start": "2021-09-05T22:54:58Z",
     "asin": "B000FC0R7O",
-    "wpm": 2900.5524861878453,
-    "period": "evening"
-  },
-  {
-    "start": "2021-09-05T22:56:29Z",
-    "asin": "B09F8RV343",
-    "wpm": 5421.686746987952,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -7964,7 +4514,7 @@
   {
     "start": "2021-09-05T23:36:15Z",
     "asin": "B09F8RV343",
-    "wpm": 3827.679375562894,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -8010,12 +4560,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-09-07T01:34:40Z",
-    "asin": "B000FC0R7O",
-    "wpm": 872.0930232558139,
-    "period": "morning"
-  },
-  {
     "start": "2021-09-07T01:35:54Z",
     "asin": "B000FC0R7O",
     "wpm": 248.62935101364272,
@@ -8037,12 +4581,6 @@
     "start": "2021-09-09T02:49:04Z",
     "asin": "B000FC0R7O",
     "wpm": 499.27641099855276,
-    "period": "morning"
-  },
-  {
-    "start": "2021-09-10T01:59:11Z",
-    "asin": "B000FC0R7O",
-    "wpm": 1086.9565217391305,
     "period": "morning"
   },
   {
@@ -8076,22 +4614,10 @@
     "period": "morning"
   },
   {
-    "start": "2021-09-14T00:21:51Z",
-    "asin": "B000FC0R7O",
-    "wpm": 721.1538461538461,
-    "period": "morning"
-  },
-  {
     "start": "2021-09-14T01:57:11Z",
     "asin": "B000FC0R7O",
     "wpm": 304.35317265125434,
     "period": "morning"
-  },
-  {
-    "start": "2021-09-14T19:02:42Z",
-    "asin": "B000FC0R7O",
-    "wpm": 837.9888268156425,
-    "period": "evening"
   },
   {
     "start": "2021-09-14T21:32:43Z",
@@ -8112,21 +4638,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-09-17T21:24:37Z",
-    "asin": "B000FC0R7O",
-    "wpm": 2571.428571428571,
-    "period": "evening"
-  },
-  {
     "start": "2021-09-17T21:24:57Z",
     "asin": "B07FKB3V5S",
-    "wpm": 3076.9230769230767,
-    "period": "evening"
-  },
-  {
-    "start": "2021-09-17T21:28:36Z",
-    "asin": "B07FKB3V5S",
-    "wpm": 1376.1467889908256,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -8136,21 +4650,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-09-23T03:04:10Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJJMlVDN0tPRUhFQk8mbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMEQwSzNGUUkmZW5kdGltZT0xNjMxODk2Njk3MjYx",
-    "wpm": 549.4505494505495,
-    "period": "morning"
-  },
-  {
     "start": "2021-09-23T03:04:48Z",
     "asin": "B000FC0R7O",
     "wpm": 426.43923240938165,
-    "period": "morning"
-  },
-  {
-    "start": "2021-09-24T02:25:16Z",
-    "asin": "B000FC0R7O",
-    "wpm": 797.8723404255319,
     "period": "morning"
   },
   {
@@ -8175,18 +4677,6 @@
     "start": "2021-09-26T03:03:40Z",
     "asin": "B000FC0R7O",
     "wpm": 430.0869731434579,
-    "period": "morning"
-  },
-  {
-    "start": "2021-09-26T03:21:13Z",
-    "asin": "B07FKB3V5S",
-    "wpm": 1898.7341772151901,
-    "period": "morning"
-  },
-  {
-    "start": "2021-09-26T03:21:23Z",
-    "asin": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTMwRDhOSkYyM0NKQzUmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMDBGQzBSN08mZW5kdGltZT0xNjMyNTU0NTQyMzc5",
-    "wpm": 833.3333333333334,
     "period": "morning"
   },
   {
@@ -8268,21 +4758,9 @@
     "period": "evening"
   },
   {
-    "start": "2021-10-06T21:37:36Z",
-    "asin": "B08XP24KR8",
-    "wpm": 575.8157389635317,
-    "period": "evening"
-  },
-  {
     "start": "2021-10-06T21:39:12Z",
     "asin": "B08XP24KR8",
     "wpm": 415.81962668637965,
-    "period": "evening"
-  },
-  {
-    "start": "2021-10-06T21:52:45Z",
-    "asin": "B08XP24KR8",
-    "wpm": 632.9113924050632,
     "period": "evening"
   },
   {
@@ -8295,12 +4773,6 @@
     "start": "2021-10-06T22:13:18Z",
     "asin": "B08XP24KR8",
     "wpm": 747.8519147130582,
-    "period": "evening"
-  },
-  {
-    "start": "2021-10-06T22:30:53Z",
-    "asin": "B08XP24KR8",
-    "wpm": 600,
     "period": "evening"
   },
   {
@@ -8322,12 +4794,6 @@
     "period": "evening"
   },
   {
-    "start": "2021-10-07T03:12:20Z",
-    "asin": "B08XP24KR8",
-    "wpm": 1699.7167138810198,
-    "period": "morning"
-  },
-  {
     "start": "2021-10-07T03:34:48Z",
     "asin": "B08XP24KR8",
     "wpm": 639.0627080282253,
@@ -8340,34 +4806,10 @@
     "period": "morning"
   },
   {
-    "start": "2021-10-07T22:36:40Z",
-    "asin": "B08XP24KR8",
-    "wpm": 4761.904761904762,
-    "period": "evening"
-  },
-  {
-    "start": "2021-10-07T22:40:26Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 1171.875,
-    "period": "evening"
-  },
-  {
     "start": "2021-10-07T22:41:56Z",
     "asin": "B005NY4QGM",
     "wpm": 1157.7377091710987,
     "period": "evening"
-  },
-  {
-    "start": "2021-10-07T23:07:41Z",
-    "asin": "B005NY4QGM",
-    "wpm": 646.551724137931,
-    "period": "evening"
-  },
-  {
-    "start": "2021-10-09T02:35:21Z",
-    "asin": "B005NY4QGM",
-    "wpm": 845.0704225352113,
-    "period": "morning"
   },
   {
     "start": "2021-10-09T02:36:16Z",
@@ -8388,27 +4830,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-10-25T01:00:42Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 2586.206896551724,
-    "period": "morning"
-  },
-  {
-    "start": "2021-10-25T01:01:21Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 1491.0536779324054,
-    "period": "morning"
-  },
-  {
     "start": "2021-10-25T02:52:39Z",
     "asin": "B08XP24KR8",
-    "wpm": 3822.3938223938226,
-    "period": "morning"
-  },
-  {
-    "start": "2021-10-25T02:59:41Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 717.7033492822967,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -8508,15 +4932,9 @@
     "period": "morning"
   },
   {
-    "start": "2021-11-01T01:57:43Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 2459.0163934426228,
-    "period": "morning"
-  },
-  {
     "start": "2021-11-01T01:59:01Z",
     "asin": "B09KKPHDHC",
-    "wpm": 3877.9731127197515,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -8529,12 +4947,6 @@
     "start": "2021-11-01T22:43:11Z",
     "asin": "B08RZ4PTSF",
     "wpm": 420.37285244303644,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-01T22:58:56Z",
-    "asin": "B09KKPHDHC",
-    "wpm": 2459.0163934426228,
     "period": "evening"
   },
   {
@@ -8556,24 +4968,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-11-03T04:08:42Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 1200,
-    "period": "morning"
-  },
-  {
-    "start": "2021-11-03T04:11:59Z",
-    "asin": "B09KKPHDHC",
-    "wpm": 1282.051282051282,
-    "period": "morning"
-  },
-  {
-    "start": "2021-11-03T04:16:03Z",
-    "asin": "B09KKPHDHC",
-    "wpm": 903.6144578313254,
-    "period": "morning"
-  },
-  {
     "start": "2021-11-03T04:16:55Z",
     "asin": "B09KKPHDHC",
     "wpm": 1379.242883693632,
@@ -8592,12 +4986,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-11-03T16:19:17Z",
-    "asin": "B08SJQSWYM",
-    "wpm": 2135.2313167259786,
-    "period": "evening"
-  },
-  {
     "start": "2021-11-03T18:08:20Z",
     "asin": "B08WC6VC8S",
     "wpm": 398.93617021276594,
@@ -8610,57 +4998,15 @@
     "period": "evening"
   },
   {
-    "start": "2021-11-03T20:19:34Z",
-    "asin": "B08SJQSWYM",
-    "wpm": 1986.7549668874171,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-04T03:28:42Z",
-    "asin": "B08SJQSWYM",
-    "wpm": 445.1038575667656,
-    "period": "morning"
-  },
-  {
-    "start": "2021-11-04T03:30:10Z",
-    "asin": "B08WC6VC8S",
-    "wpm": 955.4140127388536,
-    "period": "morning"
-  },
-  {
     "start": "2021-11-04T03:34:25Z",
     "asin": "B0865Z9S5L",
     "wpm": 637.6195536663125,
     "period": "morning"
   },
   {
-    "start": "2021-11-06T13:50:36Z",
-    "asin": "B0865Z9S5L",
-    "wpm": 498.33887043189367,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-06T13:51:36Z",
-    "asin": "B00MYEQGFI",
-    "wpm": 4838.709677419355,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-07T05:24:08Z",
-    "asin": "B0865Z9S5L",
-    "wpm": 1500,
-    "period": "morning"
-  },
-  {
     "start": "2021-11-07T05:24:35Z",
     "asin": "B09GYVRQWF",
     "wpm": 678.6739754633255,
-    "period": "morning"
-  },
-  {
-    "start": "2021-11-07T05:44:44Z",
-    "asin": "B09GYVRQWF",
-    "wpm": 920.2453987730062,
     "period": "morning"
   },
   {
@@ -8676,36 +5022,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-11-23T18:25:37Z",
-    "asin": "B07LGLF1JG",
-    "wpm": 2564.102564102564,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-23T18:30:02Z",
-    "asin": "B07LGLF1JG",
-    "wpm": 6000,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-23T18:30:31Z",
-    "asin": "B09KKPHDHC",
-    "wpm": 1041.6666666666667,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-24T14:38:05Z",
-    "asin": "B07LGLF1JG",
-    "wpm": 1219.5121951219512,
-    "period": "evening"
-  },
-  {
-    "start": "2021-11-29T04:02:34Z",
-    "asin": "B07LGLF1JG",
-    "wpm": 1145.0381679389313,
-    "period": "morning"
-  },
-  {
     "start": "2021-11-29T04:03:31Z",
     "asin": "B07LGLF1JG",
     "wpm": 725.0622528196865,
@@ -8715,18 +5031,6 @@
     "start": "2021-11-29T04:18:13Z",
     "asin": "B07LGLF1JG",
     "wpm": 185.72976319455194,
-    "period": "morning"
-  },
-  {
-    "start": "2021-12-10T00:09:37Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 474.68354430379753,
-    "period": "morning"
-  },
-  {
-    "start": "2021-12-10T00:10:16Z",
-    "asin": "B000FC0R7O",
-    "wpm": 1685.3932584269662,
     "period": "morning"
   },
   {
@@ -8769,12 +5073,6 @@
     "start": "2021-12-27T04:52:44Z",
     "asin": "B09887KBTZ",
     "wpm": 524.7813411078718,
-    "period": "morning"
-  },
-  {
-    "start": "2021-12-27T04:55:55Z",
-    "asin": "B09887KBTZ",
-    "wpm": 672.645739910314,
     "period": "morning"
   },
   {
@@ -8832,30 +5130,6 @@
     "period": "morning"
   },
   {
-    "start": "2021-12-29T20:21:27Z",
-    "asin": "B000FC0R7O",
-    "wpm": 3896.103896103896,
-    "period": "evening"
-  },
-  {
-    "start": "2021-12-29T20:21:35Z",
-    "asin": "B000FC0R7O",
-    "wpm": 1162.7906976744187,
-    "period": "evening"
-  },
-  {
-    "start": "2021-12-29T20:21:51Z",
-    "asin": "B000FC0R7O",
-    "wpm": 2112.6760563380285,
-    "period": "evening"
-  },
-  {
-    "start": "2021-12-29T20:22:14Z",
-    "asin": "B000FC0R7O",
-    "wpm": 1542.4164524421594,
-    "period": "evening"
-  },
-  {
     "start": "2021-12-29T22:45:35Z",
     "asin": "B000FC0R7O",
     "wpm": 439.57154405820535,
@@ -8904,12 +5178,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-01-02T03:25:35Z",
-    "asin": "B08SBMCSQQ",
-    "wpm": 1209.6774193548388,
-    "period": "morning"
-  },
-  {
     "start": "2022-01-02T03:27:43Z",
     "asin": "B08TRMSR3Z",
     "wpm": 479.2701235708511,
@@ -8932,12 +5200,6 @@
     "asin": "B08TRMSR3Z",
     "wpm": 332.8967474350578,
     "period": "morning"
-  },
-  {
-    "start": "2022-01-03T22:50:20Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 652.1739130434783,
-    "period": "evening"
   },
   {
     "start": "2022-01-04T04:50:26Z",
@@ -8988,18 +5250,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-01-07T21:58:54Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 543.4782608695652,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-07T21:59:32Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 2884.6153846153843,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-07T23:36:51Z",
     "asin": "B08TRMSR3Z",
     "wpm": 598.2367758186398,
@@ -9008,14 +5258,8 @@
   {
     "start": "2022-01-08T00:12:27Z",
     "asin": "B08TRMSR3Z",
-    "wpm": 2586.206896551724,
+    "wpm": 2000,
     "period": "morning"
-  },
-  {
-    "start": "2022-01-08T12:24:38Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 1250,
-    "period": "evening"
   },
   {
     "start": "2022-01-09T05:28:11Z",
@@ -9028,12 +5272,6 @@
     "asin": "B08TRMSR3Z",
     "wpm": 317.02617019954,
     "period": "morning"
-  },
-  {
-    "start": "2022-01-10T20:48:35Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 1041.6666666666667,
-    "period": "evening"
   },
   {
     "start": "2022-01-10T20:51:04Z",
@@ -9138,12 +5376,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-01-13T19:18:54Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 1923.076923076923,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-13T19:19:11Z",
     "asin": "B08TRMSR3Z",
     "wpm": 269.3753858241203,
@@ -9156,21 +5388,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-01-13T20:23:59Z",
-    "asin": "B08TRMSR3Z",
-    "wpm": 1181.1023622047244,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-13T20:24:29Z",
     "asin": "B08PK59474",
     "wpm": 256.8493150684931,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-13T20:27:29Z",
-    "asin": "B08PK59474",
-    "wpm": 831.0249307479224,
     "period": "evening"
   },
   {
@@ -9180,39 +5400,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-01-13T20:30:06Z",
-    "asin": "B08PK59474",
-    "wpm": 2358.490566037736,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-13T20:30:40Z",
-    "asin": "B08PK59474",
-    "wpm": 2307.6923076923076,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-13T20:31:15Z",
-    "asin": "B08PK59474",
-    "wpm": 2047.7815699658702,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-13T20:33:06Z",
-    "asin": "B08PK59474",
-    "wpm": 1363.6363636363635,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-13T21:01:13Z",
     "asin": "B08PK59474",
     "wpm": 238.03478481655452,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-13T21:59:54Z",
-    "asin": "B08PK59474",
-    "wpm": 955.4140127388536,
     "period": "evening"
   },
   {
@@ -9258,12 +5448,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-01-17T19:20:30Z",
-    "asin": "B08PF965W9",
-    "wpm": 1006.7114093959732,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-18T06:23:01Z",
     "asin": "B08PK59474",
     "wpm": 584.0363400389358,
@@ -9282,12 +5466,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-01-19T04:21:37Z",
-    "asin": "B08PK59474",
-    "wpm": 2489.6265560165975,
-    "period": "morning"
-  },
-  {
     "start": "2022-01-20T04:54:29Z",
     "asin": "B08PF965W9",
     "wpm": 307.66976778258004,
@@ -9297,12 +5475,6 @@
     "start": "2022-01-20T05:17:18Z",
     "asin": "B08PF965W9",
     "wpm": 474.5762711864407,
-    "period": "morning"
-  },
-  {
-    "start": "2022-01-21T05:15:12Z",
-    "asin": "B093B4BGRK",
-    "wpm": 2238.805970149254,
     "period": "morning"
   },
   {
@@ -9324,21 +5496,9 @@
     "period": "morning"
   },
   {
-    "start": "2022-01-21T15:58:54Z",
-    "asin": "B08VRP55V1",
-    "wpm": 961.5384615384615,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-23T15:59:55Z",
-    "asin": "B08VRP55V1",
-    "wpm": 1388.888888888889,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-23T16:01:33Z",
     "asin": "B00JV2H5I8",
-    "wpm": 10047.846889952154,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -9346,12 +5506,6 @@
     "asin": "B00JV2H5I8",
     "wpm": 969.6668324216807,
     "period": "evening"
-  },
-  {
-    "start": "2022-01-24T04:06:05Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 765.3061224489796,
-    "period": "morning"
   },
   {
     "start": "2022-01-24T04:06:39Z",
@@ -9392,37 +5546,7 @@
   {
     "start": "2022-01-25T20:58:25Z",
     "asin": "B00JV2H5I8",
-    "wpm": 13157.894736842105,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-25T21:00:00Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 2533.7837837837837,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-25T21:01:41Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 2380.952380952381,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-25T21:02:09Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 1948.051948051948,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-25T21:02:46Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 3488.3720930232557,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-25T21:08:03Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 6000,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -9522,18 +5646,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-01-29T21:27:43Z",
-    "asin": "B08VRP55V1",
-    "wpm": 1100.9174311926606,
-    "period": "evening"
-  },
-  {
-    "start": "2022-01-30T16:55:40Z",
-    "asin": "B093B4BGRK",
-    "wpm": 8333.333333333334,
-    "period": "evening"
-  },
-  {
     "start": "2022-01-30T16:55:46Z",
     "asin": "B08VRP55V1",
     "wpm": 925.9259259259259,
@@ -9548,7 +5660,7 @@
   {
     "start": "2022-01-31T04:23:51Z",
     "asin": "B087PL8YVQ",
-    "wpm": 5272.564789991064,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -9573,12 +5685,6 @@
     "start": "2022-02-02T17:07:07Z",
     "asin": "B08PF965W9",
     "wpm": 1430.517711171662,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-02T18:44:15Z",
-    "asin": "B08VRP55V1",
-    "wpm": 10000,
     "period": "evening"
   },
   {
@@ -9614,13 +5720,13 @@
   {
     "start": "2022-02-04T05:06:16Z",
     "asin": "B08VRP55V1",
-    "wpm": 2131.1475409836066,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2022-02-04T05:31:47Z",
     "asin": "B0814JSV96",
-    "wpm": 5339.805825242718,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -9660,12 +5766,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-02-04T19:38:55Z",
-    "asin": "B08B38JVKY",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
     "start": "2022-02-04T19:51:36Z",
     "asin": "B08B38JVKY",
     "wpm": 127.4968125796855,
@@ -9687,12 +5787,6 @@
     "start": "2022-02-05T02:28:45Z",
     "asin": "B08B38JVKY",
     "wpm": 218.87159533073932,
-    "period": "morning"
-  },
-  {
-    "start": "2022-02-05T02:54:34Z",
-    "asin": "B08B38JVKY",
-    "wpm": 6000,
     "period": "morning"
   },
   {
@@ -9720,24 +5814,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-02-06T00:08:13Z",
-    "asin": "B08B38JVKY",
-    "wpm": 1293.103448275862,
-    "period": "morning"
-  },
-  {
-    "start": "2022-02-06T00:43:35Z",
-    "asin": "B08B38JVKY",
-    "wpm": 12500,
-    "period": "morning"
-  },
-  {
-    "start": "2022-02-06T05:57:04Z",
-    "asin": "B001NXK1XO",
-    "wpm": 2036.1990950226243,
-    "period": "morning"
-  },
-  {
     "start": "2022-02-06T06:00:37Z",
     "asin": "B08PY1XTB8",
     "wpm": 1034.2598577892695,
@@ -9746,31 +5822,19 @@
   {
     "start": "2022-02-06T21:39:34Z",
     "asin": "B00JV2H5I8",
-    "wpm": 3336.4226135310473,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-02-06T21:42:14Z",
     "asin": "B00JV2H5I8",
-    "wpm": 2443.146896127843,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-06T21:53:34Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 404.3126684636119,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-02-07T04:49:39Z",
     "asin": "B08PY1XTB8",
     "wpm": 991.1894273127754,
-    "period": "morning"
-  },
-  {
-    "start": "2022-02-07T04:54:31Z",
-    "asin": "B08PY1XTB8",
-    "wpm": 1079.136690647482,
     "period": "morning"
   },
   {
@@ -9786,12 +5850,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-02-08T05:49:44Z",
-    "asin": "B08XTNHRR5",
-    "wpm": 877.1929824561404,
-    "period": "morning"
-  },
-  {
     "start": "2022-02-08T06:09:09Z",
     "asin": "B08WRH53MY",
     "wpm": 519.0311418685121,
@@ -9802,12 +5860,6 @@
     "asin": "B08WRH53MY",
     "wpm": 215.7928388746803,
     "period": "evening"
-  },
-  {
-    "start": "2022-02-09T05:25:48Z",
-    "asin": "B08WRH53MY",
-    "wpm": 1401.8691588785045,
-    "period": "morning"
   },
   {
     "start": "2022-02-09T05:26:23Z",
@@ -9848,7 +5900,7 @@
   {
     "start": "2022-02-09T20:13:12Z",
     "asin": "B00JV2H5I8",
-    "wpm": 3579.9522673031024,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -9862,12 +5914,6 @@
     "asin": "B00JV2H5I8",
     "wpm": 32.223415682062296,
     "period": "evening"
-  },
-  {
-    "start": "2022-02-10T05:22:16Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 590.5511811023622,
-    "period": "morning"
   },
   {
     "start": "2022-02-10T05:23:04Z",
@@ -9892,12 +5938,6 @@
     "asin": "B000FC0R7O",
     "wpm": 510.98620337250895,
     "period": "evening"
-  },
-  {
-    "start": "2022-02-11T04:12:33Z",
-    "asin": "B000FC0R7O",
-    "wpm": 1260.5042016806722,
-    "period": "morning"
   },
   {
     "start": "2022-02-11T04:13:00Z",
@@ -9954,21 +5994,9 @@
     "period": "morning"
   },
   {
-    "start": "2022-02-13T23:05:42Z",
-    "asin": "B08WRH53MY",
-    "wpm": 1282.051282051282,
-    "period": "evening"
-  },
-  {
     "start": "2022-02-14T00:19:00Z",
     "asin": "B08WRH53MY",
     "wpm": 110.3888139335214,
-    "period": "morning"
-  },
-  {
-    "start": "2022-02-14T00:45:30Z",
-    "asin": "B08WRH53MY",
-    "wpm": 779.896013864818,
     "period": "morning"
   },
   {
@@ -9992,14 +6020,8 @@
   {
     "start": "2022-02-16T06:05:25Z",
     "asin": "B08478YC6V",
-    "wpm": 2581.7555938037867,
+    "wpm": 2000,
     "period": "morning"
-  },
-  {
-    "start": "2022-02-16T22:47:01Z",
-    "asin": "B07LGLF1JG",
-    "wpm": 955.4140127388536,
-    "period": "evening"
   },
   {
     "start": "2022-02-16T22:47:21Z",
@@ -10058,55 +6080,19 @@
   {
     "start": "2022-02-22T19:23:51Z",
     "asin": "B07N2X3ST6",
-    "wpm": 5153.203342618384,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T19:25:44Z",
-    "asin": "B07N2X3ST6",
-    "wpm": 2941.176470588235,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T19:26:05Z",
-    "asin": "B07PK5RMPM",
-    "wpm": 10000,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T19:26:42Z",
-    "asin": "B07PK5RMPM",
-    "wpm": 12500,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-02-22T19:28:04Z",
     "asin": "B07PK5RMPM",
-    "wpm": 2456.331877729258,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T19:29:41Z",
-    "asin": "B07PK5RMPM",
-    "wpm": 5769.230769230769,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T20:14:09Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 1056.338028169014,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-02-22T20:15:30Z",
     "asin": "B08L3P3VGQ",
     "wpm": 372.20843672456573,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T20:22:35Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 5769.230769230769,
     "period": "evening"
   },
   {
@@ -10122,12 +6108,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-02-22T20:54:07Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 25000,
-    "period": "evening"
-  },
-  {
     "start": "2022-02-22T20:54:09Z",
     "asin": "B08L3P3VGQ",
     "wpm": 940.2121504339441,
@@ -10137,18 +6117,6 @@
     "start": "2022-02-22T21:15:31Z",
     "asin": "B08L3P3VGQ",
     "wpm": 199.40915805022158,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T21:28:44Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 4545.454545454545,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T21:30:00Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 8823.529411764706,
     "period": "evening"
   },
   {
@@ -10167,12 +6135,6 @@
     "start": "2022-02-22T21:48:58Z",
     "asin": "B08L3P3VGQ",
     "wpm": 230.57216054654143,
-    "period": "evening"
-  },
-  {
-    "start": "2022-02-22T22:22:53Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 842.6966292134831,
     "period": "evening"
   },
   {
@@ -10218,12 +6180,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-02-25T00:57:40Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 1048.951048951049,
-    "period": "morning"
-  },
-  {
     "start": "2022-02-25T00:58:04Z",
     "asin": "B093ZQCS29",
     "wpm": 578.1584582441113,
@@ -10240,12 +6196,6 @@
     "asin": "B093ZQCS29",
     "wpm": 256.8768061650433,
     "period": "evening"
-  },
-  {
-    "start": "2022-02-26T00:23:04Z",
-    "asin": "B093ZQCS29",
-    "wpm": 903.6144578313252,
-    "period": "morning"
   },
   {
     "start": "2022-02-26T01:31:38Z",
@@ -10332,12 +6282,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-03-01T06:14:03Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 1442.3076923076922,
-    "period": "morning"
-  },
-  {
     "start": "2022-03-01T06:18:22Z",
     "asin": "B08L3P3VGQ",
     "wpm": 322.0213029477335,
@@ -10347,24 +6291,6 @@
     "start": "2022-03-01T17:56:55Z",
     "asin": "B08L3P3VGQ",
     "wpm": 187.32438339057134,
-    "period": "evening"
-  },
-  {
-    "start": "2022-03-01T18:28:48Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 15000,
-    "period": "evening"
-  },
-  {
-    "start": "2022-03-01T20:49:17Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 378.78787878787875,
-    "period": "evening"
-  },
-  {
-    "start": "2022-03-01T20:51:05Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 11538.461538461537,
     "period": "evening"
   },
   {
@@ -10383,18 +6309,6 @@
     "start": "2022-03-01T21:17:19Z",
     "asin": "B08L3P3VGQ",
     "wpm": 50.30181086519115,
-    "period": "evening"
-  },
-  {
-    "start": "2022-03-01T21:24:48Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 5357.142857142857,
-    "period": "evening"
-  },
-  {
-    "start": "2022-03-01T21:27:06Z",
-    "asin": "B08L3P3VGQ",
-    "wpm": 1063.8297872340427,
     "period": "evening"
   },
   {
@@ -10424,7 +6338,7 @@
   {
     "start": "2022-03-03T02:22:38Z",
     "asin": "B09T9H87RB",
-    "wpm": 7880.5970149253735,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -10448,13 +6362,7 @@
   {
     "start": "2022-03-04T04:43:45Z",
     "asin": "B09T9H87RB",
-    "wpm": 6589.255735870173,
-    "period": "morning"
-  },
-  {
-    "start": "2022-03-04T04:50:15Z",
-    "asin": "B08RZ4PTSF",
-    "wpm": 2542.3728813559323,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -10478,13 +6386,13 @@
   {
     "start": "2022-03-04T06:01:47Z",
     "asin": "B0108VD2L4",
-    "wpm": 3473.5950296526407,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2022-03-04T06:07:48Z",
     "asin": "B0108VD2L4",
-    "wpm": 3248.031496062992,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -10604,7 +6512,7 @@
   {
     "start": "2022-03-11T04:58:53Z",
     "asin": "B00JV2H5I8",
-    "wpm": 2311.248073959938,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -10629,12 +6537,6 @@
     "start": "2022-03-12T05:47:29Z",
     "asin": "B07TZYFR71",
     "wpm": 392.83083722072183,
-    "period": "morning"
-  },
-  {
-    "start": "2022-03-12T06:07:54Z",
-    "asin": "B07TZYFR71",
-    "wpm": 1724.1379310344828,
     "period": "morning"
   },
   {
@@ -10752,12 +6654,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-03-16T03:19:12Z",
-    "asin": "B08QM8VHRT",
-    "wpm": 2307.6923076923076,
-    "period": "morning"
-  },
-  {
     "start": "2022-03-16T04:08:11Z",
     "asin": "B07TZYFR71",
     "wpm": 697.7769072568798,
@@ -10800,28 +6696,10 @@
     "period": "morning"
   },
   {
-    "start": "2022-03-18T17:33:53Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 4166.666666666667,
-    "period": "evening"
-  },
-  {
     "start": "2022-03-21T23:52:42Z",
     "asin": "B08N8Z99MK",
     "wpm": 13.600507752289419,
     "period": "evening"
-  },
-  {
-    "start": "2022-03-22T03:09:02Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1456.3106796116506,
-    "period": "morning"
-  },
-  {
-    "start": "2022-03-22T03:10:36Z",
-    "asin": "",
-    "wpm": 717.7033492822967,
-    "period": "morning"
   },
   {
     "start": "2022-03-22T03:11:45Z",
@@ -10854,28 +6732,10 @@
     "period": "morning"
   },
   {
-    "start": "2022-03-23T04:34:07Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 903.6144578313252,
-    "period": "morning"
-  },
-  {
     "start": "2022-03-23T04:35:52Z",
     "asin": "B08N8Z99MK",
     "wpm": 311.2808168008633,
     "period": "morning"
-  },
-  {
-    "start": "2022-03-23T21:41:24Z",
-    "asin": "B094GQBBPQ",
-    "wpm": 4137.931034482758,
-    "period": "evening"
-  },
-  {
-    "start": "2022-03-23T21:42:58Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1875,
-    "period": "evening"
   },
   {
     "start": "2022-03-23T21:43:11Z",
@@ -10887,12 +6747,6 @@
     "start": "2022-03-26T03:13:47Z",
     "asin": "B08N8Z99MK",
     "wpm": 539.3864479154961,
-    "period": "morning"
-  },
-  {
-    "start": "2022-03-26T03:28:43Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1973.6842105263156,
     "period": "morning"
   },
   {
@@ -11016,12 +6870,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-01T15:50:04Z",
-    "asin": "B08FH9BV7N",
-    "wpm": 2000,
-    "period": "evening"
-  },
-  {
     "start": "2022-04-01T18:18:06Z",
     "asin": "B08FH9BV7N",
     "wpm": 181.83917335334527,
@@ -11094,12 +6942,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-07T02:53:16Z",
-    "asin": "B09T9H87RB",
-    "wpm": 3015.075376884422,
-    "period": "morning"
-  },
-  {
     "start": "2022-04-07T03:41:26Z",
     "asin": "B08N8Z99MK",
     "wpm": 394.3476832073612,
@@ -11118,12 +6960,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-09T03:55:14Z",
-    "asin": "B08G1NJK2R",
-    "wpm": 1505.0167224080267,
-    "period": "morning"
-  },
-  {
     "start": "2022-04-09T03:56:38Z",
     "asin": "B08G1NJK2R",
     "wpm": 212.56495040151157,
@@ -11136,12 +6972,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-04-09T16:04:44Z",
-    "asin": "B08G1NJK2R",
-    "wpm": 2036.1990950226243,
-    "period": "evening"
-  },
-  {
     "start": "2022-04-09T16:50:56Z",
     "asin": "B08G1NJK2R",
     "wpm": 655.5944055944055,
@@ -11151,12 +6981,6 @@
     "start": "2022-04-09T16:58:13Z",
     "asin": "B08G1NJK2R",
     "wpm": 471.4510214772132,
-    "period": "evening"
-  },
-  {
-    "start": "2022-04-09T20:05:48Z",
-    "asin": "B08G1NJK2R",
-    "wpm": 5232.558139534884,
     "period": "evening"
   },
   {
@@ -11256,21 +7080,9 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-14T02:44:58Z",
-    "asin": "B08G1NJK2R",
-    "wpm": 1724.1379310344828,
-    "period": "morning"
-  },
-  {
     "start": "2022-04-14T02:45:17Z",
     "asin": "B098PXP11K",
     "wpm": 1170.7317073170732,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-14T02:55:39Z",
-    "asin": "B08G1NJK2R",
-    "wpm": 1764.7058823529412,
     "period": "morning"
   },
   {
@@ -11316,12 +7128,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-15T03:03:02Z",
-    "asin": "B098PXP11K",
-    "wpm": 753.7688442211055,
-    "period": "morning"
-  },
-  {
     "start": "2022-04-16T04:02:52Z",
     "asin": "B098PXP11K",
     "wpm": 175.54125219426564,
@@ -11344,18 +7150,6 @@
     "asin": "B098PXP11K",
     "wpm": 248.53639677454987,
     "period": "morning"
-  },
-  {
-    "start": "2022-04-17T17:31:23Z",
-    "asin": "B098PXP11K",
-    "wpm": 1437.6996805111824,
-    "period": "evening"
-  },
-  {
-    "start": "2022-04-17T17:35:37Z",
-    "asin": "B098PXP11K",
-    "wpm": 1829.268292682927,
-    "period": "evening"
   },
   {
     "start": "2022-04-17T23:42:47Z",
@@ -11406,39 +7200,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-04-20T02:06:11Z",
-    "asin": "B08JKC299M",
-    "wpm": 3260.869565217391,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-20T02:06:28Z",
-    "asin": "B08JKC299M",
-    "wpm": 1711.0266159695816,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-20T02:06:59Z",
-    "asin": "B08JKC299M",
-    "wpm": 12500,
-    "period": "morning"
-  },
-  {
     "start": "2022-04-20T03:25:54Z",
     "asin": "B08JKC299M",
     "wpm": 101.51139183397248,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-20T03:30:45Z",
-    "asin": "B09T9H87RB",
-    "wpm": 11111.111111111111,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-20T03:33:27Z",
-    "asin": "B08JKC299M",
-    "wpm": 2054.794520547945,
     "period": "morning"
   },
   {
@@ -11478,12 +7242,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-04-21T19:25:12Z",
-    "asin": "B08JKC299M",
-    "wpm": 5172.413793103448,
-    "period": "evening"
-  },
-  {
     "start": "2022-04-22T03:04:39Z",
     "asin": "B08JKC299M",
     "wpm": 292.40568886936467,
@@ -11493,12 +7251,6 @@
     "start": "2022-04-22T20:14:31Z",
     "asin": "B08JKC299M",
     "wpm": 282.43752139678196,
-    "period": "evening"
-  },
-  {
-    "start": "2022-04-22T22:46:42Z",
-    "asin": "B08JKC299M",
-    "wpm": 386.59793814432993,
     "period": "evening"
   },
   {
@@ -11534,19 +7286,13 @@
   {
     "start": "2022-04-23T18:37:52Z",
     "asin": "B08JKC299M",
-    "wpm": 7222.609909281228,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-04-23T18:40:37Z",
     "asin": "B08JKC299M",
     "wpm": 401.33779264214047,
-    "period": "evening"
-  },
-  {
-    "start": "2022-04-23T19:04:34Z",
-    "asin": "B08JKC299M",
-    "wpm": 266.4298401420959,
     "period": "evening"
   },
   {
@@ -11562,12 +7308,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-04-23T20:14:18Z",
-    "asin": "B08JKC299M",
-    "wpm": 424.92917847025495,
-    "period": "evening"
-  },
-  {
     "start": "2022-04-23T20:21:33Z",
     "asin": "B08JKC299M",
     "wpm": 238.2573179033356,
@@ -11578,18 +7318,6 @@
     "asin": "B08JKC299M",
     "wpm": 352.69221725840583,
     "period": "morning"
-  },
-  {
-    "start": "2022-04-24T12:25:09Z",
-    "asin": "B08JKC299M",
-    "wpm": 3658.536585365854,
-    "period": "evening"
-  },
-  {
-    "start": "2022-04-24T20:09:35Z",
-    "asin": "B08JKC299M",
-    "wpm": 566.0377358490566,
-    "period": "evening"
   },
   {
     "start": "2022-04-24T20:16:02Z",
@@ -11619,18 +7347,6 @@
     "start": "2022-04-25T02:43:28Z",
     "asin": "B01LWWK7WR",
     "wpm": 77.46733460724062,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-25T02:44:53Z",
-    "asin": "B01LWWK7WR",
-    "wpm": 588.2352941176471,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-25T02:45:22Z",
-    "asin": "B01LWWK7WR",
-    "wpm": 2054.794520547945,
     "period": "morning"
   },
   {
@@ -11682,12 +7398,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-26T14:40:31Z",
-    "asin": "B01LWWK7WR",
-    "wpm": 1851.8518518518517,
-    "period": "evening"
-  },
-  {
     "start": "2022-04-26T20:51:36Z",
     "asin": "B01LWWK7WR",
     "wpm": 189.8133502056311,
@@ -11724,18 +7434,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-04-28T01:55:11Z",
-    "asin": "B01LWWK7WR",
-    "wpm": 1648.3516483516482,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-28T03:47:42Z",
-    "asin": "B098TZ17NC",
-    "wpm": 496.68874172185434,
-    "period": "morning"
-  },
-  {
     "start": "2022-04-28T03:49:18Z",
     "asin": "B098TZ17NC",
     "wpm": 225.9436469962786,
@@ -11745,12 +7443,6 @@
     "start": "2022-04-28T04:08:57Z",
     "asin": "B0018ND8B6",
     "wpm": 361.35870874488074,
-    "period": "morning"
-  },
-  {
-    "start": "2022-04-28T04:30:27Z",
-    "asin": "B099DRHTLX",
-    "wpm": 1578.9473684210527,
     "period": "morning"
   },
   {
@@ -11800,18 +7492,6 @@
     "asin": "B091Y4KGFH",
     "wpm": 212.0606444693609,
     "period": "morning"
-  },
-  {
-    "start": "2022-04-30T14:02:03Z",
-    "asin": "B091Y4KGFH",
-    "wpm": 12952.646239554317,
-    "period": "evening"
-  },
-  {
-    "start": "2022-04-30T18:18:31Z",
-    "asin": "B091Y4KGFH",
-    "wpm": 709.2198581560284,
-    "period": "evening"
   },
   {
     "start": "2022-05-01T01:07:09Z",
@@ -11892,12 +7572,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-04T22:52:01Z",
-    "asin": "B00JV2H5I8",
-    "wpm": 1162.7906976744187,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-04T22:52:20Z",
     "asin": "B091Y4KGFH",
     "wpm": 290.5041457362464,
@@ -11946,28 +7620,10 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-07T21:41:34Z",
-    "asin": "B091Y4KGFH",
-    "wpm": 2586.206896551724,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-07T21:42:16Z",
     "asin": "B08PY1XTB8",
     "wpm": 1077.414205905826,
     "period": "evening"
-  },
-  {
-    "start": "2022-05-07T22:13:27Z",
-    "asin": "B08PY1XTB8",
-    "wpm": 3448.2758620689656,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-08T05:29:38Z",
-    "asin": "B08PY1XTB8",
-    "wpm": 1363.6363636363637,
-    "period": "morning"
   },
   {
     "start": "2022-05-08T05:30:11Z",
@@ -12018,12 +7674,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-05-09T02:39:58Z",
-    "asin": "B099DRHTLX",
-    "wpm": 1056.338028169014,
-    "period": "morning"
-  },
-  {
     "start": "2022-05-09T02:40:36Z",
     "asin": "B099DRHTLX",
     "wpm": 311.9584055459272,
@@ -12032,7 +7682,7 @@
   {
     "start": "2022-05-09T19:21:06Z",
     "asin": "B09Z1Y1MG9",
-    "wpm": 5460.46287367406,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -12042,22 +7692,10 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-09T20:05:07Z",
-    "asin": "B099DRHTLX",
-    "wpm": 4761.904761904762,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-10T01:51:07Z",
     "asin": "B099DRHTLX",
     "wpm": 318.8682011435273,
     "period": "morning"
-  },
-  {
-    "start": "2022-05-10T20:41:08Z",
-    "asin": "B099DRHTLX",
-    "wpm": 1415.0943396226414,
-    "period": "evening"
   },
   {
     "start": "2022-05-10T21:37:31Z",
@@ -12120,12 +7758,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-05-13T01:35:00Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 2000,
-    "period": "morning"
-  },
-  {
     "start": "2022-05-13T04:28:35Z",
     "asin": "B01NBJMMRR",
     "wpm": 370.60445874511606,
@@ -12138,21 +7770,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-14T00:05:25Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 1020.4081632653061,
-    "period": "morning"
-  },
-  {
     "start": "2022-05-14T00:06:25Z",
     "asin": "B01NBJMMRR",
     "wpm": 705.5503292568203,
-    "period": "morning"
-  },
-  {
-    "start": "2022-05-14T00:11:04Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 334.82142857142856,
     "period": "morning"
   },
   {
@@ -12192,12 +7812,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-05-14T01:34:43Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 3191.4893617021276,
-    "period": "morning"
-  },
-  {
     "start": "2022-05-14T02:59:16Z",
     "asin": "B01NBJMMRR",
     "wpm": 372.51655629139077,
@@ -12225,12 +7839,6 @@
     "start": "2022-05-14T16:46:36Z",
     "asin": "B01NBJMMRR",
     "wpm": 1160.5415860735009,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-14T17:02:29Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 7500,
     "period": "evening"
   },
   {
@@ -12288,30 +7896,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-05-15T02:57:05Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 1003.3444816053511,
-    "period": "morning"
-  },
-  {
-    "start": "2022-05-15T02:58:30Z",
-    "asin": "B0756J4NRG",
-    "wpm": 2036.1990950226243,
-    "period": "morning"
-  },
-  {
-    "start": "2022-05-15T14:46:35Z",
-    "asin": "B01NBJMMRR",
-    "wpm": 1401.8691588785045,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-15T14:46:53Z",
-    "asin": "B0756J4NRG",
-    "wpm": 5000,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-15T16:02:07Z",
     "asin": "B0756J4NRG",
     "wpm": 31.27606338615513,
@@ -12336,12 +7920,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-15T17:43:21Z",
-    "asin": "B0756J4NRG",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-15T20:05:50Z",
     "asin": "B0756J4NRG",
     "wpm": 471.737151369693,
@@ -12351,12 +7929,6 @@
     "start": "2022-05-15T21:28:00Z",
     "asin": "B0756J4NRG",
     "wpm": 379.0724677276142,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-15T22:09:16Z",
-    "asin": "B0756J4NRG",
-    "wpm": 6040.268456375839,
     "period": "evening"
   },
   {
@@ -12450,34 +8022,10 @@
     "period": "morning"
   },
   {
-    "start": "2022-05-17T01:41:52Z",
-    "asin": "B07GVCBVYC",
-    "wpm": 1485.148514851485,
-    "period": "morning"
-  },
-  {
-    "start": "2022-05-18T02:23:44Z",
-    "asin": "B07GVCBVYC",
-    "wpm": 3370.7865168539324,
-    "period": "morning"
-  },
-  {
-    "start": "2022-05-20T02:25:07Z",
-    "asin": "B07WYSF921",
-    "wpm": 3658.536585365854,
-    "period": "morning"
-  },
-  {
     "start": "2022-05-20T02:27:28Z",
     "asin": "B08XTNHRR5",
     "wpm": 1985.2941176470588,
     "period": "morning"
-  },
-  {
-    "start": "2022-05-20T17:08:51Z",
-    "asin": "B0756J4NRG",
-    "wpm": 568.1818181818181,
-    "period": "evening"
   },
   {
     "start": "2022-05-20T17:09:44Z",
@@ -12534,12 +8082,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-22T17:25:42Z",
-    "asin": "B095MMJYSR",
-    "wpm": 1094.890510948905,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-22T21:25:47Z",
     "asin": "B095MMJYSR",
     "wpm": 258.7017873941674,
@@ -12576,39 +8118,15 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-23T20:12:33Z",
-    "asin": "B07D2C6J4K",
-    "wpm": 1079.136690647482,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-23T20:13:10Z",
     "asin": "B07WYSF921",
-    "wpm": 5123.825789923143,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-24T17:13:51Z",
-    "asin": "B07D2C6J4K",
-    "wpm": 272.2323049001815,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-05-24T17:14:51Z",
     "asin": "B07D2C6J4K",
     "wpm": 621.9991270187691,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-24T18:24:02Z",
-    "asin": "B07D2C6J4K",
-    "wpm": 903.6144578313252,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-24T19:07:19Z",
-    "asin": "B07D2C6J4K",
-    "wpm": 1401.8691588785045,
     "period": "evening"
   },
   {
@@ -12634,12 +8152,6 @@
     "asin": "B09BTJNJCX",
     "wpm": 299.04306220095697,
     "period": "morning"
-  },
-  {
-    "start": "2022-05-27T20:30:53Z",
-    "asin": "B09BTJNJCX",
-    "wpm": 909.090909090909,
-    "period": "evening"
   },
   {
     "start": "2022-05-27T20:31:18Z",
@@ -12678,12 +8190,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-05-28T17:26:17Z",
-    "asin": "B07D2C6J4K",
-    "wpm": 2912.621359223301,
-    "period": "evening"
-  },
-  {
     "start": "2022-05-29T04:15:03Z",
     "asin": "B07D2C6J4K",
     "wpm": 493.09664694280076,
@@ -12693,12 +8199,6 @@
     "start": "2022-05-29T16:36:33Z",
     "asin": "B07D2C6J4K",
     "wpm": 337.70262157294377,
-    "period": "evening"
-  },
-  {
-    "start": "2022-05-29T16:40:09Z",
-    "asin": "B07D2C6J4K",
-    "wpm": 1351.3513513513515,
     "period": "evening"
   },
   {
@@ -12804,18 +8304,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-06-03T20:33:32Z",
-    "asin": "B09Q1SQ567",
-    "wpm": 2400,
-    "period": "evening"
-  },
-  {
-    "start": "2022-06-03T20:33:45Z",
-    "asin": "B09QCX4JK7",
-    "wpm": 4545.454545454545,
-    "period": "evening"
-  },
-  {
     "start": "2022-06-04T03:05:40Z",
     "asin": "B09BTJNJCX",
     "wpm": 112.45220781168004,
@@ -12849,18 +8337,6 @@
     "start": "2022-06-06T02:51:59Z",
     "asin": "B09BTJNJCX",
     "wpm": 300.6012024048096,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-06T02:57:16Z",
-    "asin": "B08XTNHRR5",
-    "wpm": 2343.75,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-06T02:59:19Z",
-    "asin": "B09Z1Y1MG9",
-    "wpm": 2278.481012658228,
     "period": "morning"
   },
   {
@@ -12906,12 +8382,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-06-08T03:15:06Z",
-    "asin": "B09BTJNJCX",
-    "wpm": 2500,
-    "period": "morning"
-  },
-  {
     "start": "2022-06-08T03:15:27Z",
     "asin": "B096DH95W8",
     "wpm": 1125,
@@ -12930,28 +8400,10 @@
     "period": "evening"
   },
   {
-    "start": "2022-06-09T01:44:02Z",
-    "asin": "B09P37M6P3",
-    "wpm": 867.0520231213873,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-09T02:41:16Z",
-    "asin": "B09BTJNJCX",
-    "wpm": 785.3403141361256,
-    "period": "morning"
-  },
-  {
     "start": "2022-06-09T03:57:52Z",
     "asin": "B098QS47D3",
     "wpm": 366.1141055629005,
     "period": "morning"
-  },
-  {
-    "start": "2022-06-09T14:44:18Z",
-    "asin": "B096DH95W8",
-    "wpm": 704.2253521126761,
-    "period": "evening"
   },
   {
     "start": "2022-06-09T14:45:14Z",
@@ -12963,12 +8415,6 @@
     "start": "2022-06-09T17:54:27Z",
     "asin": "B098QS47D3",
     "wpm": 241.54589371980677,
-    "period": "evening"
-  },
-  {
-    "start": "2022-06-09T17:55:40Z",
-    "asin": "B098QS47D3",
-    "wpm": 821.9178082191781,
     "period": "evening"
   },
   {
@@ -13068,18 +8514,6 @@
     "period": "evening"
   },
   {
-    "start": "2022-06-12T21:03:57Z",
-    "asin": "B098QS47D3",
-    "wpm": 3308.823529411765,
-    "period": "evening"
-  },
-  {
-    "start": "2022-06-17T04:49:12Z",
-    "asin": "B098TZ17NC",
-    "wpm": 1384.6153846153848,
-    "period": "morning"
-  },
-  {
     "start": "2022-06-17T04:49:59Z",
     "asin": "B098TZ17NC",
     "wpm": 286.07755880483154,
@@ -13104,24 +8538,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-06-19T04:51:33Z",
-    "asin": "B09BTJNJCX",
-    "wpm": 3620.689655172414,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-19T04:52:05Z",
-    "asin": "B09BTJNJCX",
-    "wpm": 1948.051948051948,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-19T04:54:41Z",
-    "asin": "B098TZ17NC",
-    "wpm": 2631.578947368421,
-    "period": "morning"
-  },
-  {
     "start": "2022-06-19T05:06:44Z",
     "asin": "B08KL58Q4X",
     "wpm": 411.3924050632911,
@@ -13136,43 +8552,19 @@
   {
     "start": "2022-06-20T04:23:06Z",
     "asin": "B08KL58Q4X",
-    "wpm": 2045.614860098754,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-20T04:30:34Z",
-    "asin": "B098TZ17NC",
-    "wpm": 3580.901856763926,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-21T01:10:22Z",
-    "asin": "B098TZ17NC",
-    "wpm": 1276.595744680851,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-21T01:38:15Z",
-    "asin": "B09QBBMXCR",
-    "wpm": 13701.923076923076,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2022-06-21T01:46:55Z",
     "asin": "B08J3YYP2M",
-    "wpm": 6864.06460296097,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2022-06-21T01:50:57Z",
     "asin": "B08J3YYP2M",
-    "wpm": 8040.131940626718,
-    "period": "morning"
-  },
-  {
-    "start": "2022-06-22T04:46:44Z",
-    "asin": "B08P98PVY2",
-    "wpm": 1079.136690647482,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -13214,7 +8606,7 @@
   {
     "start": "2022-06-23T16:38:08Z",
     "asin": "B08J3YYP2M",
-    "wpm": 2838.8746803069052,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -13263,12 +8655,6 @@
     "start": "2022-06-24T21:18:30Z",
     "asin": "B08P98PVY2",
     "wpm": 24.84266313348791,
-    "period": "evening"
-  },
-  {
-    "start": "2022-06-24T22:52:29Z",
-    "asin": "B08P98PVY2",
-    "wpm": 413.22314049586777,
     "period": "evening"
   },
   {
@@ -13440,12 +8826,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-07-12T21:05:23Z",
-    "asin": "B095MPSYWY",
-    "wpm": 675.6756756756757,
-    "period": "evening"
-  },
-  {
     "start": "2022-07-12T21:12:10Z",
     "asin": "B095MPSYWY",
     "wpm": 387.0967741935484,
@@ -13596,51 +8976,21 @@
     "period": "morning"
   },
   {
-    "start": "2022-07-19T16:58:24Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1546.3917525773197,
-    "period": "evening"
-  },
-  {
     "start": "2022-07-19T19:40:16Z",
     "asin": "B08N8Z99MK",
-    "wpm": 10520.361990950227,
-    "period": "evening"
-  },
-  {
-    "start": "2022-07-19T19:41:55Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1991.1504424778761,
-    "period": "evening"
-  },
-  {
-    "start": "2022-07-19T20:51:05Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 10144.927536231884,
-    "period": "evening"
-  },
-  {
-    "start": "2022-07-20T15:53:44Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1525.4237288135594,
-    "period": "evening"
-  },
-  {
-    "start": "2022-07-20T16:45:36Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 1485.148514851485,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-07-20T22:27:56Z",
     "asin": "B08N8Z99MK",
-    "wpm": 2367.879203843514,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2022-07-20T22:40:30Z",
     "asin": "B08N8Z99MK",
-    "wpm": 2127.6595744680853,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -13650,28 +9000,10 @@
     "period": "evening"
   },
   {
-    "start": "2022-07-20T22:53:15Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 3839.590443686007,
-    "period": "evening"
-  },
-  {
-    "start": "2022-07-20T23:34:49Z",
-    "asin": "B08N8Z99MK",
-    "wpm": 16564.41717791411,
-    "period": "evening"
-  },
-  {
     "start": "2022-07-21T02:50:11Z",
     "asin": "B095MPSYWY",
     "wpm": 438.21209465381247,
     "period": "morning"
-  },
-  {
-    "start": "2022-07-21T16:15:27Z",
-    "asin": "B095MPSYWY",
-    "wpm": 1578.9473684210527,
-    "period": "evening"
   },
   {
     "start": "2022-07-21T16:16:07Z",
@@ -13682,7 +9014,7 @@
   {
     "start": "2022-07-21T16:30:13Z",
     "asin": "B08N8Z99MK",
-    "wpm": 12923.923006416131,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -13776,21 +9108,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-07-31T03:16:56Z",
-    "asin": "B09HCD24DJ",
-    "wpm": 1048.951048951049,
-    "period": "morning"
-  },
-  {
     "start": "2022-07-31T03:17:29Z",
     "asin": "B08HL86V91",
     "wpm": 256.4102564102564,
-    "period": "morning"
-  },
-  {
-    "start": "2022-08-02T02:49:00Z",
-    "asin": "B08HL86V91",
-    "wpm": 291.8287937743191,
     "period": "morning"
   },
   {
@@ -13816,12 +9136,6 @@
     "asin": "B084M663VB",
     "wpm": 395.7187005351624,
     "period": "morning"
-  },
-  {
-    "start": "2022-08-04T14:36:36Z",
-    "asin": "B084M663VB",
-    "wpm": 1145.0381679389313,
-    "period": "evening"
   },
   {
     "start": "2022-08-05T04:06:53Z",
@@ -13988,7 +9302,7 @@
   {
     "start": "2022-08-15T03:22:13Z",
     "asin": "B00OICLVBI",
-    "wpm": 2788.4089666484415,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -14034,21 +9348,9 @@
     "period": "morning"
   },
   {
-    "start": "2022-08-22T03:02:24Z",
-    "asin": "B098TZ17NC",
-    "wpm": 688.0733944954128,
-    "period": "morning"
-  },
-  {
     "start": "2022-08-22T03:03:24Z",
     "asin": "B08YRM9NBM",
     "wpm": 430.91065785693763,
-    "period": "morning"
-  },
-  {
-    "start": "2022-08-23T03:51:08Z",
-    "asin": "B08YRM9NBM",
-    "wpm": 691.2442396313363,
     "period": "morning"
   },
   {
@@ -14061,12 +9363,6 @@
     "start": "2022-08-23T04:48:31Z",
     "asin": "B08YRM9NBM",
     "wpm": 161.29032258064515,
-    "period": "morning"
-  },
-  {
-    "start": "2022-08-23T11:33:26Z",
-    "asin": "B08YRM9NBM",
-    "wpm": 1522.8426395939086,
     "period": "morning"
   },
   {
@@ -14193,12 +9489,6 @@
     "start": "2022-09-02T03:26:55Z",
     "asin": "B09JPFYQY2",
     "wpm": 39.784280788612854,
-    "period": "morning"
-  },
-  {
-    "start": "2022-09-02T03:46:09Z",
-    "asin": "B09JPFYQY2",
-    "wpm": 1456.3106796116506,
     "period": "morning"
   },
   {
@@ -14334,12 +9624,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-09-13T04:18:02Z",
-    "asin": "B09841WSGD",
-    "wpm": 834.8794063079778,
-    "period": "morning"
-  },
-  {
     "start": "2022-09-15T04:07:24Z",
     "asin": "B09841WSGD",
     "wpm": 516.2352237019303,
@@ -14358,12 +9642,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-09-16T18:47:03Z",
-    "asin": "B09G9C2WRT",
-    "wpm": 402.1447721179624,
-    "period": "evening"
-  },
-  {
     "start": "2022-09-16T18:47:44Z",
     "asin": "B09JPFYQY2",
     "wpm": 301.0033444816053,
@@ -14376,21 +9654,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-09-18T02:48:24Z",
-    "asin": "B0BCPF7HGJ",
-    "wpm": 6190.47619047619,
-    "period": "morning"
-  },
-  {
     "start": "2022-09-20T02:46:14Z",
     "asin": "B0BCPF7HGJ",
-    "wpm": 5714.285714285714,
-    "period": "morning"
-  },
-  {
-    "start": "2022-09-20T03:19:38Z",
-    "asin": "B08PC3SZHX",
-    "wpm": 1518.987341772152,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -14398,18 +9664,6 @@
     "asin": "B08PC3SZHX",
     "wpm": 476.63881369895256,
     "period": "morning"
-  },
-  {
-    "start": "2022-09-20T17:01:21Z",
-    "asin": "B08PC3SZHX",
-    "wpm": 1351.3513513513515,
-    "period": "evening"
-  },
-  {
-    "start": "2022-09-20T22:27:46Z",
-    "asin": "B08PC3SZHX",
-    "wpm": 1630.4347826086957,
-    "period": "evening"
   },
   {
     "start": "2022-09-20T22:29:46Z",
@@ -14434,12 +9688,6 @@
     "asin": "B09NTJPTKN",
     "wpm": 649.9535747446611,
     "period": "morning"
-  },
-  {
-    "start": "2022-09-23T19:14:03Z",
-    "asin": "B09NLPTNQ2",
-    "wpm": 25000,
-    "period": "evening"
   },
   {
     "start": "2022-09-25T03:32:57Z",
@@ -14478,12 +9726,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-09-27T22:30:18Z",
-    "asin": "B097769VDM",
-    "wpm": 1515.151515151515,
-    "period": "evening"
-  },
-  {
     "start": "2022-09-28T00:47:00Z",
     "asin": "B097769VDM",
     "wpm": 470.11729659281326,
@@ -14499,12 +9741,6 @@
     "start": "2022-09-28T02:35:30Z",
     "asin": "B097769VDM",
     "wpm": 422.41401788740836,
-    "period": "morning"
-  },
-  {
-    "start": "2022-09-28T09:44:19Z",
-    "asin": "B097769VDM",
-    "wpm": 2542.3728813559323,
     "period": "morning"
   },
   {
@@ -14628,30 +9864,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-10-05T02:16:31Z",
-    "asin": "B000FC0QBQ",
-    "wpm": 1515.151515151515,
-    "period": "morning"
-  },
-  {
-    "start": "2022-10-05T02:17:23Z",
-    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
-    "wpm": 2008.9285714285713,
-    "period": "morning"
-  },
-  {
-    "start": "2022-10-05T02:18:20Z",
-    "asin": "B09NLPTNQ2",
-    "wpm": 746.2686567164179,
-    "period": "morning"
-  },
-  {
-    "start": "2022-10-05T02:19:18Z",
-    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
-    "wpm": 379.746835443038,
-    "period": "morning"
-  },
-  {
     "start": "2022-10-05T02:20:16Z",
     "asin": "B000FC0QBQ",
     "wpm": 341.2825482430269,
@@ -14662,24 +9874,6 @@
     "asin": "B000FC0QBQ",
     "wpm": 784.167289021658,
     "period": "morning"
-  },
-  {
-    "start": "2022-10-05T17:12:58Z",
-    "asin": "B000FC0QBQ",
-    "wpm": 368.55036855036855,
-    "period": "evening"
-  },
-  {
-    "start": "2022-10-05T19:29:03Z",
-    "asin": "B000FC0QBQ",
-    "wpm": 520.8333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2022-10-05T19:31:19Z",
-    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
-    "wpm": 1437.6996805111824,
-    "period": "evening"
   },
   {
     "start": "2022-10-05T19:31:53Z",
@@ -14754,12 +9948,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-10-16T04:03:09Z",
-    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
-    "wpm": 433.52601156069363,
-    "period": "morning"
-  },
-  {
     "start": "2022-10-16T04:05:05Z",
     "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
     "wpm": 367.1221700999388,
@@ -14778,21 +9966,9 @@
     "period": "evening"
   },
   {
-    "start": "2022-10-17T23:06:48Z",
-    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
-    "wpm": 3260.8695652173915,
-    "period": "evening"
-  },
-  {
     "start": "2022-10-18T01:56:49Z",
     "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
     "wpm": 68.24385805277525,
-    "period": "morning"
-  },
-  {
-    "start": "2022-10-18T02:15:24Z",
-    "asin": "3IPAKSAWQQL2Z24WQQ2L3VFTRTUOXTTK",
-    "wpm": 1013.5135135135135,
     "period": "morning"
   },
   {
@@ -14922,12 +10098,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-10-31T02:36:58Z",
-    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
-    "wpm": 731.7073170731708,
-    "period": "morning"
-  },
-  {
     "start": "2022-10-31T02:41:50Z",
     "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
     "wpm": 226.43062988884316,
@@ -14936,7 +10106,7 @@
   {
     "start": "2022-10-31T23:01:02Z",
     "asin": "B0BKPPPQNV",
-    "wpm": 2015.1133501259444,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -14948,7 +10118,7 @@
   {
     "start": "2022-11-01T00:18:40Z",
     "asin": "B0BKPPPQNV",
-    "wpm": 4613.445378151261,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -14973,18 +10143,6 @@
     "start": "2022-11-01T02:53:41Z",
     "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
     "wpm": 331.7724419647305,
-    "period": "morning"
-  },
-  {
-    "start": "2022-11-02T02:43:48Z",
-    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
-    "wpm": 697.6744186046511,
-    "period": "morning"
-  },
-  {
-    "start": "2022-11-02T03:07:22Z",
-    "asin": "AQ3OABMEA2YURRI5PMD4TSHQZYWFTONB",
-    "wpm": 1666.6666666666667,
     "period": "morning"
   },
   {
@@ -15054,18 +10212,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-11-04T04:31:47Z",
-    "asin": "B09QPJKSXM",
-    "wpm": 3825.1366120218577,
-    "period": "morning"
-  },
-  {
-    "start": "2022-11-05T02:42:41Z",
-    "asin": "B09QPJKSXM",
-    "wpm": 1127.8195488721803,
-    "period": "morning"
-  },
-  {
     "start": "2022-11-11T05:38:56Z",
     "asin": "B09285Y1V4",
     "wpm": 505.050505050505,
@@ -15075,12 +10221,6 @@
     "start": "2022-11-11T05:45:07Z",
     "asin": "B09285Y1V4",
     "wpm": 973.5396904643035,
-    "period": "morning"
-  },
-  {
-    "start": "2022-11-13T06:18:23Z",
-    "asin": "B0BH8GTQYX",
-    "wpm": 1293.103448275862,
     "period": "morning"
   },
   {
@@ -15096,12 +10236,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-11-13T20:38:14Z",
-    "asin": "B0BH8GTQYX",
-    "wpm": 2255.6390977443607,
-    "period": "evening"
-  },
-  {
     "start": "2022-11-13T21:55:51Z",
     "asin": "B0BH8GTQYX",
     "wpm": 243.92046714465224,
@@ -15114,12 +10248,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-11-14T23:26:19Z",
-    "asin": "B0BH8GTQYX",
-    "wpm": 2727.2727272727275,
-    "period": "evening"
-  },
-  {
     "start": "2022-11-14T23:29:30Z",
     "asin": "B0BH8GTQYX",
     "wpm": 412.26674381599884,
@@ -15130,24 +10258,6 @@
     "asin": "B0BH8GTQYX",
     "wpm": 377.32376219399964,
     "period": "morning"
-  },
-  {
-    "start": "2022-11-15T22:07:20Z",
-    "asin": "B0BH8GTQYX",
-    "wpm": 789.4736842105264,
-    "period": "evening"
-  },
-  {
-    "start": "2022-11-15T22:07:46Z",
-    "asin": "B0BH8GTQYX",
-    "wpm": 2500,
-    "period": "evening"
-  },
-  {
-    "start": "2022-11-15T22:08:22Z",
-    "asin": "N4LRBDHXLHWB6GQCAL74CNNNWOIWTPMJ",
-    "wpm": 1229.5081967213114,
-    "period": "evening"
   },
   {
     "start": "2022-11-16T04:34:42Z",
@@ -15246,30 +10356,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-12-02T14:31:27Z",
-    "asin": "B09NH4DJBP",
-    "wpm": 802.1390374331552,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-02T20:55:16Z",
-    "asin": "B09NH4DJBP",
-    "wpm": 3409.090909090909,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-02T20:56:25Z",
-    "asin": "B08KH4LZDM",
-    "wpm": 1587.3015873015872,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-02T21:10:44Z",
-    "asin": "B09NH4DJBP",
-    "wpm": 1408.4507042253522,
-    "period": "evening"
-  },
-  {
     "start": "2022-12-02T21:11:55Z",
     "asin": "B08KH4LZDM",
     "wpm": 171.6961498439126,
@@ -15306,12 +10392,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-12-05T00:44:34Z",
-    "asin": "B08KH4LZDM",
-    "wpm": 1764.7058823529412,
-    "period": "morning"
-  },
-  {
     "start": "2022-12-05T04:14:03Z",
     "asin": "B08KH4LZDM",
     "wpm": 271.6551084411855,
@@ -15322,12 +10402,6 @@
     "asin": "B08KH4LZDM",
     "wpm": 110.07827788649706,
     "period": "evening"
-  },
-  {
-    "start": "2022-12-06T05:50:58Z",
-    "asin": "B08KH4LZDM",
-    "wpm": 468.75,
-    "period": "morning"
   },
   {
     "start": "2022-12-06T05:51:47Z",
@@ -15368,7 +10442,7 @@
   {
     "start": "2022-12-13T03:50:44Z",
     "asin": "B0B33PJZJT",
-    "wpm": 2842.9602888086642,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -15386,25 +10460,13 @@
   {
     "start": "2022-12-14T04:13:16Z",
     "asin": "B0B33PJZJT",
-    "wpm": 2236.1240516438174,
-    "period": "morning"
-  },
-  {
-    "start": "2022-12-14T17:44:27Z",
-    "asin": "B0B33PJZJT",
-    "wpm": 3703.7037037037035,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-15T03:28:13Z",
-    "asin": "B0B33PJZJT",
-    "wpm": 3947.3684210526317,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2022-12-15T03:29:00Z",
     "asin": "B0B33PJZJT",
-    "wpm": 2701.644479248238,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -15414,27 +10476,9 @@
     "period": "morning"
   },
   {
-    "start": "2022-12-15T23:18:38Z",
-    "asin": "B09RX45W14",
-    "wpm": 764.0067911714771,
-    "period": "evening"
-  },
-  {
     "start": "2022-12-16T04:01:07Z",
     "asin": "B09RX45W14",
     "wpm": 105.67632850241547,
-    "period": "morning"
-  },
-  {
-    "start": "2022-12-16T04:21:26Z",
-    "asin": "B09RX2WQ3M",
-    "wpm": 3000,
-    "period": "morning"
-  },
-  {
-    "start": "2022-12-16T04:24:31Z",
-    "asin": "B09RX45W14",
-    "wpm": 1239.6694214876034,
     "period": "morning"
   },
   {
@@ -15444,51 +10488,9 @@
     "period": "morning"
   },
   {
-    "start": "2022-12-16T05:09:28Z",
-    "asin": "B09RX2WQ3M",
-    "wpm": 2054.794520547945,
-    "period": "morning"
-  },
-  {
     "start": "2022-12-16T05:17:24Z",
     "asin": "B097XBXQ1T",
     "wpm": 523.3111322549953,
-    "period": "morning"
-  },
-  {
-    "start": "2022-12-18T22:26:47Z",
-    "asin": "B09RX45W14",
-    "wpm": 769.2307692307692,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-18T22:33:20Z",
-    "asin": "B097XBXQ1T",
-    "wpm": 1127.8195488721803,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-18T22:33:49Z",
-    "asin": "B09RX45W14",
-    "wpm": 906.344410876133,
-    "period": "evening"
-  },
-  {
-    "start": "2022-12-20T03:41:48Z",
-    "asin": "B09RX45W14",
-    "wpm": 1515.151515151515,
-    "period": "morning"
-  },
-  {
-    "start": "2022-12-20T03:42:33Z",
-    "asin": "B08BYBNGMW",
-    "wpm": 1662.0498614958449,
-    "period": "morning"
-  },
-  {
-    "start": "2022-12-20T03:43:21Z",
-    "asin": "B08BYBNGMW",
-    "wpm": 1315.7894736842104,
     "period": "morning"
   },
   {
@@ -15502,12 +10504,6 @@
     "asin": "B08BYBNGMW",
     "wpm": 426.6750948166877,
     "period": "morning"
-  },
-  {
-    "start": "2022-12-20T18:59:58Z",
-    "asin": "B0BKPPPQNV",
-    "wpm": 3448.2758620689656,
-    "period": "evening"
   },
   {
     "start": "2022-12-20T23:18:48Z",
@@ -15588,12 +10584,6 @@
     "period": "morning"
   },
   {
-    "start": "2022-12-25T19:31:21Z",
-    "asin": "B08BYBNGMW",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
     "start": "2022-12-25T23:34:11Z",
     "asin": "B08BYBNGMW",
     "wpm": 437.4088731514268,
@@ -15616,12 +10606,6 @@
     "asin": "B08BYBNGMW",
     "wpm": 680.3811967378357,
     "period": "morning"
-  },
-  {
-    "start": "2022-12-26T13:35:34Z",
-    "asin": "B08BYBNGMW",
-    "wpm": 909.090909090909,
-    "period": "evening"
   },
   {
     "start": "2022-12-26T23:25:09Z",
@@ -15702,12 +10686,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-01-02T03:39:18Z",
-    "asin": "B01HNJIJ3U",
-    "wpm": 530.035335689046,
-    "period": "morning"
-  },
-  {
     "start": "2023-01-02T04:23:15Z",
     "asin": "B01HNJIJ3U",
     "wpm": 463.0005685971895,
@@ -15741,18 +10719,6 @@
     "start": "2023-01-03T04:52:20Z",
     "asin": "B09T9D8QY7",
     "wpm": 717.6234979973298,
-    "period": "morning"
-  },
-  {
-    "start": "2023-01-03T05:08:22Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 576.9230769230769,
-    "period": "morning"
-  },
-  {
-    "start": "2023-01-03T05:09:44Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 1265.8227848101264,
     "period": "morning"
   },
   {
@@ -15816,27 +10782,9 @@
     "period": "morning"
   },
   {
-    "start": "2023-01-12T05:31:47Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 937.5,
-    "period": "morning"
-  },
-  {
-    "start": "2023-01-12T05:35:47Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 2830.188679245283,
-    "period": "morning"
-  },
-  {
     "start": "2023-01-12T05:37:12Z",
     "asin": "B0BQVLNL73",
-    "wpm": 4486.42266824085,
-    "period": "morning"
-  },
-  {
-    "start": "2023-01-12T05:50:04Z",
-    "asin": "B0BQVLNL73",
-    "wpm": 12500,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -15882,12 +10830,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-01-18T20:40:03Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 1282.051282051282,
-    "period": "evening"
-  },
-  {
     "start": "2023-01-19T05:31:59Z",
     "asin": "B003L77UKC",
     "wpm": 509.62627406568515,
@@ -15898,12 +10840,6 @@
     "asin": "B09QMHZ53K",
     "wpm": 328.1557646029315,
     "period": "morning"
-  },
-  {
-    "start": "2023-01-24T22:50:38Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 800,
-    "period": "evening"
   },
   {
     "start": "2023-01-25T00:55:25Z",
@@ -15978,22 +10914,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-01-28T05:16:24Z",
-    "asin": "B09R21YVLM",
-    "wpm": 2586.206896551724,
-    "period": "morning"
-  },
-  {
     "start": "2023-01-28T05:28:13Z",
     "asin": "B003L77UKC",
     "wpm": 971.9222462203024,
     "period": "morning"
-  },
-  {
-    "start": "2023-01-30T21:30:37Z",
-    "asin": "B003L77UKC",
-    "wpm": 1530.6122448979593,
-    "period": "evening"
   },
   {
     "start": "2023-01-31T04:34:25Z",
@@ -16017,12 +10941,6 @@
     "start": "2023-02-01T19:31:25Z",
     "asin": "B09NTK9WDQ",
     "wpm": 1107.8286558345642,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-01T19:36:35Z",
-    "asin": "B003L77UKC",
-    "wpm": 1036.2694300518135,
     "period": "evening"
   },
   {
@@ -16080,18 +10998,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-02-05T17:09:41Z",
-    "asin": "B09NTK9WDQ",
-    "wpm": 1047.1204188481677,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-05T17:10:48Z",
-    "asin": "B003L77UKC",
-    "wpm": 2272.7272727272725,
-    "period": "evening"
-  },
-  {
     "start": "2023-02-05T17:13:23Z",
     "asin": "B09NTK9WDQ",
     "wpm": 127.80790085205268,
@@ -16107,18 +11013,6 @@
     "start": "2023-02-05T20:54:56Z",
     "asin": "B09NTK9WDQ",
     "wpm": 1797.3856209150326,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-05T20:59:44Z",
-    "asin": "B09NTK9WDQ",
-    "wpm": 636.9426751592356,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-06T23:56:50Z",
-    "asin": "B09NTK9WDQ",
-    "wpm": 1500,
     "period": "evening"
   },
   {
@@ -16176,12 +11070,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-02-13T19:13:07Z",
-    "asin": "B09NTK9WDQ",
-    "wpm": 1282.051282051282,
-    "period": "evening"
-  },
-  {
     "start": "2023-02-13T19:13:44Z",
     "asin": "B09QMHZ53K",
     "wpm": 336.4389233954451,
@@ -16197,12 +11085,6 @@
     "start": "2023-02-13T19:29:01Z",
     "asin": "B09QMHZ53K",
     "wpm": 392.82440748985204,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-13T20:38:30Z",
-    "asin": "B09QMHZ53K",
-    "wpm": 1875,
     "period": "evening"
   },
   {
@@ -16244,19 +11126,13 @@
   {
     "start": "2023-02-15T05:53:28Z",
     "asin": "B09QMHZ53K",
-    "wpm": 3016.8946098149636,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2023-02-15T06:07:01Z",
     "asin": "B09NTK9WDQ",
     "wpm": 1607.5845012366035,
-    "period": "morning"
-  },
-  {
-    "start": "2023-02-15T06:11:32Z",
-    "asin": "B00PSSG4MM",
-    "wpm": 1875,
     "period": "morning"
   },
   {
@@ -16290,33 +11166,15 @@
     "period": "morning"
   },
   {
-    "start": "2023-02-20T02:26:43Z",
-    "asin": "B01COJUEZ0",
-    "wpm": 925.9259259259259,
-    "period": "morning"
-  },
-  {
     "start": "2023-02-20T02:27:03Z",
     "asin": "B01COJUEZ0",
     "wpm": 255.53662691652468,
     "period": "morning"
   },
   {
-    "start": "2023-02-20T02:29:04Z",
-    "asin": "B01COJUEZ0",
-    "wpm": 656.4551422319474,
-    "period": "morning"
-  },
-  {
     "start": "2023-02-20T02:45:20Z",
     "asin": "B01COJUEZ0",
     "wpm": 142.04545454545453,
-    "period": "morning"
-  },
-  {
-    "start": "2023-02-20T03:04:42Z",
-    "asin": "B07VDJBKNJ",
-    "wpm": 1704.5454545454545,
     "period": "morning"
   },
   {
@@ -16338,12 +11196,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-02-20T19:12:18Z",
-    "asin": "B07VDJBKNJ",
-    "wpm": 911.854103343465,
-    "period": "evening"
-  },
-  {
     "start": "2023-02-20T19:14:09Z",
     "asin": "B07VDJBKNJ",
     "wpm": 399.57378795950984,
@@ -16359,12 +11211,6 @@
     "start": "2023-02-20T19:29:32Z",
     "asin": "B07VDJBKNJ",
     "wpm": 575.6578947368421,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-20T21:39:22Z",
-    "asin": "B07VDJBKNJ",
-    "wpm": 1612.9032258064517,
     "period": "evening"
   },
   {
@@ -16389,12 +11235,6 @@
     "start": "2023-02-21T04:47:59Z",
     "asin": "B0B2F5J32D",
     "wpm": 556.2422744128554,
-    "period": "morning"
-  },
-  {
-    "start": "2023-02-21T05:09:08Z",
-    "asin": "B003L77UKC",
-    "wpm": 2307.6923076923076,
     "period": "morning"
   },
   {
@@ -16440,22 +11280,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-02-23T19:38:14Z",
-    "asin": "B003L77UKC",
-    "wpm": 1119.402985074627,
-    "period": "evening"
-  },
-  {
     "start": "2023-02-23T19:38:52Z",
     "asin": "B08KQ4W18H",
     "wpm": 263.21747990490206,
     "period": "evening"
-  },
-  {
-    "start": "2023-02-24T03:56:59Z",
-    "asin": "B08KQ4W18H",
-    "wpm": 742.5742574257425,
-    "period": "morning"
   },
   {
     "start": "2023-02-24T03:57:36Z",
@@ -16484,7 +11312,7 @@
   {
     "start": "2023-02-27T23:51:19Z",
     "asin": "B0BWMMN631",
-    "wpm": 3171.1555169417898,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -16492,12 +11320,6 @@
     "asin": "B08QXTPXPH",
     "wpm": 307.5114804286027,
     "period": "morning"
-  },
-  {
-    "start": "2023-02-28T19:24:49Z",
-    "asin": "B003L77UKC",
-    "wpm": 1048.951048951049,
-    "period": "evening"
   },
   {
     "start": "2023-02-28T19:33:16Z",
@@ -16530,18 +11352,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-02-28T21:03:31Z",
-    "asin": "B08QXTPXPH",
-    "wpm": 8333.333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-28T21:05:09Z",
-    "asin": "B08QXTPXPH",
-    "wpm": 595.2380952380953,
-    "period": "evening"
-  },
-  {
     "start": "2023-02-28T21:06:06Z",
     "asin": "B08QXTPXPH",
     "wpm": 198.93899204244033,
@@ -16557,12 +11367,6 @@
     "start": "2023-02-28T21:16:43Z",
     "asin": "B08QXTPXPH",
     "wpm": 481.7987152034261,
-    "period": "evening"
-  },
-  {
-    "start": "2023-02-28T21:18:42Z",
-    "asin": "B08QXTPXPH",
-    "wpm": 329.6703296703297,
     "period": "evening"
   },
   {
@@ -16626,12 +11430,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-03T04:17:47Z",
-    "asin": "B09NW4FN2R",
-    "wpm": 1315.7894736842104,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-03T04:18:40Z",
     "asin": "B09NW4FN2R",
     "wpm": 178.91932726332948,
@@ -16656,21 +11454,9 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-07T03:33:07Z",
-    "asin": "B09NW4FN2R",
-    "wpm": 669.6428571428571,
-    "period": "morning"
-  },
-  {
-    "start": "2023-03-07T03:36:13Z",
-    "asin": "B003L77UKC",
-    "wpm": 568.1818181818181,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-07T03:36:55Z",
     "asin": "B003L77UKC",
-    "wpm": 2371.5415019762845,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -16686,12 +11472,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-08T06:25:41Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 622.4066390041494,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-08T06:26:27Z",
     "asin": "B09N6VX4K7",
     "wpm": 243.47826086956522,
@@ -16701,18 +11481,6 @@
     "start": "2023-03-08T19:51:31Z",
     "asin": "B09JBCGQB8",
     "wpm": 354.6698192872825,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-08T20:24:44Z",
-    "asin": "B09JBCGQB8",
-    "wpm": 7500,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-08T22:10:15Z",
-    "asin": "B09N6VX4K7",
-    "wpm": 974.025974025974,
     "period": "evening"
   },
   {
@@ -16743,12 +11511,6 @@
     "start": "2023-03-09T17:47:46Z",
     "asin": "B09N6VX4K7",
     "wpm": 332.22591362126246,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-09T17:55:27Z",
-    "asin": "B09N6VX4K7",
-    "wpm": 1190.4761904761906,
     "period": "evening"
   },
   {
@@ -16932,12 +11694,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-14T04:01:28Z",
-    "asin": "B003L77UKC",
-    "wpm": 374.0648379052369,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-14T04:02:15Z",
     "asin": "B003L77UKC",
     "wpm": 1692.7083333333335,
@@ -16953,12 +11709,6 @@
     "start": "2023-03-14T04:43:22Z",
     "asin": "B09JBCGQB8",
     "wpm": 472.2481343283582,
-    "period": "morning"
-  },
-  {
-    "start": "2023-03-14T05:40:27Z",
-    "asin": "B09JBCGQB8",
-    "wpm": 627.6150627615064,
     "period": "morning"
   },
   {
@@ -17022,12 +11772,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-17T03:00:38Z",
-    "asin": "B0B3Y8DJFJ",
-    "wpm": 2777.777777777778,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-17T03:01:14Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 401.5296367112811,
@@ -17037,12 +11781,6 @@
     "start": "2023-03-17T03:14:44Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 361.34683821516563,
-    "period": "morning"
-  },
-  {
-    "start": "2023-03-17T06:39:56Z",
-    "asin": "B0B3Y8DJFJ",
-    "wpm": 549.4505494505495,
     "period": "morning"
   },
   {
@@ -17100,12 +11838,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-19T04:48:25Z",
-    "asin": "B006CUDDUG",
-    "wpm": 572.5190839694657,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-19T04:49:21Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 243.192980782986,
@@ -17115,12 +11847,6 @@
     "start": "2023-03-20T01:56:26Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 592.8853754940712,
-    "period": "morning"
-  },
-  {
-    "start": "2023-03-20T02:00:14Z",
-    "asin": "B003L77UKC",
-    "wpm": 416.6666666666667,
     "period": "morning"
   },
   {
@@ -17214,12 +11940,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-03-23T21:22:58Z",
-    "asin": "B007D1TKAU",
-    "wpm": 552.4861878453039,
-    "period": "evening"
-  },
-  {
     "start": "2023-03-23T21:24:11Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 231.69999141851883,
@@ -17238,12 +11958,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-24T20:33:55Z",
-    "asin": "B0B3Y8DJFJ",
-    "wpm": 1401.8691588785045,
-    "period": "evening"
-  },
-  {
     "start": "2023-03-24T20:38:22Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 187.52604528406724,
@@ -17253,12 +11967,6 @@
     "start": "2023-03-24T20:56:11Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 208.33333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-24T22:23:38Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 1020.4081632653061,
     "period": "evening"
   },
   {
@@ -17274,27 +11982,9 @@
     "period": "morning"
   },
   {
-    "start": "2023-03-25T15:07:55Z",
-    "asin": "B0B3Y8DJFJ",
-    "wpm": 937.5,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-25T18:14:28Z",
-    "asin": "B07MXCRB2F",
-    "wpm": 4245.2830188679245,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-25T18:29:08Z",
-    "asin": "B0B3Y8DJFJ",
-    "wpm": 1219.5121951219512,
-    "period": "evening"
-  },
-  {
     "start": "2023-03-25T18:29:52Z",
     "asin": "B007D1TKAU",
-    "wpm": 2059.6711307001187,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -17319,12 +12009,6 @@
     "start": "2023-03-27T03:59:09Z",
     "asin": "B09RTYQW2S",
     "wpm": 400.5696991276482,
-    "period": "morning"
-  },
-  {
-    "start": "2023-03-29T02:35:39Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 862.0689655172414,
     "period": "morning"
   },
   {
@@ -17364,24 +12048,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-03-29T21:13:40Z",
-    "asin": "B0B3989NDF",
-    "wpm": 530.035335689046,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-30T03:46:52Z",
-    "asin": "B07MXCRB2F",
-    "wpm": 5555.555555555556,
-    "period": "morning"
-  },
-  {
-    "start": "2023-03-30T03:47:26Z",
-    "asin": "B0BWMMN631",
-    "wpm": 8260.869565217392,
-    "period": "morning"
-  },
-  {
     "start": "2023-03-30T05:08:15Z",
     "asin": "B0B3Y8DJFJ",
     "wpm": 319.55688112484023,
@@ -17410,30 +12076,6 @@
     "asin": "B0B1Y1ZKFX",
     "wpm": 208.00316957210777,
     "period": "morning"
-  },
-  {
-    "start": "2023-03-31T16:16:32Z",
-    "asin": "B075SPBQDV",
-    "wpm": 3296.7032967032965,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-31T20:09:27Z",
-    "asin": "B075SPBQDV",
-    "wpm": 75000,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-31T20:09:28Z",
-    "asin": "B075SPBQDV",
-    "wpm": 10489.510489510489,
-    "period": "evening"
-  },
-  {
-    "start": "2023-03-31T20:58:10Z",
-    "asin": "B0B1Y1ZKFX",
-    "wpm": 597.609561752988,
-    "period": "evening"
   },
   {
     "start": "2023-03-31T20:59:03Z",
@@ -17484,18 +12126,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-03T02:24:28Z",
-    "asin": "B075SPBQDV",
-    "wpm": 7317.073170731708,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-03T02:25:13Z",
-    "asin": "B075SPBQDV",
-    "wpm": 21428.571428571428,
-    "period": "morning"
-  },
-  {
     "start": "2023-04-03T04:02:25Z",
     "asin": "B075SPBQDV",
     "wpm": 272.2213260203259,
@@ -17516,7 +12146,7 @@
   {
     "start": "2023-04-04T02:03:48Z",
     "asin": "B07HB5DKQX",
-    "wpm": 3257.6505429417575,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -17524,12 +12154,6 @@
     "asin": "B07HB5DKQX",
     "wpm": 237.33021761355337,
     "period": "morning"
-  },
-  {
-    "start": "2023-04-04T23:11:49Z",
-    "asin": "B075SPBQDV",
-    "wpm": 2884.6153846153843,
-    "period": "evening"
   },
   {
     "start": "2023-04-04T23:12:27Z",
@@ -17542,18 +12166,6 @@
     "asin": "B07HB5DKQX",
     "wpm": 358.85167464114835,
     "period": "evening"
-  },
-  {
-    "start": "2023-04-05T00:15:04Z",
-    "asin": "B07HB5DKQX",
-    "wpm": 5555.555555555556,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-05T03:24:18Z",
-    "asin": "B07HB5DKQX",
-    "wpm": 737.1007371007371,
-    "period": "morning"
   },
   {
     "start": "2023-04-05T04:28:15Z",
@@ -17610,22 +12222,10 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-09T23:05:46Z",
-    "asin": "B004HW7DZ2",
-    "wpm": 833.3333333333334,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-09T23:14:17Z",
     "asin": "B000U913EI",
     "wpm": 411.52263374485597,
     "period": "evening"
-  },
-  {
-    "start": "2023-04-10T02:50:41Z",
-    "asin": "B000U913EI",
-    "wpm": 898.2035928143713,
-    "period": "morning"
   },
   {
     "start": "2023-04-10T02:51:20Z",
@@ -17670,15 +12270,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-10T23:43:46Z",
-    "asin": "B0B3HPSFJ7",
-    "wpm": 1376.1467889908256,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-10T23:44:25Z",
     "asin": "B087BQ7GK3",
-    "wpm": 4277.524621490519,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -17694,33 +12288,15 @@
     "period": "morning"
   },
   {
-    "start": "2023-04-11T03:08:10Z",
-    "asin": "B000U913EI",
-    "wpm": 4285.714285714285,
-    "period": "morning"
-  },
-  {
     "start": "2023-04-11T03:22:47Z",
     "asin": "B000U913EI",
     "wpm": 210.87680355160933,
     "period": "morning"
   },
   {
-    "start": "2023-04-12T00:28:27Z",
-    "asin": "B000U913EI",
-    "wpm": 349.65034965034965,
-    "period": "morning"
-  },
-  {
     "start": "2023-04-12T00:30:07Z",
     "asin": "B000U913EI",
     "wpm": 242.19380713039402,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-12T03:46:16Z",
-    "asin": "B000U913EI",
-    "wpm": 1190.4761904761906,
     "period": "morning"
   },
   {
@@ -17742,22 +12318,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-04-12T13:22:50Z",
-    "asin": "B000U913EI",
-    "wpm": 1351.3513513513515,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-13T04:09:35Z",
     "asin": "B000U913EI",
     "wpm": 298.2588134135856,
     "period": "morning"
-  },
-  {
-    "start": "2023-04-13T17:05:59Z",
-    "asin": "B000U913EI",
-    "wpm": 2027.027027027027,
-    "period": "evening"
   },
   {
     "start": "2023-04-13T18:08:06Z",
@@ -17808,12 +12372,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-04-14T02:03:58Z",
-    "asin": "B0B1BTJLJN",
-    "wpm": 7317.073170731707,
-    "period": "morning"
-  },
-  {
     "start": "2023-04-14T02:39:09Z",
     "asin": "B0B1BTJLJN",
     "wpm": 360.082304526749,
@@ -17828,7 +12386,7 @@
   {
     "start": "2023-04-14T17:57:19Z",
     "asin": "B0B1BTJLJN",
-    "wpm": 2672.8439059158945,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -17838,21 +12396,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-14T18:22:27Z",
-    "asin": "B0B1BTJLJN",
-    "wpm": 4838.709677419355,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-14T18:24:11Z",
     "asin": "B0B1BTJLJN",
     "wpm": 337.07865168539325,
-    "period": "evening"
-  },
-  {
-    "start": "2023-04-14T18:49:28Z",
-    "asin": "B0B1BTJLJN",
-    "wpm": 9375,
     "period": "evening"
   },
   {
@@ -17874,12 +12420,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-14T19:51:26Z",
-    "asin": "B0B1BTJLJN",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-14T19:52:04Z",
     "asin": "B0B1BTJLJN",
     "wpm": 879.7054009819967,
@@ -17895,12 +12435,6 @@
     "start": "2023-04-14T20:12:40Z",
     "asin": "B0B1BTJLJN",
     "wpm": 719.355457510071,
-    "period": "evening"
-  },
-  {
-    "start": "2023-04-14T20:22:36Z",
-    "asin": "B0B1BTJLJN",
-    "wpm": 18750,
     "period": "evening"
   },
   {
@@ -17970,18 +12504,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-04-19T19:06:34Z",
-    "asin": "B000U913EI",
-    "wpm": 1351.3513513513515,
-    "period": "evening"
-  },
-  {
-    "start": "2023-04-19T19:07:29Z",
-    "asin": "B000U913EI",
-    "wpm": 574.7126436781609,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-19T19:08:52Z",
     "asin": "B000U913EI",
     "wpm": 100,
@@ -18036,24 +12558,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-22T03:55:09Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 543.4782608695652,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-22T03:56:35Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 588.2352941176471,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-23T04:47:09Z",
-    "asin": "B000U913EI",
-    "wpm": 1875,
-    "period": "morning"
-  },
-  {
     "start": "2023-04-23T04:47:27Z",
     "asin": "B003L77UKC",
     "wpm": 1474.7191011235955,
@@ -18063,18 +12567,6 @@
     "start": "2023-04-23T04:51:12Z",
     "asin": "B000U913EI",
     "wpm": 144.81305950500266,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-24T03:08:04Z",
-    "asin": "B000U913EI",
-    "wpm": 420.1680672268908,
-    "period": "morning"
-  },
-  {
-    "start": "2023-04-24T03:09:40Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 943.3962264150942,
     "period": "morning"
   },
   {
@@ -18088,12 +12580,6 @@
     "asin": "B0B6Z3LN2D",
     "wpm": 343.69271788035326,
     "period": "morning"
-  },
-  {
-    "start": "2023-04-24T16:01:35Z",
-    "asin": "B0B6Z3LN2D",
-    "wpm": 1546.3917525773197,
-    "period": "evening"
   },
   {
     "start": "2023-04-24T22:33:18Z",
@@ -18168,22 +12654,10 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-27T22:14:49Z",
-    "asin": "B0B6Z3LN2D",
-    "wpm": 903.6144578313252,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-27T22:15:36Z",
     "asin": "B0B6Z3LN2D",
     "wpm": 520.8333333333333,
     "period": "evening"
-  },
-  {
-    "start": "2023-04-28T03:38:29Z",
-    "asin": "B0B6Z4SVTH",
-    "wpm": 2406.4171122994653,
-    "period": "morning"
   },
   {
     "start": "2023-04-28T03:39:39Z",
@@ -18198,15 +12672,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-04-28T19:53:44Z",
-    "asin": "B0B6Z4SVTH",
-    "wpm": 2479.3388429752067,
-    "period": "evening"
-  },
-  {
     "start": "2023-04-28T19:54:15Z",
     "asin": "B0C3QHMLGL",
-    "wpm": 8455.882352941177,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -18219,12 +12687,6 @@
     "start": "2023-04-28T22:49:29Z",
     "asin": "B0B6Z4SVTH",
     "wpm": 241.35156878519712,
-    "period": "evening"
-  },
-  {
-    "start": "2023-04-30T21:03:41Z",
-    "asin": "B09RTYQW2S",
-    "wpm": 1744.1860465116279,
     "period": "evening"
   },
   {
@@ -18255,12 +12717,6 @@
     "start": "2023-05-02T01:20:28Z",
     "asin": "B084357H23",
     "wpm": 301.5729096858123,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-02T01:24:45Z",
-    "asin": "B084357H23",
-    "wpm": 8064.5161290322585,
     "period": "morning"
   },
   {
@@ -18354,18 +12810,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-05-08T17:26:42Z",
-    "asin": "B003L77UKC",
-    "wpm": 10714.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2023-05-08T17:26:59Z",
-    "asin": "B003L77UKC",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
     "start": "2023-05-08T17:27:31Z",
     "asin": "B003L77UKC",
     "wpm": 111.74016686531584,
@@ -18408,21 +12852,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-05-11T02:50:28Z",
-    "asin": "B0BBCB6PFC",
-    "wpm": 1327.4336283185842,
-    "period": "morning"
-  },
-  {
     "start": "2023-05-11T02:51:11Z",
     "asin": "B09GW3P1KJ",
     "wpm": 312.6085446335533,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-12T02:39:16Z",
-    "asin": "B09GW3P1KJ",
-    "wpm": 852.2727272727273,
     "period": "morning"
   },
   {
@@ -18436,12 +12868,6 @@
     "asin": "B09XL59MJX",
     "wpm": 177.3632004204165,
     "period": "morning"
-  },
-  {
-    "start": "2023-05-12T15:46:42Z",
-    "asin": "B09XL59MJX",
-    "wpm": 491.80327868852464,
-    "period": "evening"
   },
   {
     "start": "2023-05-12T15:47:15Z",
@@ -18510,12 +12936,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-05-14T17:42:05Z",
-    "asin": "B09XL59MJX",
-    "wpm": 1304.3478260869565,
-    "period": "evening"
-  },
-  {
     "start": "2023-05-14T18:00:33Z",
     "asin": "B09XL59MJX",
     "wpm": 542.968226303794,
@@ -18525,12 +12945,6 @@
     "start": "2023-05-14T18:13:24Z",
     "asin": "B09XL59MJX",
     "wpm": 336.0716952949963,
-    "period": "evening"
-  },
-  {
-    "start": "2023-05-14T18:15:39Z",
-    "asin": "B09XL59MJX",
-    "wpm": 4687.5,
     "period": "evening"
   },
   {
@@ -18555,24 +12969,6 @@
     "start": "2023-05-15T02:32:17Z",
     "asin": "B09XL59MJX",
     "wpm": 450.59753150917516,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-15T02:57:56Z",
-    "asin": "B003L77UKC",
-    "wpm": 1700.6802721088436,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-15T03:07:59Z",
-    "asin": "B09XL59MJX",
-    "wpm": 2884.6153846153843,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-15T03:09:13Z",
-    "asin": "B09GW3P1KJ",
-    "wpm": 3846.153846153846,
     "period": "morning"
   },
   {
@@ -18610,12 +13006,6 @@
     "asin": "B09Y46DSD7",
     "wpm": 240.1921537229784,
     "period": "morning"
-  },
-  {
-    "start": "2023-05-16T20:43:46Z",
-    "asin": "B003L77UKC",
-    "wpm": 2571.428571428571,
-    "period": "evening"
   },
   {
     "start": "2023-05-16T20:44:17Z",
@@ -18657,18 +13047,6 @@
     "start": "2023-05-18T04:17:33Z",
     "asin": "B08D4QJRY2",
     "wpm": 162.38159675236807,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-20T03:43:35Z",
-    "asin": "B08D4QJRY2",
-    "wpm": 678.7330316742082,
-    "period": "morning"
-  },
-  {
-    "start": "2023-05-20T03:44:31Z",
-    "asin": "B003L77UKC",
-    "wpm": 1401.8691588785045,
     "period": "morning"
   },
   {
@@ -18806,25 +13184,13 @@
   {
     "start": "2023-05-27T18:04:31Z",
     "asin": "B0B3Y4RYX6",
-    "wpm": 4952.830188679245,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2023-05-27T18:07:06Z",
     "asin": "B098433CGQ",
     "wpm": 200.09528346831823,
-    "period": "evening"
-  },
-  {
-    "start": "2023-05-27T19:44:07Z",
-    "asin": "B098433CGQ",
-    "wpm": 585.9375,
-    "period": "evening"
-  },
-  {
-    "start": "2023-05-27T22:34:02Z",
-    "asin": "B098433CGQ",
-    "wpm": 1546.3917525773197,
     "period": "evening"
   },
   {
@@ -18888,12 +13254,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-05-29T17:17:56Z",
-    "asin": "B08PG6CKZJ",
-    "wpm": 2083.3333333333335,
-    "period": "evening"
-  },
-  {
     "start": "2023-06-03T03:25:42Z",
     "asin": "B0B5SR4KBR",
     "wpm": 300.2001334222815,
@@ -18924,34 +13284,16 @@
     "period": "morning"
   },
   {
-    "start": "2023-06-07T19:05:10Z",
-    "asin": "B09XBGYWSR",
-    "wpm": 50000,
-    "period": "evening"
-  },
-  {
     "start": "2023-06-07T19:05:19Z",
     "asin": "B09XBGYWSR",
     "wpm": 198.22541060977912,
     "period": "evening"
   },
   {
-    "start": "2023-06-08T01:09:32Z",
-    "asin": "B09XBGYWSR",
-    "wpm": 669.6428571428571,
-    "period": "morning"
-  },
-  {
     "start": "2023-06-08T03:33:45Z",
     "asin": "B09XBGYWSR",
     "wpm": 164.37882108663052,
     "period": "morning"
-  },
-  {
-    "start": "2023-06-08T21:27:15Z",
-    "asin": "B09XBGYWSR",
-    "wpm": 2267.002518891688,
-    "period": "evening"
   },
   {
     "start": "2023-06-08T21:37:46Z",
@@ -18996,22 +13338,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-06-12T03:22:50Z",
-    "asin": "B09XBGYWSR",
-    "wpm": 1321.5859030837003,
-    "period": "morning"
-  },
-  {
     "start": "2023-06-12T03:23:26Z",
     "asin": "B000GCFX6S",
     "wpm": 105.94521557548212,
     "period": "morning"
-  },
-  {
-    "start": "2023-06-12T18:48:24Z",
-    "asin": "B000GCFX6S",
-    "wpm": 21428.571428571428,
-    "period": "evening"
   },
   {
     "start": "2023-06-12T18:49:44Z",
@@ -19023,24 +13353,6 @@
     "start": "2023-06-12T19:03:21Z",
     "asin": "B000GCFX6S",
     "wpm": 34.94874184529357,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-12T19:11:13Z",
-    "asin": "B000GCFX6S",
-    "wpm": 731.7073170731708,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-12T19:34:13Z",
-    "asin": "B000GCFX6S",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-12T19:52:36Z",
-    "asin": "B000GCFX6S",
-    "wpm": 7500,
     "period": "evening"
   },
   {
@@ -19068,12 +13380,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-06-14T03:43:14Z",
-    "asin": "B0BBCB6PFC",
-    "wpm": 882.3529411764706,
-    "period": "morning"
-  },
-  {
     "start": "2023-06-14T03:45:09Z",
     "asin": "B000GCFX6S",
     "wpm": 239.32987634623055,
@@ -19098,21 +13404,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-06-14T20:40:33Z",
-    "asin": "B0BHCXVWGT",
-    "wpm": 4166.666666666667,
-    "period": "evening"
-  },
-  {
     "start": "2023-06-14T20:40:38Z",
     "asin": "B0BHCXVWGT",
     "wpm": 167.41071428571428,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-14T20:43:13Z",
-    "asin": "B0BHCXVWGT",
-    "wpm": 515.4639175257732,
     "period": "evening"
   },
   {
@@ -19125,18 +13419,6 @@
     "start": "2023-06-14T22:23:21Z",
     "asin": "B0BHCXVWGT",
     "wpm": 426.8639726807058,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-14T22:26:42Z",
-    "asin": "B0BHCXVWGT",
-    "wpm": 868.7258687258687,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-14T23:01:56Z",
-    "asin": "B000GCFX6S",
-    "wpm": 1006.7114093959732,
     "period": "evening"
   },
   {
@@ -19224,12 +13506,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-06-20T03:05:00Z",
-    "asin": "B0BHCXVWGT",
-    "wpm": 1102.9411764705883,
-    "period": "morning"
-  },
-  {
     "start": "2023-06-20T03:05:48Z",
     "asin": "B000GCFX6S",
     "wpm": 264.6085997794928,
@@ -19240,12 +13516,6 @@
     "asin": "B000GCFX6S",
     "wpm": 321.37118371719333,
     "period": "morning"
-  },
-  {
-    "start": "2023-06-21T17:27:26Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 6428.571428571428,
-    "period": "evening"
   },
   {
     "start": "2023-06-21T17:28:04Z",
@@ -19266,12 +13536,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-06-21T19:11:24Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
     "start": "2023-06-21T19:50:34Z",
     "asin": "B0BHTN6TL6",
     "wpm": 223.7136465324385,
@@ -19284,28 +13548,10 @@
     "period": "evening"
   },
   {
-    "start": "2023-06-22T02:57:33Z",
-    "asin": "B000GCFX6S",
-    "wpm": 1136.3636363636363,
-    "period": "morning"
-  },
-  {
     "start": "2023-06-22T02:58:26Z",
     "asin": "B0BHTN6TL6",
     "wpm": 288.2709747162333,
     "period": "morning"
-  },
-  {
-    "start": "2023-06-22T20:37:59Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 1515.151515151515,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-22T22:39:06Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 1530.6122448979593,
-    "period": "evening"
   },
   {
     "start": "2023-06-22T22:40:09Z",
@@ -19350,12 +13596,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-06-24T13:07:23Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 1764.7058823529412,
-    "period": "evening"
-  },
-  {
     "start": "2023-06-25T03:30:01Z",
     "asin": "B0BHTN6TL6",
     "wpm": 229.31572188589251,
@@ -19371,18 +13611,6 @@
     "start": "2023-06-26T19:58:03Z",
     "asin": "B0BHTN6TL6",
     "wpm": 274.66937945066127,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-26T19:58:11Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 0,
-    "period": "evening"
-  },
-  {
-    "start": "2023-06-26T20:36:22Z",
-    "asin": "B0BHTN6TL6",
-    "wpm": 1515.151515151515,
     "period": "evening"
   },
   {
@@ -19524,18 +13752,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-07-05T02:07:01Z",
-    "asin": "B016TG0SAK",
-    "wpm": 7563.0252100840335,
-    "period": "morning"
-  },
-  {
-    "start": "2023-07-05T02:14:43Z",
-    "asin": "B000GCFX6S",
-    "wpm": 1648.3516483516482,
-    "period": "morning"
-  },
-  {
     "start": "2023-07-05T02:16:56Z",
     "asin": "B09Y94K74X",
     "wpm": 24.777006937561943,
@@ -19584,12 +13800,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-07-07T19:16:55Z",
-    "asin": "B09Y94K74X",
-    "wpm": 1086.9565217391305,
-    "period": "evening"
-  },
-  {
     "start": "2023-07-07T19:20:22Z",
     "asin": "B09Y94K74X",
     "wpm": 275.11121517209085,
@@ -19628,7 +13838,7 @@
   {
     "start": "2023-07-14T02:49:10Z",
     "asin": "B09Y94K74X",
-    "wpm": 4394.69320066335,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -19806,12 +14016,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-07-26T03:54:16Z",
-    "asin": "B084G9Z5C3",
-    "wpm": 1562.5,
-    "period": "morning"
-  },
-  {
     "start": "2023-07-26T03:54:37Z",
     "asin": "B084G9Z5C3",
     "wpm": 331.0344827586207,
@@ -19821,18 +14025,6 @@
     "start": "2023-07-26T20:29:04Z",
     "asin": "B084G9Z5C3",
     "wpm": 322.9278794402583,
-    "period": "evening"
-  },
-  {
-    "start": "2023-07-26T20:35:25Z",
-    "asin": "B0BH4QWM85",
-    "wpm": 1351.3513513513515,
-    "period": "evening"
-  },
-  {
-    "start": "2023-07-26T20:35:38Z",
-    "asin": "B0BH4QWM85",
-    "wpm": 1648.3516483516482,
     "period": "evening"
   },
   {
@@ -19858,12 +14050,6 @@
     "asin": "B084G9Z5C3",
     "wpm": 326.3734884304783,
     "period": "morning"
-  },
-  {
-    "start": "2023-07-28T18:41:25Z",
-    "asin": "B084G9Z5C3",
-    "wpm": 1704.5454545454545,
-    "period": "evening"
   },
   {
     "start": "2023-07-29T01:21:20Z",
@@ -19962,12 +14148,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-08-04T04:10:55Z",
-    "asin": "B084G9Z5C3",
-    "wpm": 2054.794520547945,
-    "period": "morning"
-  },
-  {
     "start": "2023-08-04T04:19:16Z",
     "asin": "B0BH4QWM85",
     "wpm": 429.72480250021704,
@@ -20016,12 +14196,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-08-07T21:37:47Z",
-    "asin": "B0BH4QWM85",
-    "wpm": 1162.7906976744187,
-    "period": "evening"
-  },
-  {
     "start": "2023-08-07T21:38:19Z",
     "asin": "B0BH4QWM85",
     "wpm": 148.16810344827587,
@@ -20064,22 +14238,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-08-10T21:55:31Z",
-    "asin": "B0BL126WSH",
-    "wpm": 967.7419354838709,
-    "period": "evening"
-  },
-  {
     "start": "2023-08-11T03:54:20Z",
     "asin": "B0BL126WSH",
     "wpm": 283.9643652561247,
     "period": "morning"
-  },
-  {
-    "start": "2023-08-11T20:34:35Z",
-    "asin": "B0BL126WSH",
-    "wpm": 746.2686567164179,
-    "period": "evening"
   },
   {
     "start": "2023-08-11T20:36:07Z",
@@ -20190,12 +14352,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-08-23T03:14:53Z",
-    "asin": "B000GCFX6S",
-    "wpm": 1293.103448275862,
-    "period": "morning"
-  },
-  {
     "start": "2023-08-23T03:15:38Z",
     "asin": "B0BGJ3W5D3",
     "wpm": 574.642748555792,
@@ -20258,7 +14414,7 @@
   {
     "start": "2023-08-26T04:01:00Z",
     "asin": "B000GCFX6S",
-    "wpm": 2164.5021645021643,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -20286,30 +14442,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-08-28T17:49:55Z",
-    "asin": "B093R2CP2V",
-    "wpm": 2678.5714285714284,
-    "period": "evening"
-  },
-  {
-    "start": "2023-08-28T17:50:04Z",
-    "asin": "B093R2CP2V",
-    "wpm": 13235.29411764706,
-    "period": "evening"
-  },
-  {
-    "start": "2023-08-28T17:50:43Z",
-    "asin": "B092T947PJ",
-    "wpm": 1515.151515151515,
-    "period": "evening"
-  },
-  {
-    "start": "2023-08-28T17:51:47Z",
-    "asin": "B0BHY38ZPH",
-    "wpm": 3797.4683544303803,
-    "period": "evening"
-  },
-  {
     "start": "2023-08-28T17:52:22Z",
     "asin": "B092T947PJ",
     "wpm": 556.4715581203628,
@@ -20332,12 +14464,6 @@
     "asin": "B093R2CP2V",
     "wpm": 171.5658240878417,
     "period": "evening"
-  },
-  {
-    "start": "2023-08-31T03:10:52Z",
-    "asin": "B093R2CP2V",
-    "wpm": 641.025641025641,
-    "period": "morning"
   },
   {
     "start": "2023-08-31T03:11:40Z",
@@ -20412,22 +14538,10 @@
     "period": "evening"
   },
   {
-    "start": "2023-09-04T01:03:45Z",
-    "asin": "B0BLY7J9DC",
-    "wpm": 5172.413793103448,
-    "period": "morning"
-  },
-  {
     "start": "2023-09-04T02:57:42Z",
     "asin": "B0BLY7J9DC",
     "wpm": 372.0115075559671,
     "period": "morning"
-  },
-  {
-    "start": "2023-09-04T16:15:41Z",
-    "asin": "B0BLY7J9DC",
-    "wpm": 655.0218340611353,
-    "period": "evening"
   },
   {
     "start": "2023-09-04T16:16:42Z",
@@ -20490,12 +14604,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-09-07T17:59:14Z",
-    "asin": "B0BBC769LV",
-    "wpm": 506.7567567567568,
-    "period": "evening"
-  },
-  {
     "start": "2023-09-07T19:23:13Z",
     "asin": "B0BBC769LV",
     "wpm": 24.626498111968477,
@@ -20532,21 +14640,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-09-14T03:27:49Z",
-    "asin": "B0BKKVQPLB",
-    "wpm": 1111.111111111111,
-    "period": "morning"
-  },
-  {
     "start": "2023-09-14T03:28:34Z",
     "asin": "B09721CTG1",
     "wpm": 351.6174402250351,
-    "period": "morning"
-  },
-  {
-    "start": "2023-09-16T03:03:35Z",
-    "asin": "B09721CTG1",
-    "wpm": 1415.0943396226414,
     "period": "morning"
   },
   {
@@ -20670,12 +14766,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-09-25T02:55:55Z",
-    "asin": "B0BJNKTFGH",
-    "wpm": 3185.3281853281856,
-    "period": "morning"
-  },
-  {
     "start": "2023-09-25T02:57:04Z",
     "asin": "B0BQLKNTYR",
     "wpm": 24.979184013322232,
@@ -20736,12 +14826,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-09-28T01:24:36Z",
-    "asin": "B0BQLKNTYR",
-    "wpm": 551.4705882352941,
-    "period": "morning"
-  },
-  {
     "start": "2023-09-28T03:54:25Z",
     "asin": "B0BQLKNTYR",
     "wpm": 482.3151125401929,
@@ -20751,18 +14835,6 @@
     "start": "2023-09-28T03:58:21Z",
     "asin": "B0BQLKNTYR",
     "wpm": 358.60655737704917,
-    "period": "morning"
-  },
-  {
-    "start": "2023-09-28T04:08:17Z",
-    "asin": "B0BJNKTFGH",
-    "wpm": 660.7929515418501,
-    "period": "morning"
-  },
-  {
-    "start": "2023-09-28T04:09:22Z",
-    "asin": "B0BJNKTFGH",
-    "wpm": 1485.148514851485,
     "period": "morning"
   },
   {
@@ -20776,12 +14848,6 @@
     "asin": "B0BJNKTFGH",
     "wpm": 123.39754575992322,
     "period": "morning"
-  },
-  {
-    "start": "2023-09-28T12:58:02Z",
-    "asin": "B0BJNKTFGH",
-    "wpm": 694.4444444444445,
-    "period": "evening"
   },
   {
     "start": "2023-09-28T21:23:13Z",
@@ -20835,18 +14901,6 @@
     "start": "2023-10-01T00:52:48Z",
     "asin": "B0BQLKNTYR",
     "wpm": 25,
-    "period": "morning"
-  },
-  {
-    "start": "2023-10-01T01:32:52Z",
-    "asin": "B0BQLKNTYR",
-    "wpm": 967.7419354838709,
-    "period": "morning"
-  },
-  {
-    "start": "2023-10-01T01:36:44Z",
-    "asin": "B09721CTG1",
-    "wpm": 1020.4081632653061,
     "period": "morning"
   },
   {
@@ -20964,33 +15018,15 @@
     "period": "evening"
   },
   {
-    "start": "2023-10-07T01:15:45Z",
-    "asin": "B0BBC9K8C3",
-    "wpm": 2586.206896551724,
-    "period": "morning"
-  },
-  {
     "start": "2023-10-07T03:33:45Z",
     "asin": "B0BP66G6B7",
     "wpm": 317.79661016949154,
     "period": "morning"
   },
   {
-    "start": "2023-10-07T03:35:48Z",
-    "asin": "B0BP66G6B7",
-    "wpm": 1807.2289156626505,
-    "period": "morning"
-  },
-  {
     "start": "2023-10-07T03:36:09Z",
     "asin": "B0BBC9K8C3",
     "wpm": 283.0570157703194,
-    "period": "morning"
-  },
-  {
-    "start": "2023-10-07T03:39:37Z",
-    "asin": "B0BBC9K8C3",
-    "wpm": 3846.153846153846,
     "period": "morning"
   },
   {
@@ -21006,12 +15042,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-10-11T00:37:23Z",
-    "asin": "B0BKKVQPLB",
-    "wpm": 1428.5714285714287,
-    "period": "morning"
-  },
-  {
     "start": "2023-10-11T00:42:54Z",
     "asin": "B0CBW58P3J",
     "wpm": 194.36997319034853,
@@ -21021,12 +15051,6 @@
     "start": "2023-10-11T21:09:41Z",
     "asin": "B0CBW58P3J",
     "wpm": 345.46292031321974,
-    "period": "evening"
-  },
-  {
-    "start": "2023-10-11T21:15:15Z",
-    "asin": "B09RMQJCZJ",
-    "wpm": 2941.1764705882356,
     "period": "evening"
   },
   {
@@ -21048,12 +15072,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-10-12T05:50:57Z",
-    "asin": "B0CBW58P3J",
-    "wpm": 321.19914346895075,
-    "period": "morning"
-  },
-  {
     "start": "2023-10-12T05:51:46Z",
     "asin": "B0CBW58P3J",
     "wpm": 312.3140987507436,
@@ -21066,45 +15084,15 @@
     "period": "morning"
   },
   {
-    "start": "2023-10-12T16:51:29Z",
-    "asin": "B09RMQJCZJ",
-    "wpm": 2027.027027027027,
-    "period": "evening"
-  },
-  {
-    "start": "2023-10-12T16:52:31Z",
-    "asin": "B004HW7DZ2",
-    "wpm": 6701.030927835051,
-    "period": "evening"
-  },
-  {
-    "start": "2023-10-12T16:53:35Z",
-    "asin": "B09BV2JNWV",
-    "wpm": 1477.832512315271,
-    "period": "evening"
-  },
-  {
     "start": "2023-10-12T16:54:02Z",
     "asin": "B004HW7DZ2",
     "wpm": 127.8772378516624,
     "period": "evening"
   },
   {
-    "start": "2023-10-12T16:56:02Z",
-    "asin": "B09BV2JNWV",
-    "wpm": 1785.7142857142856,
-    "period": "evening"
-  },
-  {
     "start": "2023-10-12T19:00:54Z",
     "asin": "B09BV2JNWV",
     "wpm": 194.42644199611146,
-    "period": "evening"
-  },
-  {
-    "start": "2023-10-12T19:06:05Z",
-    "asin": "B09BV2JNWV",
-    "wpm": 3947.368421052631,
     "period": "evening"
   },
   {
@@ -21153,12 +15141,6 @@
     "start": "2023-10-19T03:55:20Z",
     "asin": "B09BV2JNWV",
     "wpm": 284.0012622278321,
-    "period": "morning"
-  },
-  {
-    "start": "2023-10-19T04:12:34Z",
-    "asin": "B09RMQJCZJ",
-    "wpm": 797.8723404255319,
     "period": "morning"
   },
   {
@@ -21228,28 +15210,10 @@
     "period": "evening"
   },
   {
-    "start": "2023-10-24T03:06:09Z",
-    "asin": "B0BP6S1S57",
-    "wpm": 5172.413793103448,
-    "period": "morning"
-  },
-  {
-    "start": "2023-10-24T03:06:13Z",
-    "asin": "B0BP6S1S57",
-    "wpm": 1333.3333333333333,
-    "period": "morning"
-  },
-  {
     "start": "2023-10-24T03:21:39Z",
     "asin": "B0BP6S1S57",
     "wpm": 423.8143289606458,
     "period": "morning"
-  },
-  {
-    "start": "2023-10-24T13:34:07Z",
-    "asin": "B0BP6S1S57",
-    "wpm": 1470.5882352941176,
-    "period": "evening"
   },
   {
     "start": "2023-10-26T04:23:31Z",
@@ -21318,12 +15282,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-11-01T00:21:48Z",
-    "asin": "B0B9KVXCQ6",
-    "wpm": 1181.1023622047244,
-    "period": "morning"
-  },
-  {
     "start": "2023-11-01T00:22:08Z",
     "asin": "B0CHWJCN94",
     "wpm": 400.5340453938585,
@@ -21372,12 +15330,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-11-03T03:19:46Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 3191.4893617021276,
-    "period": "morning"
-  },
-  {
     "start": "2023-11-03T03:19:55Z",
     "asin": "B0BPX7SF89",
     "wpm": 298.4846165620695,
@@ -21414,27 +15366,9 @@
     "period": "morning"
   },
   {
-    "start": "2023-11-06T20:58:58Z",
-    "asin": "B0BPX7SF89",
-    "wpm": 12078.651685393259,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-06T22:53:28Z",
-    "asin": "B0BPX7SF89",
-    "wpm": 1562.5,
-    "period": "evening"
-  },
-  {
     "start": "2023-11-06T22:54:33Z",
     "asin": "B07CWDMQ45",
     "wpm": 357.40695094897706,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-06T23:41:53Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 931.6770186335405,
     "period": "evening"
   },
   {
@@ -21450,39 +15384,9 @@
     "period": "morning"
   },
   {
-    "start": "2023-11-08T18:57:57Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 4377.4319066147855,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-08T19:05:34Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 6000,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-08T20:21:40Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 2439.0243902439024,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-08T20:21:55Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 3529.4117647058824,
-    "period": "evening"
-  },
-  {
     "start": "2023-11-09T04:35:10Z",
     "asin": "B07CWDMQ45",
     "wpm": 193.12475859405174,
-    "period": "morning"
-  },
-  {
-    "start": "2023-11-11T03:46:59Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 1229.5081967213114,
     "period": "morning"
   },
   {
@@ -21502,12 +15406,6 @@
     "asin": "B0BR511292",
     "wpm": 303.2187840149277,
     "period": "morning"
-  },
-  {
-    "start": "2023-11-11T13:10:59Z",
-    "asin": "B07CWDMQ45",
-    "wpm": 6521.739130434783,
-    "period": "evening"
   },
   {
     "start": "2023-11-12T21:37:25Z",
@@ -21558,18 +15456,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-11-14T13:26:14Z",
-    "asin": "B0BR511292",
-    "wpm": 1382.4884792626726,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-14T13:29:36Z",
-    "asin": "B0BR511292",
-    "wpm": 1111.111111111111,
-    "period": "evening"
-  },
-  {
     "start": "2023-11-15T03:57:16Z",
     "asin": "B006CUDDUG",
     "wpm": 312.3915307185005,
@@ -21618,28 +15504,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-11-22T03:26:49Z",
-    "asin": "B0BR511292",
-    "wpm": 5000,
-    "period": "morning"
-  },
-  {
     "start": "2023-11-22T03:30:59Z",
     "asin": "B09YRR8DB6",
     "wpm": 262.9901179470832,
     "period": "morning"
-  },
-  {
-    "start": "2023-11-22T17:59:50Z",
-    "asin": "B09YRR8DB6",
-    "wpm": 3000,
-    "period": "evening"
-  },
-  {
-    "start": "2023-11-22T18:00:03Z",
-    "asin": "B09YRR8DB6",
-    "wpm": 5263.157894736842,
-    "period": "evening"
   },
   {
     "start": "2023-11-22T21:59:36Z",
@@ -21658,12 +15526,6 @@
     "asin": "B09YRR8DB6",
     "wpm": 380.95238095238096,
     "period": "evening"
-  },
-  {
-    "start": "2023-11-27T05:46:34Z",
-    "asin": "B0BR511292",
-    "wpm": 570.3422053231939,
-    "period": "morning"
   },
   {
     "start": "2023-11-27T21:50:46Z",
@@ -21687,12 +15549,6 @@
     "start": "2023-11-28T05:17:37Z",
     "asin": "B0BR511292",
     "wpm": 418.7952952358322,
-    "period": "morning"
-  },
-  {
-    "start": "2023-11-28T06:13:02Z",
-    "asin": "B0BR511292",
-    "wpm": 5357.142857142857,
     "period": "morning"
   },
   {
@@ -21730,12 +15586,6 @@
     "asin": "B0BR511292",
     "wpm": 579.3780687397709,
     "period": "morning"
-  },
-  {
-    "start": "2023-12-01T21:27:55Z",
-    "asin": "B0BR511292",
-    "wpm": 1562.5,
-    "period": "evening"
   },
   {
     "start": "2023-12-01T21:28:35Z",
@@ -21816,12 +15666,6 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-09T18:24:43Z",
-    "asin": "B0C5LRCM2F",
-    "wpm": 3468.208092485549,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-09T19:49:28Z",
     "asin": "B0C5LRCM2F",
     "wpm": 469.52679064628984,
@@ -21840,39 +15684,15 @@
     "period": "morning"
   },
   {
-    "start": "2023-12-11T17:04:49Z",
-    "asin": "B0C5LRCM2F",
-    "wpm": 1456.3106796116506,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-11T17:06:23Z",
     "asin": "B0BR511292",
     "wpm": 361.37006389441706,
     "period": "evening"
   },
   {
-    "start": "2023-12-11T17:25:35Z",
-    "asin": "B0BR511292",
-    "wpm": 4285.714285714286,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-11T19:24:41Z",
-    "asin": "B0BR511292",
-    "wpm": 10000,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-11T21:27:12Z",
     "asin": "B0BR511292",
-    "wpm": 5583.501006036217,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-11T21:36:26Z",
-    "asin": "B0BR511292",
-    "wpm": 1226.158038147139,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -21894,34 +15714,10 @@
     "period": "morning"
   },
   {
-    "start": "2023-12-12T19:31:09Z",
-    "asin": "B0C5LRCM2F",
-    "wpm": 3571.428571428571,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-12T19:32:27Z",
     "asin": "B0C5LRCM2F",
     "wpm": 300.6012024048096,
     "period": "evening"
-  },
-  {
-    "start": "2023-12-12T19:39:34Z",
-    "asin": "B0C5LRCM2F",
-    "wpm": 3750,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-12T19:42:40Z",
-    "asin": "B0B6B4WPSF",
-    "wpm": 333.3333333333333,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-13T05:21:59Z",
-    "asin": "B0C5LRCM2F",
-    "wpm": 1442.3076923076922,
-    "period": "morning"
   },
   {
     "start": "2023-12-13T05:23:32Z",
@@ -21954,15 +15750,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-13T20:56:05Z",
-    "asin": "B0BR511292",
-    "wpm": 2803.738317757009,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-13T21:00:51Z",
     "asin": "B0BR511292",
-    "wpm": 3133.159268929504,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -21978,27 +15768,15 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-13T21:09:32Z",
-    "asin": "B0BR511292",
-    "wpm": 13636.363636363636,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-13T21:12:20Z",
     "asin": "B0BR511292",
     "wpm": 588.4782159818294,
     "period": "evening"
   },
   {
-    "start": "2023-12-13T21:53:58Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 1442.3076923076922,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-13T21:54:44Z",
     "asin": "B0BR511292",
-    "wpm": 8861.671469740633,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -22014,39 +15792,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-14T02:54:26Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 1685.3932584269662,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-14T02:54:44Z",
-    "asin": "B0BR511292",
-    "wpm": 11073.825503355705,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-14T03:04:10Z",
-    "asin": "B0BR511292",
-    "wpm": 10103.626943005182,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-14T03:14:11Z",
-    "asin": "B0BR511292",
-    "wpm": 9415.584415584415,
-    "period": "morning"
-  },
-  {
     "start": "2023-12-14T03:22:56Z",
     "asin": "B0BR511292",
-    "wpm": 9565.217391304348,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-14T03:38:56Z",
-    "asin": "B0BR511292",
-    "wpm": 3125,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -22068,39 +15816,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-15T16:36:38Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 2631.5789473684213,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T16:39:04Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-15T16:52:46Z",
     "asin": "B0B9SN8K6H",
     "wpm": 154.87867836861125,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T16:56:02Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 10000,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T16:57:11Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 3370.7865168539324,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T17:01:39Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 5769.230769230769,
     "period": "evening"
   },
   {
@@ -22110,45 +15828,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-15T17:26:27Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 2777.777777777778,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T17:26:48Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T17:33:10Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 1162.7906976744187,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T17:35:58Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 1704.5454545454545,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T17:36:30Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 925.9259259259259,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-15T17:37:10Z",
-    "asin": "B0B9SN8K6H",
-    "wpm": 1327.4336283185842,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-15T17:47:10Z",
     "asin": "B0B9SN8K6H",
-    "wpm": 4576.976421636616,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -22190,31 +15872,13 @@
   {
     "start": "2023-12-20T05:21:36Z",
     "asin": "B0B399L6KP",
-    "wpm": 4637.3850868232885,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2023-12-20T05:48:21Z",
     "asin": "B08FGV64B1",
-    "wpm": 8549.222797927461,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-20T05:51:38Z",
-    "asin": "B08FGV64B1",
-    "wpm": 9135.559921414539,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-20T05:52:43Z",
-    "asin": "B08FGV64B1",
-    "wpm": 4918.032786885246,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-20T05:54:32Z",
-    "asin": "B08FGV64B1",
-    "wpm": 3750,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -22242,45 +15906,9 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-22T16:56:55Z",
-    "asin": "B09Y467GZY",
-    "wpm": 7894.736842105262,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-22T17:00:28Z",
-    "asin": "B09Y467GZY",
-    "wpm": 25000,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-22T17:09:47Z",
-    "asin": "B09Y467GZY",
-    "wpm": 2586.206896551724,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-22T17:10:12Z",
     "asin": "B09Y467GZY",
     "wpm": 165.71533787516114,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-22T17:19:23Z",
-    "asin": "B09Y467GZY",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-22T17:19:30Z",
-    "asin": "B09Y467GZY",
-    "wpm": 6818.181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-22T17:22:31Z",
-    "asin": "B09Y467GZY",
-    "wpm": 5769.230769230769,
     "period": "evening"
   },
   {
@@ -22290,57 +15918,15 @@
     "period": "evening"
   },
   {
-    "start": "2023-12-22T20:25:47Z",
-    "asin": "B09Y467GZY",
-    "wpm": 3125,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-23T05:11:25Z",
-    "asin": "B09Y467GZY",
-    "wpm": 1127.8195488721803,
-    "period": "morning"
-  },
-  {
     "start": "2023-12-23T05:12:57Z",
     "asin": "B09Y467GZY",
     "wpm": 417.12646214963587,
     "period": "morning"
   },
   {
-    "start": "2023-12-23T18:10:53Z",
-    "asin": "B09Y467GZY",
-    "wpm": 1056.338028169014,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-23T18:12:04Z",
-    "asin": "B0B7NGCGHG",
-    "wpm": 321.8884120171674,
-    "period": "evening"
-  },
-  {
     "start": "2023-12-23T18:13:02Z",
     "asin": "B09Y94K74X",
     "wpm": 463.06504961411247,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-23T18:20:08Z",
-    "asin": "B09S3WWY98",
-    "wpm": 8418.367346938776,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-24T23:13:59Z",
-    "asin": "B09S3WWY98",
-    "wpm": 5625,
-    "period": "evening"
-  },
-  {
-    "start": "2023-12-24T23:14:22Z",
-    "asin": "B09Y467GZY",
-    "wpm": 738.9162561576355,
     "period": "evening"
   },
   {
@@ -22368,12 +15954,6 @@
     "period": "morning"
   },
   {
-    "start": "2023-12-27T00:52:05Z",
-    "asin": "B09Y467GZY",
-    "wpm": 4411.764705882353,
-    "period": "morning"
-  },
-  {
     "start": "2023-12-27T00:54:35Z",
     "asin": "B09Q2F1X14",
     "wpm": 949.367088607595,
@@ -22394,25 +15974,13 @@
   {
     "start": "2023-12-27T03:09:03Z",
     "asin": "B09Y467GZY",
-    "wpm": 2188.7159533073927,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-27T03:10:51Z",
-    "asin": "B09Y94K74X",
-    "wpm": 589.3909626719056,
+    "wpm": 2000,
     "period": "morning"
   },
   {
     "start": "2023-12-27T03:39:59Z",
     "asin": "B09Y467GZY",
     "wpm": 539.8749763212729,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-29T04:49:54Z",
-    "asin": "B09Y467GZY",
-    "wpm": 1282.051282051282,
     "period": "morning"
   },
   {
@@ -22434,21 +16002,9 @@
     "period": "morning"
   },
   {
-    "start": "2023-12-31T04:49:13Z",
-    "asin": "B003XT60E0",
-    "wpm": 625,
-    "period": "morning"
-  },
-  {
     "start": "2023-12-31T04:49:53Z",
     "asin": "B09Y467GZY",
     "wpm": 502.51256281407035,
-    "period": "morning"
-  },
-  {
-    "start": "2023-12-31T04:53:56Z",
-    "asin": "B09Y467GZY",
-    "wpm": 700.9345794392523,
     "period": "morning"
   },
   {
@@ -22500,27 +16056,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-01-03T18:49:32Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 1041.6666666666667,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-03T19:09:49Z",
     "asin": "B0B7R4Q5DJ",
     "wpm": 181.8181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-03T19:30:11Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 24375,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-03T19:30:22Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 3061.2244897959185,
     "period": "evening"
   },
   {
@@ -22530,21 +16068,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-01-03T20:05:37Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 3488.3720930232557,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-03T20:08:51Z",
     "asin": "B0B7R4Q5DJ",
     "wpm": 115.38461538461539,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-03T20:16:55Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 3197.6744186046512,
     "period": "evening"
   },
   {
@@ -22554,40 +16080,10 @@
     "period": "evening"
   },
   {
-    "start": "2024-01-03T20:30:03Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 1293.103448275862,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-03T20:30:37Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 862.0689655172414,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-03T20:39:11Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 10169.49152542373,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-03T21:31:33Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 1041.6666666666667,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-03T21:32:45Z",
     "asin": "B0B7R4Q5DJ",
     "wpm": 240.43715846994536,
     "period": "evening"
-  },
-  {
-    "start": "2024-01-04T03:06:24Z",
-    "asin": "B0B7R4Q5DJ",
-    "wpm": 1027.3972602739725,
-    "period": "morning"
   },
   {
     "start": "2024-01-04T04:02:09Z",
@@ -22620,12 +16116,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-01-05T21:12:47Z",
-    "asin": "B07LF64DZ2",
-    "wpm": 925.9259259259259,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-05T21:13:23Z",
     "asin": "B0B7R4Q5DJ",
     "wpm": 125.33073388107506,
@@ -22654,12 +16144,6 @@
     "asin": "B0BST5X6GS",
     "wpm": 172.49310027598898,
     "period": "evening"
-  },
-  {
-    "start": "2024-01-08T04:11:24Z",
-    "asin": "B0BST5X6GS",
-    "wpm": 1562.5,
-    "period": "morning"
   },
   {
     "start": "2024-01-08T04:17:34Z",
@@ -22707,12 +16191,6 @@
     "start": "2024-01-10T02:37:16Z",
     "asin": "B000JMKNV0",
     "wpm": 409.806906953911,
-    "period": "morning"
-  },
-  {
-    "start": "2024-01-10T05:02:02Z",
-    "asin": "B09S3WWY98",
-    "wpm": 964.6302250803859,
     "period": "morning"
   },
   {
@@ -22794,12 +16272,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-01-15T04:29:02Z",
-    "asin": "B0BH4QWM85",
-    "wpm": 1388.888888888889,
-    "period": "morning"
-  },
-  {
     "start": "2024-01-15T04:29:29Z",
     "asin": "B07WG8L7WC",
     "wpm": 273.6074084467518,
@@ -22827,12 +16299,6 @@
     "start": "2024-01-16T00:09:17Z",
     "asin": "B08TF1VTGX",
     "wpm": 260.0317144623324,
-    "period": "morning"
-  },
-  {
-    "start": "2024-01-16T02:16:43Z",
-    "asin": "B07WG8L7WC",
-    "wpm": 1048.951048951049,
     "period": "morning"
   },
   {
@@ -22884,18 +16350,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-01-16T21:56:56Z",
-    "asin": "B07WG8L7WC",
-    "wpm": 2000,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-17T02:05:25Z",
-    "asin": "B07WG8L7WC",
-    "wpm": 1181.1023622047244,
-    "period": "morning"
-  },
-  {
     "start": "2024-01-17T03:55:20Z",
     "asin": "B07WG8L7WC",
     "wpm": 444.0174491067719,
@@ -22911,12 +16365,6 @@
     "start": "2024-01-18T03:55:52Z",
     "asin": "B07WG8L7WC",
     "wpm": 706.0785767234988,
-    "period": "morning"
-  },
-  {
-    "start": "2024-01-18T04:43:15Z",
-    "asin": "B0927NRBFB",
-    "wpm": 1401.8691588785045,
     "period": "morning"
   },
   {
@@ -22942,12 +16390,6 @@
     "asin": "B0BL6271NP",
     "wpm": 194.14334250121343,
     "period": "evening"
-  },
-  {
-    "start": "2024-01-20T04:49:18Z",
-    "asin": "B0BL6271NP",
-    "wpm": 7500,
-    "period": "morning"
   },
   {
     "start": "2024-01-20T04:50:34Z",
@@ -23010,24 +16452,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-01-25T20:32:30Z",
-    "asin": "B0BJSGV831",
-    "wpm": 1630.4347826086957,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-25T20:33:06Z",
-    "asin": "B0C3C886FY",
-    "wpm": 4740.406320541761,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-25T20:33:58Z",
-    "asin": "B0C7RK8P8K",
-    "wpm": 1535.8361774744028,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-25T20:34:53Z",
     "asin": "B0BJSGV831",
     "wpm": 89.44010494305647,
@@ -23058,27 +16482,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-01-26T19:05:31Z",
-    "asin": "B0C592RHNC",
-    "wpm": 297.029702970297,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-26T19:06:41Z",
-    "asin": "B0C592RHNC",
-    "wpm": 1056.338028169014,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-26T19:19:18Z",
     "asin": "B0C3C886FY",
     "wpm": 328.0839895013123,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-26T19:25:32Z",
-    "asin": "B0C3C886FY",
-    "wpm": 16666.666666666668,
     "period": "evening"
   },
   {
@@ -23091,18 +16497,6 @@
     "start": "2024-01-26T19:43:06Z",
     "asin": "B0C3C886FY",
     "wpm": 179.7175866495507,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-26T20:14:03Z",
-    "asin": "B0C3C886FY",
-    "wpm": 3571.428571428571,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-26T21:01:42Z",
-    "asin": "B0BJSGV831",
-    "wpm": 1083.0324909747292,
     "period": "evening"
   },
   {
@@ -23178,39 +16572,15 @@
     "period": "evening"
   },
   {
-    "start": "2024-01-29T14:47:06Z",
-    "asin": "B0C3C886FY",
-    "wpm": 2830.188679245283,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-29T14:47:56Z",
-    "asin": "B0C7RK8P8K",
-    "wpm": 617.283950617284,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-29T18:15:18Z",
-    "asin": "B0C592RHNC",
-    "wpm": 292.39766081871346,
-    "period": "evening"
-  },
-  {
     "start": "2024-01-29T18:33:05Z",
     "asin": "B0BH4QWM85",
-    "wpm": 4085.9088528025145,
-    "period": "evening"
-  },
-  {
-    "start": "2024-01-29T21:12:35Z",
-    "asin": "B0C592RHNC",
-    "wpm": 735.2941176470588,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2024-01-29T21:13:01Z",
     "asin": "B0BH4QWM85",
-    "wpm": 3890.2743142144636,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -23262,12 +16632,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-02-02T17:47:34Z",
-    "asin": "B0C592RHNC",
-    "wpm": 2912.621359223301,
-    "period": "evening"
-  },
-  {
     "start": "2024-02-02T17:47:47Z",
     "asin": "B0C592RHNC",
     "wpm": 71.01432122144632,
@@ -23277,24 +16641,6 @@
     "start": "2024-02-02T18:02:15Z",
     "asin": "B0C592RHNC",
     "wpm": 233.82696804364772,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-02T18:04:26Z",
-    "asin": "B0C592RHNC",
-    "wpm": 6818.181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-02T18:04:36Z",
-    "asin": "B0C592RHNC",
-    "wpm": 8823.529411764706,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-02T18:04:43Z",
-    "asin": "B0C592RHNC",
-    "wpm": 5555.555555555556,
     "period": "evening"
   },
   {
@@ -23340,12 +16686,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-02-06T22:00:45Z",
-    "asin": "B0C7RK8P8K",
-    "wpm": 842.6966292134831,
-    "period": "evening"
-  },
-  {
     "start": "2024-02-06T22:01:26Z",
     "asin": "B09LHBX5KV",
     "wpm": 255.56150513556926,
@@ -23370,39 +16710,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-02-07T18:27:35Z",
-    "asin": "B09LHBX5KV",
-    "wpm": 25000,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-07T18:27:37Z",
-    "asin": "B09LHBX5KV",
-    "wpm": 4285.714285714285,
-    "period": "evening"
-  },
-  {
     "start": "2024-02-07T18:28:04Z",
     "asin": "B09LHBX5KV",
     "wpm": 111.69024571854058,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-07T19:12:20Z",
-    "asin": "B09LHBX5KV",
-    "wpm": 5357.142857142857,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-07T19:16:12Z",
-    "asin": "B09LHBX5KV",
-    "wpm": 1973.6842105263156,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-07T19:44:38Z",
-    "asin": "B09LHBX5KV",
-    "wpm": 3125,
     "period": "evening"
   },
   {
@@ -23452,18 +16762,6 @@
     "asin": "B0B72HGHW8",
     "wpm": 237.2948388372553,
     "period": "morning"
-  },
-  {
-    "start": "2024-02-11T17:54:44Z",
-    "asin": "B0B72HGHW8",
-    "wpm": 1500,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-11T17:55:11Z",
-    "asin": "B0BDMPQ2FC",
-    "wpm": 1147.227533460803,
-    "period": "evening"
   },
   {
     "start": "2024-02-11T21:10:38Z",
@@ -23523,24 +16821,6 @@
     "start": "2024-02-13T19:41:35Z",
     "asin": "B0BDMPQ2FC",
     "wpm": 673.5896716250351,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-13T21:39:01Z",
-    "asin": "B0BDMPQ2FC",
-    "wpm": 1376.1467889908256,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-13T21:40:42Z",
-    "asin": "B0044781ZQ",
-    "wpm": 563.9097744360902,
-    "period": "evening"
-  },
-  {
-    "start": "2024-02-13T21:41:15Z",
-    "asin": "B0BJSGV831",
-    "wpm": 1829.268292682927,
     "period": "evening"
   },
   {
@@ -23658,12 +16938,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-02-20T22:52:28Z",
-    "asin": "B0CLQVQSVL",
-    "wpm": 423.7288135593221,
-    "period": "evening"
-  },
-  {
     "start": "2024-02-21T04:35:08Z",
     "asin": "B0CLQVQSVL",
     "wpm": 299.56427015250546,
@@ -23700,12 +16974,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-02-22T18:05:11Z",
-    "asin": "B0CLQVQSVL",
-    "wpm": 1500,
-    "period": "evening"
-  },
-  {
     "start": "2024-02-22T20:08:35Z",
     "asin": "B0044781ZQ",
     "wpm": 201.63831127914304,
@@ -23734,12 +17002,6 @@
     "asin": "B0B72HGHW8",
     "wpm": 188.9168765743073,
     "period": "morning"
-  },
-  {
-    "start": "2024-02-27T22:27:47Z",
-    "asin": "B0B72HGHW8",
-    "wpm": 1388.888888888889,
-    "period": "evening"
   },
   {
     "start": "2024-02-27T23:40:57Z",
@@ -23850,12 +17112,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-03-01T04:19:14Z",
-    "asin": "B0BPNP7YQB",
-    "wpm": 3764.478764478765,
-    "period": "morning"
-  },
-  {
     "start": "2024-03-01T04:20:23Z",
     "asin": "B0C6KMGND1",
     "wpm": 380.46924540266326,
@@ -23925,12 +17181,6 @@
     "start": "2024-03-03T18:53:55Z",
     "asin": "B0C7RPT9B3",
     "wpm": 252.28681026851578,
-    "period": "evening"
-  },
-  {
-    "start": "2024-03-04T22:35:00Z",
-    "asin": "B0C7RPT9B3",
-    "wpm": 815.2173913043479,
     "period": "evening"
   },
   {
@@ -24054,12 +17304,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-03-10T18:29:13Z",
-    "asin": "B0C6KMGND1",
-    "wpm": 1598.5790408525754,
-    "period": "evening"
-  },
-  {
     "start": "2024-03-10T18:30:52Z",
     "asin": "B0BPNP7YQB",
     "wpm": 587.0841487279844,
@@ -24162,12 +17406,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-03-19T19:54:50Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 12000,
-    "period": "evening"
-  },
-  {
     "start": "2024-03-19T19:56:39Z",
     "asin": "B008J2G5Y6",
     "wpm": 646.551724137931,
@@ -24258,12 +17496,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-03-26T02:53:34Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 1181.1023622047244,
-    "period": "morning"
-  },
-  {
     "start": "2024-03-26T02:53:52Z",
     "asin": "B0BTZRQHJM",
     "wpm": 299.07184599518735,
@@ -24279,12 +17511,6 @@
     "start": "2024-03-28T16:31:57Z",
     "asin": "B0BTZRQHJM",
     "wpm": 267.9102996626315,
-    "period": "evening"
-  },
-  {
-    "start": "2024-03-28T16:33:20Z",
-    "asin": "B0BTZRQHJM",
-    "wpm": 1034.4827586206895,
     "period": "evening"
   },
   {
@@ -24360,18 +17586,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-03-30T02:07:12Z",
-    "asin": "B0BWGKNK7G",
-    "wpm": 402.1447721179624,
-    "period": "morning"
-  },
-  {
-    "start": "2024-03-30T02:08:08Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 1621.6216216216214,
-    "period": "morning"
-  },
-  {
     "start": "2024-03-30T03:53:04Z",
     "asin": "B008J2G5Y6",
     "wpm": 238.51076207097148,
@@ -24438,52 +17652,10 @@
     "period": "evening"
   },
   {
-    "start": "2024-04-01T21:37:07Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 428.57142857142856,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-02T03:38:59Z",
     "asin": "B008J2G5Y6",
     "wpm": 337.67250660663603,
     "period": "morning"
-  },
-  {
-    "start": "2024-04-02T03:56:17Z",
-    "asin": "B007RMYE9M",
-    "wpm": 442.47787610619474,
-    "period": "morning"
-  },
-  {
-    "start": "2024-04-02T19:26:36Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 3529.4117647058824,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-02T19:27:15Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 3658.536585365854,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-02T19:35:01Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 14000,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-02T19:42:48Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 12676.05633802817,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-02T20:57:43Z",
-    "asin": "B007RMYE9M",
-    "wpm": 1351.3513513513515,
-    "period": "evening"
   },
   {
     "start": "2024-04-02T20:58:07Z",
@@ -24500,13 +17672,7 @@
   {
     "start": "2024-04-02T23:12:34Z",
     "asin": "B008J2G5Y6",
-    "wpm": 4345.917471466199,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-02T23:26:26Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 11980.830670926518,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -24514,12 +17680,6 @@
     "asin": "B008J2G5Y6",
     "wpm": 522.1023320570832,
     "period": "evening"
-  },
-  {
-    "start": "2024-04-03T00:09:15Z",
-    "asin": "B008J2G5Y6",
-    "wpm": 7614.213197969544,
-    "period": "morning"
   },
   {
     "start": "2024-04-03T00:14:40Z",
@@ -24530,13 +17690,7 @@
   {
     "start": "2024-04-03T00:32:42Z",
     "asin": "B008J2G5Y6",
-    "wpm": 8767.123287671233,
-    "period": "morning"
-  },
-  {
-    "start": "2024-04-03T03:17:48Z",
-    "asin": "B007RMYE9M",
-    "wpm": 1807.2289156626505,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -24562,24 +17716,6 @@
     "asin": "B0BXTB6HSN",
     "wpm": 420.5786142147075,
     "period": "morning"
-  },
-  {
-    "start": "2024-04-04T19:13:53Z",
-    "asin": "B0BXTB6HSN",
-    "wpm": 25000,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-04T19:13:56Z",
-    "asin": "B0BXTB6HSN",
-    "wpm": 4285.714285714285,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-04T19:14:13Z",
-    "asin": "B0BXTB6HSN",
-    "wpm": 684.931506849315,
-    "period": "evening"
   },
   {
     "start": "2024-04-04T22:07:47Z",
@@ -24660,12 +17796,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-04-08T23:23:24Z",
-    "asin": "B007RMYE9M",
-    "wpm": 2941.176470588235,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-08T23:23:37Z",
     "asin": "B00BUP18U0",
     "wpm": 489.3964110929853,
@@ -24676,12 +17806,6 @@
     "asin": "B00BUP18U0",
     "wpm": 118.21366024518387,
     "period": "morning"
-  },
-  {
-    "start": "2024-04-09T22:19:35Z",
-    "asin": "B00BUP18U0",
-    "wpm": 2173.913043478261,
-    "period": "evening"
   },
   {
     "start": "2024-04-10T03:04:27Z",
@@ -24714,22 +17838,10 @@
     "period": "morning"
   },
   {
-    "start": "2024-04-11T04:10:28Z",
-    "asin": "B092T8QDYW",
-    "wpm": 1562.5,
-    "period": "morning"
-  },
-  {
     "start": "2024-04-11T04:15:58Z",
     "asin": "B092T8QDYW",
     "wpm": 186.63348738002134,
     "period": "morning"
-  },
-  {
-    "start": "2024-04-11T22:16:12Z",
-    "asin": "B092T8QDYW",
-    "wpm": 1388.888888888889,
-    "period": "evening"
   },
   {
     "start": "2024-04-11T22:37:10Z",
@@ -24750,39 +17862,15 @@
     "period": "morning"
   },
   {
-    "start": "2024-04-13T22:34:07Z",
-    "asin": "B00BUP18U0",
-    "wpm": 275.22935779816515,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-14T21:37:52Z",
-    "asin": "B00BUP18U0",
-    "wpm": 1923.076923076923,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-14T21:38:13Z",
     "asin": "B0BJSGV831",
     "wpm": 76.6311487374106,
     "period": "evening"
   },
   {
-    "start": "2024-04-15T20:34:21Z",
-    "asin": "B0BJSGV831",
-    "wpm": 1923.076923076923,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-15T20:36:29Z",
     "asin": "B003B4IW2U",
     "wpm": 972.1322099805573,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-15T20:45:04Z",
-    "asin": "B003B4IW2U",
-    "wpm": 2689.2430278884462,
     "period": "evening"
   },
   {
@@ -24844,12 +17932,6 @@
     "asin": "B0BJSGV831",
     "wpm": 370.8281829419036,
     "period": "evening"
-  },
-  {
-    "start": "2024-04-22T03:34:54Z",
-    "asin": "B0BJSGV831",
-    "wpm": 394.7368421052632,
-    "period": "morning"
   },
   {
     "start": "2024-04-22T03:36:25Z",
@@ -24924,18 +18006,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-04-27T15:45:20Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 604.8387096774194,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-27T15:48:19Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 10606.060606060606,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-27T18:46:13Z",
     "asin": "B0C772ZLMQ",
     "wpm": 529.3258700413726,
@@ -24948,27 +18018,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-04-28T23:04:32Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 1395.3488372093022,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-28T23:13:51Z",
     "asin": "B0C772ZLMQ",
     "wpm": 161.72506738544473,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-28T23:18:05Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 3191.4893617021276,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-28T23:21:41Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 2752.293577981651,
     "period": "evening"
   },
   {
@@ -24984,12 +18036,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-04-29T18:03:16Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-29T18:06:13Z",
     "asin": "B0C772ZLMQ",
     "wpm": 1597.6331360946745,
@@ -24998,55 +18044,7 @@
   {
     "start": "2024-04-29T18:08:20Z",
     "asin": "B0C772ZLMQ",
-    "wpm": 2586.206896551724,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:09:49Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 37500,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:12:05Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 7653.061224489796,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:23:40Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 3214.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:41:32Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 4143.646408839779,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:46:31Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 6308.41121495327,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:52:19Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 7627.118644067797,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:53:14Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 2173.913043478261,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T18:54:01Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 6818.181818181818,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -25056,27 +18054,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-04-29T19:08:17Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 5585.106382978723,
-    "period": "evening"
-  },
-  {
     "start": "2024-04-29T19:17:30Z",
     "asin": "B0C772ZLMQ",
     "wpm": 435.09789702683105,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T19:22:10Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 3846.153846153846,
-    "period": "evening"
-  },
-  {
-    "start": "2024-04-29T21:02:26Z",
-    "asin": "B0C772ZLMQ",
-    "wpm": 1094.890510948905,
     "period": "evening"
   },
   {
@@ -25140,96 +18120,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-05-05T18:17:47Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 769.2307692307692,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:23:49Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 16964.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:31:44Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 6818.181818181818,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:34:29Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 10135.135135135135,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:43:19Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 13043.478260869566,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:46:31Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 8881.57894736842,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:48:29Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 3658.536585365854,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:51:53Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 12972.972972972972,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T18:57:56Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 16666.666666666668,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T19:05:23Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 1657.4585635359115,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T19:05:48Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 16666.666666666668,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T20:44:18Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 3488.3720930232557,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T21:10:26Z",
-    "asin": "B0C4PX8RD7",
-    "wpm": 1685.3932584269662,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T21:11:04Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 895.5223880597015,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-05T21:11:16Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 1685.3932584269662,
-    "period": "evening"
-  },
-  {
     "start": "2024-05-05T21:11:45Z",
     "asin": "B0C4PX8RD7",
     "wpm": 164.3321073636435,
@@ -25245,12 +18135,6 @@
     "start": "2024-05-06T04:56:29Z",
     "asin": "B0C4PX8RD7",
     "wpm": 344.7219243143864,
-    "period": "morning"
-  },
-  {
-    "start": "2024-05-06T05:22:10Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 1013.5135135135135,
     "period": "morning"
   },
   {
@@ -25296,27 +18180,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-05-08T16:48:49Z",
-    "asin": "B00BUP18U0",
-    "wpm": 834.8794063079778,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-08T16:49:55Z",
-    "asin": "B0C4PX8RD7",
-    "wpm": 785.3403141361256,
-    "period": "evening"
-  },
-  {
     "start": "2024-05-08T16:51:17Z",
     "asin": "B0C4PX8RD7",
     "wpm": 147.34774066797644,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-08T20:00:02Z",
-    "asin": "B0C4PX8RD7",
-    "wpm": 10000,
     "period": "evening"
   },
   {
@@ -25332,21 +18198,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-05-08T22:36:54Z",
-    "asin": "B00BUP18U0",
-    "wpm": 2238.805970149254,
-    "period": "evening"
-  },
-  {
     "start": "2024-05-08T22:43:23Z",
     "asin": "B0C4PX8RD7",
     "wpm": 581.3648981302048,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-08T23:15:18Z",
-    "asin": "B0C4PX8RD7",
-    "wpm": 2027.027027027027,
     "period": "evening"
   },
   {
@@ -25406,19 +18260,7 @@
   {
     "start": "2024-05-11T04:54:42Z",
     "asin": "B0BJSGV831",
-    "wpm": 2750.352609308886,
-    "period": "morning"
-  },
-  {
-    "start": "2024-05-11T04:55:59Z",
-    "asin": "B0BJSGV831",
-    "wpm": 609.7560975609756,
-    "period": "morning"
-  },
-  {
-    "start": "2024-05-11T04:57:00Z",
-    "asin": "B0BPNP7YQB",
-    "wpm": 1376.1467889908256,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -25500,12 +18342,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-05-13T03:10:13Z",
-    "asin": "B0BPNP7YQB",
-    "wpm": 468.75,
-    "period": "morning"
-  },
-  {
     "start": "2024-05-13T03:16:17Z",
     "asin": "B0C97G1ZR6",
     "wpm": 117.15699036709191,
@@ -25521,12 +18357,6 @@
     "start": "2024-05-14T08:00:48Z",
     "asin": "B0CDKLBD2W",
     "wpm": 97.21322099805575,
-    "period": "morning"
-  },
-  {
-    "start": "2024-05-15T03:44:37Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 735.2941176470588,
     "period": "morning"
   },
   {
@@ -25578,12 +18408,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-05-21T04:33:36Z",
-    "asin": "B092T8QDYW",
-    "wpm": 1470.5882352941176,
-    "period": "morning"
-  },
-  {
     "start": "2024-05-21T04:33:56Z",
     "asin": "B0CDKLBD2W",
     "wpm": 36.64345914254306,
@@ -25623,12 +18447,6 @@
     "start": "2024-05-22T22:03:20Z",
     "asin": "B0CDKLBD2W",
     "wpm": 893.5219657483246,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-22T22:05:46Z",
-    "asin": "B0CDKLBD2W",
-    "wpm": 1724.1379310344828,
     "period": "evening"
   },
   {
@@ -25677,12 +18495,6 @@
     "start": "2024-05-25T15:33:22Z",
     "asin": "B0CJ9TSSYB",
     "wpm": 199.85565980125463,
-    "period": "evening"
-  },
-  {
-    "start": "2024-05-25T19:02:05Z",
-    "asin": "B0CJ9TSSYB",
-    "wpm": 622.4066390041494,
     "period": "evening"
   },
   {
@@ -25800,12 +18612,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-05-30T03:54:38Z",
-    "asin": "B092T8QDYW",
-    "wpm": 756.3025210084033,
-    "period": "morning"
-  },
-  {
     "start": "2024-05-30T03:59:47Z",
     "asin": "B0CDKLBD2W",
     "wpm": 484.1997961264016,
@@ -25845,12 +18651,6 @@
     "start": "2024-06-01T17:43:24Z",
     "asin": "B09X34KMRM",
     "wpm": 252.24215246636774,
-    "period": "evening"
-  },
-  {
-    "start": "2024-06-01T18:43:36Z",
-    "asin": "B09X34KMRM",
-    "wpm": 2238.805970149254,
     "period": "evening"
   },
   {
@@ -26046,27 +18846,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-06-11T02:38:22Z",
-    "asin": "B0CL5G23ZF",
-    "wpm": 1234.567901234568,
-    "period": "morning"
-  },
-  {
-    "start": "2024-06-11T02:39:25Z",
-    "asin": "B0CL5G23ZF",
-    "wpm": 2830.188679245283,
-    "period": "morning"
-  },
-  {
     "start": "2024-06-11T02:39:47Z",
     "asin": "B002C7Z57C",
-    "wpm": 2186.8250539956807,
-    "period": "morning"
-  },
-  {
-    "start": "2024-06-11T03:33:26Z",
-    "asin": "B0CGTHLBT9",
-    "wpm": 556.5862708719852,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -26100,12 +18882,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-06-13T02:33:25Z",
-    "asin": "B0BWGKNK7G",
-    "wpm": 1127.8195488721803,
-    "period": "morning"
-  },
-  {
     "start": "2024-06-13T02:33:43Z",
     "asin": "B0CGTHLBT9",
     "wpm": 295.90948651000866,
@@ -26130,27 +18906,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-06-15T21:46:27Z",
-    "asin": "B0BWGKNK7G",
-    "wpm": 1648.3516483516482,
-    "period": "evening"
-  },
-  {
-    "start": "2024-06-15T21:47:38Z",
-    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
-    "wpm": 1153.8461538461538,
-    "period": "evening"
-  },
-  {
     "start": "2024-06-15T23:00:58Z",
     "asin": "096E674F00DC4192A0B7E99C3AB4A388",
     "wpm": 461.36811023622045,
-    "period": "evening"
-  },
-  {
-    "start": "2024-06-15T23:32:25Z",
-    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
-    "wpm": 6976.7441860465115,
     "period": "evening"
   },
   {
@@ -26166,12 +18924,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-06-17T03:52:38Z",
-    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
-    "wpm": 1829.268292682927,
-    "period": "morning"
-  },
-  {
     "start": "2024-06-17T03:56:15Z",
     "asin": "096E674F00DC4192A0B7E99C3AB4A388",
     "wpm": 303.0497386396434,
@@ -26182,24 +18934,6 @@
     "asin": "096E674F00DC4192A0B7E99C3AB4A388",
     "wpm": 76.21951219512195,
     "period": "morning"
-  },
-  {
-    "start": "2024-06-17T11:59:49Z",
-    "asin": "B09S3WWY98",
-    "wpm": 11538.461538461537,
-    "period": "morning"
-  },
-  {
-    "start": "2024-06-17T18:05:47Z",
-    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
-    "wpm": 1840.4907975460123,
-    "period": "evening"
-  },
-  {
-    "start": "2024-06-17T18:15:52Z",
-    "asin": "096E674F00DC4192A0B7E99C3AB4A388",
-    "wpm": 4838.709677419355,
-    "period": "evening"
   },
   {
     "start": "2024-06-18T02:51:19Z",
@@ -26238,21 +18972,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-06-21T03:45:31Z",
-    "asin": "B0C7RK8P8K",
-    "wpm": 2400,
-    "period": "morning"
-  },
-  {
     "start": "2024-06-21T03:45:57Z",
     "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
     "wpm": 288.5386053967406,
-    "period": "morning"
-  },
-  {
-    "start": "2024-06-21T04:31:06Z",
-    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
-    "wpm": 1282.051282051282,
     "period": "morning"
   },
   {
@@ -26322,21 +19044,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-06-29T03:58:35Z",
-    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
-    "wpm": 1630.4347826086957,
-    "period": "morning"
-  },
-  {
     "start": "2024-06-29T04:23:56Z",
     "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
     "wpm": 337.05701078582433,
-    "period": "morning"
-  },
-  {
-    "start": "2024-06-30T02:44:43Z",
-    "asin": "9AB16AE6EC24449DBFB06E5EB1561B67",
-    "wpm": 1470.5882352941176,
     "period": "morning"
   },
   {
@@ -26412,12 +19122,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-07-02T21:15:00Z",
-    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
-    "wpm": 2205.8823529411766,
-    "period": "evening"
-  },
-  {
     "start": "2024-07-02T21:19:12Z",
     "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
     "wpm": 298.5322166017083,
@@ -26490,24 +19194,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-07-08T22:00:29Z",
-    "asin": "C36A14E8EC2F4079AD3377ED35C616AE",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-08T22:00:48Z",
-    "asin": "2C4B5A07F41247DAAF830F1590836876",
-    "wpm": 4411.764705882352,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-08T22:04:55Z",
-    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
-    "wpm": 320.5128205128205,
-    "period": "evening"
-  },
-  {
     "start": "2024-07-08T22:05:47Z",
     "asin": "2C4B5A07F41247DAAF830F1590836876",
     "wpm": 192.51653667686838,
@@ -26518,12 +19204,6 @@
     "asin": "2C4B5A07F41247DAAF830F1590836876",
     "wpm": 226.89947272884433,
     "period": "morning"
-  },
-  {
-    "start": "2024-07-09T21:45:11Z",
-    "asin": "2C4B5A07F41247DAAF830F1590836876",
-    "wpm": 385.60411311053986,
-    "period": "evening"
   },
   {
     "start": "2024-07-09T22:27:54Z",
@@ -26568,12 +19248,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-07-12T19:17:46Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 3910.6145251396647,
-    "period": "evening"
-  },
-  {
     "start": "2024-07-12T20:09:32Z",
     "asin": "2C4B5A07F41247DAAF830F1590836876",
     "wpm": 212.33734414983394,
@@ -26592,34 +19266,10 @@
     "period": "evening"
   },
   {
-    "start": "2024-07-14T00:00:25Z",
-    "asin": "2C4B5A07F41247DAAF830F1590836876",
-    "wpm": 5714.285714285715,
-    "period": "morning"
-  },
-  {
     "start": "2024-07-14T04:09:18Z",
     "asin": "2C4B5A07F41247DAAF830F1590836876",
     "wpm": 196.18993460335514,
     "period": "morning"
-  },
-  {
-    "start": "2024-07-14T23:59:14Z",
-    "asin": "2C4B5A07F41247DAAF830F1590836876",
-    "wpm": 4054.054054054054,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-14T23:59:49Z",
-    "asin": "2C4B5A07F41247DAAF830F1590836876",
-    "wpm": 2631.578947368421,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-14T23:59:57Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 405.40540540540536,
-    "period": "evening"
   },
   {
     "start": "2024-07-15T03:29:16Z",
@@ -26637,12 +19287,6 @@
     "start": "2024-07-15T21:24:30Z",
     "asin": "2C4B5A07F41247DAAF830F1590836876",
     "wpm": 429.6747525290982,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-15T22:10:55Z",
-    "asin": "02A4171C317D47ABB064E2F24B3D5CFC",
-    "wpm": 1666.6666666666667,
     "period": "evening"
   },
   {
@@ -26688,27 +19332,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-07-17T11:41:55Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 3409.090909090909,
-    "period": "morning"
-  },
-  {
     "start": "2024-07-17T19:47:26Z",
     "asin": "28C62463866C4CC99233564ED847A1A5",
     "wpm": 1981.3519813519813,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-17T22:38:46Z",
-    "asin": "B0CH1NHWNW",
-    "wpm": 343.2494279176201,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-17T22:39:24Z",
-    "asin": "B0CH1NHWNW",
-    "wpm": 3571.428571428571,
     "period": "evening"
   },
   {
@@ -26716,12 +19342,6 @@
     "asin": "B0CH1NHWNW",
     "wpm": 182.67435252090607,
     "period": "evening"
-  },
-  {
-    "start": "2024-07-18T00:19:33Z",
-    "asin": "B0CH1NHWNW",
-    "wpm": 1500,
-    "period": "morning"
   },
   {
     "start": "2024-07-18T03:31:28Z",
@@ -26733,12 +19353,6 @@
     "start": "2024-07-18T17:51:47Z",
     "asin": "B0C7729CF8",
     "wpm": 99.62049335863378,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-18T18:31:44Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 700.9345794392523,
     "period": "evening"
   },
   {
@@ -26760,12 +19374,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-07-19T21:34:50Z",
-    "asin": "B0C7729CF8",
-    "wpm": 1260.5042016806722,
-    "period": "evening"
-  },
-  {
     "start": "2024-07-19T21:35:10Z",
     "asin": "B0CH1NHWNW",
     "wpm": 119.38450654403961,
@@ -26782,12 +19390,6 @@
     "asin": "28C62463866C4CC99233564ED847A1A5",
     "wpm": 874.1721854304635,
     "period": "morning"
-  },
-  {
-    "start": "2024-07-20T18:48:51Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 1595.7446808510638,
-    "period": "evening"
   },
   {
     "start": "2024-07-20T18:49:07Z",
@@ -26818,24 +19420,6 @@
     "asin": "B0C7729CF8",
     "wpm": 171.05815977432326,
     "period": "evening"
-  },
-  {
-    "start": "2024-07-23T01:13:15Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 3461.5384615384614,
-    "period": "morning"
-  },
-  {
-    "start": "2024-07-23T01:13:31Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 3488.3720930232557,
-    "period": "morning"
-  },
-  {
-    "start": "2024-07-23T01:13:47Z",
-    "asin": "B0C7729CF8",
-    "wpm": 1339.2857142857142,
-    "period": "morning"
   },
   {
     "start": "2024-07-23T01:16:23Z",
@@ -26894,20 +19478,8 @@
   {
     "start": "2024-07-24T21:47:56Z",
     "asin": "B0C7729CF8",
-    "wpm": 10873.146622734761,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2024-07-25T00:58:40Z",
-    "asin": "B0C7729CF8",
-    "wpm": 1851.8518518518517,
-    "period": "morning"
-  },
-  {
-    "start": "2024-07-25T01:17:28Z",
-    "asin": "B0C7729CF8",
-    "wpm": 2054.794520547945,
-    "period": "morning"
   },
   {
     "start": "2024-07-25T03:25:35Z",
@@ -26918,7 +19490,7 @@
   {
     "start": "2024-07-25T17:16:26Z",
     "asin": "B0C7729CF8",
-    "wpm": 3203.240058910162,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -26926,30 +19498,6 @@
     "asin": "B0C7729CF8",
     "wpm": 79.1765637371338,
     "period": "evening"
-  },
-  {
-    "start": "2024-07-25T23:20:05Z",
-    "asin": "B0C7729CF8",
-    "wpm": 977.1986970684038,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-25T23:38:40Z",
-    "asin": "B0C7729CF8",
-    "wpm": 2564.102564102564,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-26T03:02:50Z",
-    "asin": "B0C7729CF8",
-    "wpm": 1775.1479289940828,
-    "period": "morning"
-  },
-  {
-    "start": "2024-07-26T03:22:42Z",
-    "asin": "B0C7729CF8",
-    "wpm": 262.23776223776224,
-    "period": "morning"
   },
   {
     "start": "2024-07-26T03:23:52Z",
@@ -26964,46 +19512,10 @@
     "period": "evening"
   },
   {
-    "start": "2024-07-26T19:17:23Z",
-    "asin": "B0C7729CF8",
-    "wpm": 439.88269794721407,
-    "period": "evening"
-  },
-  {
     "start": "2024-07-26T19:18:00Z",
     "asin": "B0CH1NHWNW",
     "wpm": 61.09150149334781,
     "period": "evening"
-  },
-  {
-    "start": "2024-07-26T21:49:28Z",
-    "asin": "B0C7729CF8",
-    "wpm": 2586.206896551724,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-26T22:45:53Z",
-    "asin": "B0C7729CF8",
-    "wpm": 2112.676056338028,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-26T22:57:45Z",
-    "asin": "B0C7729CF8",
-    "wpm": 4945.054945054945,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-26T23:20:06Z",
-    "asin": "B0C7729CF8",
-    "wpm": 2439.0243902439024,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-27T02:19:32Z",
-    "asin": "B0C7729CF8",
-    "wpm": 3488.3720930232557,
-    "period": "morning"
   },
   {
     "start": "2024-07-27T03:54:39Z",
@@ -27096,27 +19608,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-07-31T10:17:54Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 831.7929759704252,
-    "period": "morning"
-  },
-  {
-    "start": "2024-07-31T14:24:39Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 1485.148514851485,
-    "period": "evening"
-  },
-  {
     "start": "2024-07-31T14:27:53Z",
     "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 6835.128417564209,
-    "period": "evening"
-  },
-  {
-    "start": "2024-07-31T21:34:29Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 1724.1379310344828,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -27168,22 +19662,10 @@
     "period": "morning"
   },
   {
-    "start": "2024-08-02T19:56:45Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 900,
-    "period": "evening"
-  },
-  {
     "start": "2024-08-04T03:15:39Z",
     "asin": "B078R46LCY",
     "wpm": 92.9054054054054,
     "period": "morning"
-  },
-  {
-    "start": "2024-08-04T17:18:06Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 688.0733944954128,
-    "period": "evening"
   },
   {
     "start": "2024-08-04T17:19:14Z",
@@ -27228,153 +19710,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-08-05T15:56:55Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 1036.8663594470045,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T15:58:43Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T15:58:48Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 16666.666666666668,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:01:20Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 9677.41935483871,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:01:25Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 4411.764705882353,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:02:08Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 13636.363636363636,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:03:07Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 4838.709677419355,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:04:09Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 11538.461538461537,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:04:53Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 2500,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:07:03Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 5769.230769230769,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:09:18Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 10714.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:12:06Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 1481.4814814814813,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:14:42Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 10000,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:15:05Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 8333.333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:16:22Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 2083.3333333333335,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:17:05Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 18750,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:18:18Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 8571.42857142857,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:19:07Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 10344.827586206897,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:41:57Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 5172.413793103448,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T16:45:10Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T17:18:00Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 18750,
-    "period": "evening"
-  },
-  {
     "start": "2024-08-05T18:50:29Z",
     "asin": "B0CL3FMNKJ",
     "wpm": 478.4688995215311,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T18:55:55Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T20:03:08Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 252.52525252525254,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T20:04:20Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 7894.736842105262,
     "period": "evening"
   },
   {
@@ -27390,40 +19728,10 @@
     "period": "evening"
   },
   {
-    "start": "2024-08-05T23:25:27Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 2230.483271375465,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T23:28:20Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 4166.666666666667,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T23:28:59Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 5172.413793103448,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-05T23:31:53Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 9493.67088607595,
-    "period": "evening"
-  },
-  {
     "start": "2024-08-06T02:46:18Z",
     "asin": "B0CL3FMNKJ",
     "wpm": 540.9791723018664,
     "period": "morning"
-  },
-  {
-    "start": "2024-08-06T20:31:02Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 3191.4893617021276,
-    "period": "evening"
   },
   {
     "start": "2024-08-07T21:05:17Z",
@@ -27432,27 +19740,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-08-08T03:12:46Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 1006.7114093959732,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-08T03:14:09Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 1327.4336283185842,
-    "period": "morning"
-  },
-  {
     "start": "2024-08-08T03:15:23Z",
     "asin": "B0CL3FMNKJ",
     "wpm": 145.56682840758714,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-09T02:39:31Z",
-    "asin": "B0CL3FMNKJ",
-    "wpm": 2205.8823529411766,
     "period": "morning"
   },
   {
@@ -27465,18 +19755,6 @@
     "start": "2024-08-09T03:00:48Z",
     "asin": "B0CL3FMNKJ",
     "wpm": 391.83978106729694,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-09T03:14:47Z",
-    "asin": "B078R46LCY",
-    "wpm": 986.8421052631578,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-09T03:19:22Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 2542.3728813559323,
     "period": "morning"
   },
   {
@@ -27594,22 +19872,10 @@
     "period": "evening"
   },
   {
-    "start": "2024-08-17T22:43:10Z",
-    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
-    "wpm": 2307.6923076923076,
-    "period": "evening"
-  },
-  {
     "start": "2024-08-18T03:15:09Z",
     "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
     "wpm": 285.77115559599633,
     "period": "morning"
-  },
-  {
-    "start": "2024-08-18T15:03:01Z",
-    "asin": "6C1EF968A24F49B0BF68A0FC5BA314DC",
-    "wpm": 602.4096385542169,
-    "period": "evening"
   },
   {
     "start": "2024-08-18T21:31:40Z",
@@ -27674,7 +19940,7 @@
   {
     "start": "2024-08-20T03:58:56Z",
     "asin": "43CBE4C46DC444119BB4453B4EF2473B",
-    "wpm": 4742.096505823627,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -27694,18 +19960,6 @@
     "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
     "wpm": 275.33622789367786,
     "period": "morning"
-  },
-  {
-    "start": "2024-08-21T13:50:33Z",
-    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
-    "wpm": 5357.142857142857,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-21T13:50:38Z",
-    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
-    "wpm": 16666.666666666668,
-    "period": "evening"
   },
   {
     "start": "2024-08-21T21:44:28Z",
@@ -27744,18 +19998,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-08-23T10:46:40Z",
-    "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
-    "wpm": 4285.714285714285,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-23T10:46:49Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 2036.1990950226243,
-    "period": "morning"
-  },
-  {
     "start": "2024-08-24T03:23:10Z",
     "asin": "3F18E7B1DE9B48E1B46CEBD543D9AD15",
     "wpm": 248.745363299149,
@@ -27786,21 +20028,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-08-25T11:04:27Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 710.9004739336492,
-    "period": "morning"
-  },
-  {
     "start": "2024-08-26T02:17:35Z",
     "asin": "28C62463866C4CC99233564ED847A1A5",
     "wpm": 552.1472392638036,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-26T02:41:30Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 1171.875,
     "period": "morning"
   },
   {
@@ -27816,40 +20046,10 @@
     "period": "morning"
   },
   {
-    "start": "2024-08-27T05:02:28Z",
-    "asin": "A7E4563B33564CA4904BBD751938CA1C",
-    "wpm": 7527.881040892194,
-    "period": "morning"
-  },
-  {
     "start": "2024-08-27T05:03:28Z",
     "asin": "A7E4563B33564CA4904BBD751938CA1C",
     "wpm": 97.15025906735751,
     "period": "morning"
-  },
-  {
-    "start": "2024-08-27T05:05:44Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 3191.4893617021276,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-27T05:05:54Z",
-    "asin": "A7E4563B33564CA4904BBD751938CA1C",
-    "wpm": 4347.826086956522,
-    "period": "morning"
-  },
-  {
-    "start": "2024-08-27T12:09:08Z",
-    "asin": "BBD0AD78686243CD9C5F343AFC7E83D6",
-    "wpm": 9230.76923076923,
-    "period": "evening"
-  },
-  {
-    "start": "2024-08-27T21:59:04Z",
-    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
-    "wpm": 3061.2244897959185,
-    "period": "evening"
   },
   {
     "start": "2024-08-27T22:05:07Z",
@@ -27942,27 +20142,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-09-01T16:50:10Z",
-    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
-    "wpm": 1714.2857142857142,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-01T16:51:48Z",
-    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
-    "wpm": 7857.142857142858,
-    "period": "evening"
-  },
-  {
     "start": "2024-09-01T18:32:04Z",
     "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
     "wpm": 11.257880516361453,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-01T18:36:40Z",
-    "asin": "3451C4DEA84A49DEBFFFDDA0092EC804",
-    "wpm": 4411.764705882353,
     "period": "evening"
   },
   {
@@ -27984,27 +20166,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-09-02T14:22:22Z",
-    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
-    "wpm": 3571.428571428571,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-02T14:43:46Z",
-    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
-    "wpm": 1145.0381679389313,
-    "period": "evening"
-  },
-  {
     "start": "2024-09-02T15:11:49Z",
     "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
     "wpm": 73.25411036952629,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-02T17:30:52Z",
-    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
-    "wpm": 5660.377358490566,
     "period": "evening"
   },
   {
@@ -28012,12 +20176,6 @@
     "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
     "wpm": 135.58709210883126,
     "period": "evening"
-  },
-  {
-    "start": "2024-09-03T01:28:02Z",
-    "asin": "05C4DA136A6A4FFC99DBA85BEE6FF300",
-    "wpm": 5555.555555555555,
-    "period": "morning"
   },
   {
     "start": "2024-09-03T01:28:12Z",
@@ -28038,27 +20196,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-09-03T11:10:17Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 2542.3728813559323,
-    "period": "morning"
-  },
-  {
-    "start": "2024-09-04T02:58:16Z",
-    "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
-    "wpm": 7031.25,
-    "period": "morning"
-  },
-  {
     "start": "2024-09-05T02:52:17Z",
     "asin": "1C34F9A4E93C4F328ADA7053A8E3D219",
     "wpm": 164.94845360824743,
-    "period": "morning"
-  },
-  {
-    "start": "2024-09-05T11:19:11Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 370.3703703703703,
     "period": "morning"
   },
   {
@@ -28134,12 +20274,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-09-11T16:59:20Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
     "start": "2024-09-12T01:58:46Z",
     "asin": "CFB210D125DE496195B7AE70BACDA51C",
     "wpm": 200.85300535608013,
@@ -28150,18 +20284,6 @@
     "asin": "CFB210D125DE496195B7AE70BACDA51C",
     "wpm": 221.65114037905556,
     "period": "morning"
-  },
-  {
-    "start": "2024-09-12T22:12:25Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 10714.285714285714,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-12T22:12:36Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 3092.7835051546394,
-    "period": "evening"
   },
   {
     "start": "2024-09-12T22:13:00Z",
@@ -28332,18 +20454,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-09-22T01:44:14Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 1764.7058823529412,
-    "period": "morning"
-  },
-  {
-    "start": "2024-09-22T01:44:48Z",
-    "asin": "B0CQFXKTPW",
-    "wpm": 3876.739562624254,
-    "period": "morning"
-  },
-  {
     "start": "2024-09-22T01:45:43Z",
     "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
     "wpm": 315.466890998678,
@@ -28356,57 +20466,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-09-22T02:16:24Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 669.6428571428571,
-    "period": "morning"
-  },
-  {
     "start": "2024-09-22T02:40:28Z",
     "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
     "wpm": 302.14126198712614,
-    "period": "morning"
-  },
-  {
-    "start": "2024-09-22T20:57:52Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 595.2380952380953,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-22T20:58:45Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 9836.065573770491,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-22T20:59:46Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 588.2352941176471,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-22T21:39:05Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 4687.5,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-22T21:55:15Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 3370.7865168539324,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-22T21:58:54Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 3879.3103448275865,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-23T01:45:09Z",
-    "asin": "5XMZNFFBFJGCDIF7CF2TJMLGHI2DH2MZ",
-    "wpm": 1500,
     "period": "morning"
   },
   {
@@ -28428,12 +20490,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-09-23T19:26:59Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 5113.636363636364,
-    "period": "evening"
-  },
-  {
     "start": "2024-09-24T02:18:22Z",
     "asin": "B0CQJHF3HQ",
     "wpm": 281.09627547434997,
@@ -28452,18 +20508,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-09-24T18:52:03Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 2830.188679245283,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-24T20:02:24Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 4891.304347826087,
-    "period": "evening"
-  },
-  {
     "start": "2024-09-24T22:21:30Z",
     "asin": "B0CQJHF3HQ",
     "wpm": 260.9186215974801,
@@ -28476,12 +20520,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-09-25T03:17:46Z",
-    "asin": "B0CQJHF3HQ",
-    "wpm": 2941.176470588235,
-    "period": "morning"
-  },
-  {
     "start": "2024-09-25T03:55:50Z",
     "asin": "B0CQJHF3HQ",
     "wpm": 470.52996532937095,
@@ -28491,12 +20529,6 @@
     "start": "2024-09-26T20:58:36Z",
     "asin": "B0CQJHF3HQ",
     "wpm": 678.119349005425,
-    "period": "evening"
-  },
-  {
-    "start": "2024-09-26T21:20:36Z",
-    "asin": "CFB210D125DE496195B7AE70BACDA51C",
-    "wpm": 2459.0163934426228,
     "period": "evening"
   },
   {
@@ -28536,12 +20568,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-10-01T20:21:48Z",
-    "asin": "CFB210D125DE496195B7AE70BACDA51C",
-    "wpm": 1714.2857142857142,
-    "period": "evening"
-  },
-  {
     "start": "2024-10-01T23:29:48Z",
     "asin": "CFB210D125DE496195B7AE70BACDA51C",
     "wpm": 354.4154255094722,
@@ -28551,12 +20577,6 @@
     "start": "2024-10-02T02:36:23Z",
     "asin": "CFB210D125DE496195B7AE70BACDA51C",
     "wpm": 400.96741344195516,
-    "period": "morning"
-  },
-  {
-    "start": "2024-10-02T02:49:42Z",
-    "asin": "B0CGZFPKTZ",
-    "wpm": 847.4576271186442,
     "period": "morning"
   },
   {
@@ -28572,21 +20592,9 @@
     "period": "evening"
   },
   {
-    "start": "2024-10-02T20:01:07Z",
-    "asin": "CFB210D125DE496195B7AE70BACDA51C",
-    "wpm": 3947.368421052631,
-    "period": "evening"
-  },
-  {
     "start": "2024-10-02T20:04:59Z",
     "asin": "B0CQHM2KL5",
     "wpm": 223.88059701492537,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-02T21:37:05Z",
-    "asin": "CFB210D125DE496195B7AE70BACDA51C",
-    "wpm": 1704.5454545454545,
     "period": "evening"
   },
   {
@@ -28608,33 +20616,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-10-03T18:48:39Z",
-    "asin": "B0CGZFPKTZ",
-    "wpm": 2083.3333333333335,
-    "period": "evening"
-  },
-  {
     "start": "2024-10-03T18:51:23Z",
     "asin": "B0CGZFPKTZ",
     "wpm": 1517.3410404624278,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-03T19:31:19Z",
-    "asin": "B0CQHM2KL5",
-    "wpm": 1190.4761904761906,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-03T19:31:37Z",
-    "asin": "B0CGZFPKTZ",
-    "wpm": 2173.913043478261,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-03T20:46:01Z",
-    "asin": "B0CGZFPKTZ",
-    "wpm": 3409.090909090909,
     "period": "evening"
   },
   {
@@ -28704,12 +20688,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-10-07T22:37:30Z",
-    "asin": "ZPWKCGLPBBCYS2KJQQBLM6VSBP3NWID3",
-    "wpm": 2000,
-    "period": "evening"
-  },
-  {
     "start": "2024-10-07T22:38:02Z",
     "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
     "wpm": 303.6375781866764,
@@ -28728,12 +20706,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-10-09T02:24:23Z",
-    "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
-    "wpm": 700.9345794392523,
-    "period": "morning"
-  },
-  {
     "start": "2024-10-09T02:25:08Z",
     "asin": "B0CW1J3Y5G",
     "wpm": 293.69039348196804,
@@ -28743,18 +20715,6 @@
     "start": "2024-10-09T05:57:10Z",
     "asin": "B0CW1J3Y5G",
     "wpm": 24.98750624687656,
-    "period": "morning"
-  },
-  {
-    "start": "2024-10-09T19:20:30Z",
-    "asin": "B0CW1J3Y5G",
-    "wpm": 591.7159763313609,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-10T01:16:14Z",
-    "asin": "B0CW1J3Y5G",
-    "wpm": 3169.0140845070423,
     "period": "morning"
   },
   {
@@ -28774,12 +20734,6 @@
     "asin": "B0CW1J3Y5G",
     "wpm": 51.440329218106996,
     "period": "evening"
-  },
-  {
-    "start": "2024-10-15T03:17:02Z",
-    "asin": "B0CW1J3Y5G",
-    "wpm": 3550.2958579881656,
-    "period": "morning"
   },
   {
     "start": "2024-10-15T03:18:36Z",
@@ -28809,12 +20763,6 @@
     "start": "2024-10-16T19:32:03Z",
     "asin": "B0CW1J3Y5G",
     "wpm": 301.2804418779814,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-16T21:22:17Z",
-    "asin": "B0CW1J3Y5G",
-    "wpm": 1595.7446808510638,
     "period": "evening"
   },
   {
@@ -28905,12 +20853,6 @@
     "start": "2024-10-22T23:04:45Z",
     "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
     "wpm": 131.57894736842104,
-    "period": "evening"
-  },
-  {
-    "start": "2024-10-22T23:42:00Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 1048.951048951049,
     "period": "evening"
   },
   {
@@ -29022,22 +20964,10 @@
     "period": "morning"
   },
   {
-    "start": "2024-10-29T07:49:56Z",
-    "asin": "CQ3N5YSGGUHIX2SAY53DAX226KYAHXEQ",
-    "wpm": 824.1758241758241,
-    "period": "morning"
-  },
-  {
     "start": "2024-10-29T07:50:30Z",
     "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
     "wpm": 84.29672447013486,
     "period": "morning"
-  },
-  {
-    "start": "2024-10-29T22:08:23Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 14563.106796116504,
-    "period": "evening"
   },
   {
     "start": "2024-10-29T22:09:08Z",
@@ -29118,12 +21048,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-11-04T04:24:01Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 1578.9473684210527,
-    "period": "morning"
-  },
-  {
     "start": "2024-11-04T04:24:39Z",
     "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
     "wpm": 549.3355655540441,
@@ -29156,13 +21080,7 @@
   {
     "start": "2024-11-05T22:23:08Z",
     "asin": "AJRS4BNGDESXUY7M52PBWGHXN6W3VFMT",
-    "wpm": 2036.1990950226245,
-    "period": "evening"
-  },
-  {
-    "start": "2024-11-05T22:30:53Z",
-    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
-    "wpm": 2748.6910994764394,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -29170,12 +21088,6 @@
     "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
     "wpm": 240.05761382731856,
     "period": "evening"
-  },
-  {
-    "start": "2024-11-06T04:28:13Z",
-    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
-    "wpm": 582.5242718446602,
-    "period": "morning"
   },
   {
     "start": "2024-11-06T04:29:11Z",
@@ -29190,33 +21102,15 @@
     "period": "evening"
   },
   {
-    "start": "2024-11-06T17:18:55Z",
-    "asin": "B0BBC9K8C3",
-    "wpm": 6666.666666666667,
-    "period": "evening"
-  },
-  {
     "start": "2024-11-07T02:35:43Z",
     "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
     "wpm": 1954.8941676679915,
     "period": "morning"
   },
   {
-    "start": "2024-11-07T03:38:56Z",
-    "asin": "Q2GMDSWTP3KRSTVF5WHAONVIHS325UHL",
-    "wpm": 1630.4347826086957,
-    "period": "morning"
-  },
-  {
     "start": "2024-11-07T03:39:14Z",
     "asin": "28C62463866C4CC99233564ED847A1A5",
     "wpm": 478.9006107717935,
-    "period": "morning"
-  },
-  {
-    "start": "2024-11-08T04:56:45Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 1595.7446808510638,
     "period": "morning"
   },
   {
@@ -29230,12 +21124,6 @@
     "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
     "wpm": 410.8338405356056,
     "period": "evening"
-  },
-  {
-    "start": "2024-11-11T04:52:28Z",
-    "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
-    "wpm": 1181.1023622047244,
-    "period": "morning"
   },
   {
     "start": "2024-11-11T04:52:53Z",
@@ -29286,21 +21174,9 @@
     "period": "morning"
   },
   {
-    "start": "2024-11-17T04:16:03Z",
-    "asin": "RRN3W2L2FVRE27HZJJBTVE5KZTAMZNHN",
-    "wpm": 539.568345323741,
-    "period": "morning"
-  },
-  {
     "start": "2024-11-17T04:16:44Z",
     "asin": "N2GXACRU2Y75KKK7J7XPZLMLHHQJ3XEB",
     "wpm": 38.47140292382662,
-    "period": "morning"
-  },
-  {
-    "start": "2024-11-17T04:27:21Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 6250,
     "period": "morning"
   },
   {
@@ -29412,12 +21288,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-11-25T17:49:24Z",
-    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
-    "wpm": 2912.621359223301,
-    "period": "evening"
-  },
-  {
     "start": "2024-11-25T22:04:14Z",
     "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
     "wpm": 140.66219433023156,
@@ -29451,12 +21321,6 @@
     "start": "2024-11-27T20:58:08Z",
     "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
     "wpm": 119.06651849499922,
-    "period": "evening"
-  },
-  {
-    "start": "2024-11-27T22:12:36Z",
-    "asin": "7FLHIN5CJDB2OBP4B47X3KKHBVS7DZHH",
-    "wpm": 5555.555555555556,
     "period": "evening"
   },
   {
@@ -29582,7 +21446,7 @@
   {
     "start": "2024-12-07T06:36:35Z",
     "asin": "B0CDWDLCNS",
-    "wpm": 3421.052631578947,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -29595,12 +21459,6 @@
     "start": "2024-12-07T17:47:15Z",
     "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
     "wpm": 341.8704368988295,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-07T18:34:48Z",
-    "asin": "AQRV2TZVKL2XDXB54TOUVW5PFQVAB7WU",
-    "wpm": 1898.7341772151901,
     "period": "evening"
   },
   {
@@ -29730,46 +21588,16 @@
     "period": "morning"
   },
   {
-    "start": "2024-12-16T19:01:23Z",
-    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
-    "wpm": 1470.5882352941176,
-    "period": "evening"
-  },
-  {
     "start": "2024-12-16T19:11:24Z",
     "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
-    "wpm": 2135.8159912376777,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-16T19:14:46Z",
-    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
-    "wpm": 15789.473684210525,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-16T19:20:34Z",
-    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
-    "wpm": 7894.736842105263,
+    "wpm": 2000,
     "period": "evening"
   },
   {
     "start": "2024-12-16T20:12:28Z",
     "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
-    "wpm": 4419.121734296831,
+    "wpm": 2000,
     "period": "evening"
-  },
-  {
-    "start": "2024-12-16T20:39:48Z",
-    "asin": "B0BZ5Y513V",
-    "wpm": 2083.3333333333335,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-17T05:28:16Z",
-    "asin": "NKTH6XIJUZNFZ5PZSSWZ6BGQ6ZLGIKBQ",
-    "wpm": 986.8421052631578,
-    "period": "morning"
   },
   {
     "start": "2024-12-17T05:29:16Z",
@@ -29808,12 +21636,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-12-19T05:05:45Z",
-    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
-    "wpm": 1829.268292682927,
-    "period": "morning"
-  },
-  {
     "start": "2024-12-19T05:06:24Z",
     "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
     "wpm": 343.2494279176201,
@@ -29844,12 +21666,6 @@
     "period": "evening"
   },
   {
-    "start": "2024-12-21T06:49:02Z",
-    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
-    "wpm": 1500,
-    "period": "morning"
-  },
-  {
     "start": "2024-12-21T06:58:04Z",
     "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
     "wpm": 165.79165515335728,
@@ -29871,12 +21687,6 @@
     "start": "2024-12-23T15:34:26Z",
     "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
     "wpm": 24.98750624687656,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-23T18:43:32Z",
-    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
-    "wpm": 6382.978723404255,
     "period": "evening"
   },
   {
@@ -29910,12 +21720,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-12-26T07:11:02Z",
-    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
-    "wpm": 710.9004739336492,
-    "period": "morning"
-  },
-  {
     "start": "2024-12-26T07:11:42Z",
     "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
     "wpm": 339.95467271030526,
@@ -29925,12 +21729,6 @@
     "start": "2024-12-27T06:19:19Z",
     "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
     "wpm": 231.15220483641536,
-    "period": "morning"
-  },
-  {
-    "start": "2024-12-28T05:49:09Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 479.2332268370607,
     "period": "morning"
   },
   {
@@ -29952,30 +21750,6 @@
     "period": "morning"
   },
   {
-    "start": "2024-12-30T20:02:55Z",
-    "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
-    "wpm": 5555.555555555556,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-30T20:06:47Z",
-    "asin": "B0CZXNTCFX",
-    "wpm": 3044.2804428044283,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-30T20:10:29Z",
-    "asin": "B0CZXNTCFX",
-    "wpm": 6338.028169014085,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-30T20:10:49Z",
-    "asin": "OOAZWAIV63UB2CXNZN7NGGRP3MSZBQBM",
-    "wpm": 8522.727272727272,
-    "period": "evening"
-  },
-  {
     "start": "2024-12-30T20:32:16Z",
     "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
     "wpm": 552.9953917050691,
@@ -29985,12 +21759,6 @@
     "start": "2024-12-30T20:38:23Z",
     "asin": "B0BQGDMFH6",
     "wpm": 541.4012738853503,
-    "period": "evening"
-  },
-  {
-    "start": "2024-12-30T20:39:18Z",
-    "asin": "OOAZWAIV63UB2CXNZN7NGGRP3MSZBQBM",
-    "wpm": 1948.051948051948,
     "period": "evening"
   },
   {
@@ -30042,12 +21810,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-01-04T20:06:36Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 1293.103448275862,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-05T04:53:35Z",
     "asin": "AHLCEKLOMNBI3WZAR2LXCRUBJ2OBWCFN",
     "wpm": 352.9622017692789,
@@ -30072,18 +21834,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-05T18:21:13Z",
-    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
-    "wpm": 5660.377358490566,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-05T18:21:30Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 3658.536585365854,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-05T18:22:35Z",
     "asin": "B0CH9KQYHS",
     "wpm": 438.91733723482076,
@@ -30099,12 +21849,6 @@
     "start": "2025-01-05T18:36:58Z",
     "asin": "B0CH9KQYHS",
     "wpm": 377.35849056603774,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-05T18:44:10Z",
-    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
-    "wpm": 2439.0243902439024,
     "period": "evening"
   },
   {
@@ -30180,33 +21924,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-07T01:53:34Z",
-    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
-    "wpm": 5555.555555555556,
-    "period": "morning"
-  },
-  {
-    "start": "2025-01-07T01:53:43Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 2272.7272727272725,
-    "period": "morning"
-  },
-  {
-    "start": "2025-01-07T01:55:09Z",
-    "asin": "2EUPLKIM7ATSLPXWBOUA4B2L66BXKDTV",
-    "wpm": 1067.6156583629893,
-    "period": "morning"
-  },
-  {
     "start": "2025-01-07T03:53:42Z",
     "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
     "wpm": 348.5034850348503,
-    "period": "morning"
-  },
-  {
-    "start": "2025-01-07T05:31:28Z",
-    "asin": "JZLZQO3Y3EPKB7K2WUG7MGTYPVYOZWJS",
-    "wpm": 1327.4336283185842,
     "period": "morning"
   },
   {
@@ -30312,21 +22032,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-15T05:10:17Z",
-    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
-    "wpm": 1145.0381679389313,
-    "period": "morning"
-  },
-  {
     "start": "2025-01-15T05:12:12Z",
     "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
     "wpm": 360.3553271132466,
-    "period": "morning"
-  },
-  {
-    "start": "2025-01-15T05:13:57Z",
-    "asin": "LH2FCVKSFLIA3RE4365AAGYFG76TA7UI",
-    "wpm": 2112.676056338028,
     "period": "morning"
   },
   {
@@ -30396,12 +22104,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-01-19T19:41:12Z",
-    "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
-    "wpm": 1470.5882352941176,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-19T21:11:14Z",
     "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
     "wpm": 249.93828684275488,
@@ -30424,12 +22126,6 @@
     "asin": "2CTL27BREQN7JTZSLXXAM2YMSI6DZDZV",
     "wpm": 445.05983582237167,
     "period": "morning"
-  },
-  {
-    "start": "2025-01-20T18:47:57Z",
-    "asin": "2CTL27BREQN7JTZSLXXAM2YMSI6DZDZV",
-    "wpm": 683.371298405467,
-    "period": "evening"
   },
   {
     "start": "2025-01-20T18:54:17Z",
@@ -30486,21 +22182,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-21T20:59:37Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 12500,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-21T21:11:30Z",
     "asin": "B0CC1J32NG",
     "wpm": 119.90407673860912,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-21T21:15:41Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 1785.7142857142856,
     "period": "evening"
   },
   {
@@ -30522,21 +22206,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-21T22:09:51Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 6250,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-21T22:10:46Z",
     "asin": "B0CC1J32NG",
     "wpm": 13.722440764797366,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-21T22:29:43Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 409.8360655737705,
     "period": "evening"
   },
   {
@@ -30636,33 +22308,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-24T16:36:40Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 10000,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-24T16:37:47Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 15000,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-24T16:45:16Z",
     "asin": "B0CC1J32NG",
-    "wpm": 3388.2352941176473,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-24T16:50:24Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 7894.736842105262,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-24T21:20:06Z",
-    "asin": "B0CC1J32NG",
-    "wpm": 1315.7894736842104,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -30682,12 +22330,6 @@
     "asin": "B0DMDYK6Y6",
     "wpm": 344.4152116718488,
     "period": "evening"
-  },
-  {
-    "start": "2025-01-26T05:26:07Z",
-    "asin": "B0DMDYK6Y6",
-    "wpm": 669.6428571428571,
-    "period": "morning"
   },
   {
     "start": "2025-01-26T05:26:59Z",
@@ -30717,12 +22359,6 @@
     "start": "2025-01-26T17:41:55Z",
     "asin": "6LUZMQAT5HFFSBK25OZR3TWRUJ5BDIZS",
     "wpm": 1705.9835982585805,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-26T18:38:43Z",
-    "asin": "D81BB38BBD7A4F42B0EE762A686912BA",
-    "wpm": 1079.136690647482,
     "period": "evening"
   },
   {
@@ -30822,21 +22458,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-01-31T18:27:36Z",
-    "asin": "B0DMDYK6Y6",
-    "wpm": 5172.413793103448,
-    "period": "evening"
-  },
-  {
     "start": "2025-01-31T18:30:28Z",
     "asin": "B0DMDYK6Y6",
     "wpm": 367.2869735553379,
-    "period": "evening"
-  },
-  {
-    "start": "2025-01-31T23:29:46Z",
-    "asin": "B0DMDYK6Y6",
-    "wpm": 943.3962264150942,
     "period": "evening"
   },
   {
@@ -30906,18 +22530,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-02-05T05:29:28Z",
-    "asin": "B000JML2Z6",
-    "wpm": 683.371298405467,
-    "period": "morning"
-  },
-  {
-    "start": "2025-02-05T21:45:42Z",
-    "asin": "T6MYHFXIDDXQI6XRF7TXNWHDWDS2DECW",
-    "wpm": 522.6480836236934,
-    "period": "evening"
-  },
-  {
     "start": "2025-02-05T21:46:38Z",
     "asin": "OEEFKAZSYAYOEA57JWRZYSEGYRAUE75X",
     "wpm": 223.69696517783908,
@@ -30928,12 +22540,6 @@
     "asin": "OEEFKAZSYAYOEA57JWRZYSEGYRAUE75X",
     "wpm": 215.67217828900073,
     "period": "morning"
-  },
-  {
-    "start": "2025-02-06T21:38:44Z",
-    "asin": "OEEFKAZSYAYOEA57JWRZYSEGYRAUE75X",
-    "wpm": 449.10179640718565,
-    "period": "evening"
   },
   {
     "start": "2025-02-06T21:41:03Z",
@@ -30987,12 +22593,6 @@
     "start": "2025-02-08T05:10:04Z",
     "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
     "wpm": 181.69233431389515,
-    "period": "morning"
-  },
-  {
-    "start": "2025-02-09T05:36:29Z",
-    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
-    "wpm": 688.0733944954128,
     "period": "morning"
   },
   {
@@ -31056,18 +22656,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-02-10T22:26:36Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 3913.0434782608695,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-10T23:22:21Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 1530.6122448979593,
-    "period": "evening"
-  },
-  {
     "start": "2025-02-10T23:23:13Z",
     "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
     "wpm": 458.1005586592179,
@@ -31086,39 +22674,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-02-11T23:10:00Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 4205.607476635514,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-11T23:17:03Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 6338.028169014085,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-11T23:25:57Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 2608.695652173913,
-    "period": "evening"
-  },
-  {
     "start": "2025-02-12T00:50:08Z",
     "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
     "wpm": 388.99294049848726,
-    "period": "morning"
-  },
-  {
-    "start": "2025-02-12T01:02:15Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 788.091068301226,
-    "period": "morning"
-  },
-  {
-    "start": "2025-02-12T04:19:00Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 2830.188679245283,
     "period": "morning"
   },
   {
@@ -31138,24 +22696,6 @@
     "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
     "wpm": 286.6546342499204,
     "period": "morning"
-  },
-  {
-    "start": "2025-02-12T12:00:41Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 1515.151515151515,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-12T20:38:51Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 1127.8195488721803,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-12T22:10:56Z",
-    "asin": "WZ34AC3Z6QKT765I3B5YQEO3U3BZXKLN",
-    "wpm": 1388.888888888889,
-    "period": "evening"
   },
   {
     "start": "2025-02-13T04:22:17Z",
@@ -31260,22 +22800,10 @@
     "period": "morning"
   },
   {
-    "start": "2025-02-18T05:23:37Z",
-    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
-    "wpm": 3488.3720930232557,
-    "period": "morning"
-  },
-  {
     "start": "2025-02-18T05:23:51Z",
     "asin": "B003K15IF8",
     "wpm": 317.36872475476054,
     "period": "morning"
-  },
-  {
-    "start": "2025-02-18T12:30:15Z",
-    "asin": "B003K15IF8",
-    "wpm": 3488.3720930232557,
-    "period": "evening"
   },
   {
     "start": "2025-02-18T22:04:03Z",
@@ -31284,21 +22812,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-02-19T05:20:01Z",
-    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
-    "wpm": 570.3422053231939,
-    "period": "morning"
-  },
-  {
     "start": "2025-02-19T05:21:16Z",
     "asin": "B0CQHL1XV7",
     "wpm": 25.008336112037348,
-    "period": "morning"
-  },
-  {
-    "start": "2025-02-19T05:47:00Z",
-    "asin": "B0CQHL1XV7",
-    "wpm": 714.2857142857143,
     "period": "morning"
   },
   {
@@ -31318,12 +22834,6 @@
     "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
     "wpm": 343.03288384196827,
     "period": "morning"
-  },
-  {
-    "start": "2025-02-19T21:32:19Z",
-    "asin": "B081M4F8GH",
-    "wpm": 1764.7058823529412,
-    "period": "evening"
   },
   {
     "start": "2025-02-19T22:16:51Z",
@@ -31377,18 +22887,6 @@
     "start": "2025-02-20T20:27:35Z",
     "asin": "B081M4F8GH",
     "wpm": 141.91106906338695,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-20T20:55:57Z",
-    "asin": "B081M4F8GH",
-    "wpm": 531.9148936170213,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-20T21:50:15Z",
-    "asin": "B081M4F8GH",
-    "wpm": 955.4140127388536,
     "period": "evening"
   },
   {
@@ -31446,18 +22944,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-02-22T06:40:59Z",
-    "asin": "4LXTLEYZY7L7ETOIXN5BEITXMZHJAT2H",
-    "wpm": 2083.3333333333335,
-    "period": "morning"
-  },
-  {
-    "start": "2025-02-22T06:41:12Z",
-    "asin": "4LXTLEYZY7L7ETOIXN5BEITXMZHJAT2H",
-    "wpm": 1875,
-    "period": "morning"
-  },
-  {
     "start": "2025-02-22T06:41:45Z",
     "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
     "wpm": 194.4684528954192,
@@ -31494,36 +22980,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-02-24T18:47:40Z",
-    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
-    "wpm": 9531.772575250836,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-24T20:43:13Z",
-    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
-    "wpm": 13548.387096774191,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-24T21:00:10Z",
-    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
-    "wpm": 11157.02479338843,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-24T21:09:55Z",
-    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
-    "wpm": 9868.421052631578,
-    "period": "evening"
-  },
-  {
-    "start": "2025-02-24T21:21:44Z",
-    "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
-    "wpm": 7653.061224489796,
-    "period": "evening"
-  },
-  {
     "start": "2025-02-24T22:41:54Z",
     "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
     "wpm": 221.77046756606913,
@@ -31552,12 +23008,6 @@
     "asin": "MX76DL77CZU6RDBXMKY4ZAL5GJ55MMGG",
     "wpm": 279.98133457769484,
     "period": "morning"
-  },
-  {
-    "start": "2025-02-26T21:41:42Z",
-    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
-    "wpm": 3688.524590163934,
-    "period": "evening"
   },
   {
     "start": "2025-02-26T21:42:17Z",
@@ -31614,12 +23064,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-02-27T17:26:26Z",
-    "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
-    "wpm": 1724.1379310344828,
-    "period": "evening"
-  },
-  {
     "start": "2025-02-27T22:52:10Z",
     "asin": "HUKF6ODKYJKXSFIK5P7Q7DIOWPD325YP",
     "wpm": 295.2351612240707,
@@ -31654,18 +23098,6 @@
     "asin": "TZP5HFOTIFXZOUVZML2TN6JMK26OPH5M",
     "wpm": 216.91973969631235,
     "period": "morning"
-  },
-  {
-    "start": "2025-03-01T21:39:19Z",
-    "asin": "TZP5HFOTIFXZOUVZML2TN6JMK26OPH5M",
-    "wpm": 1393.188854489164,
-    "period": "evening"
-  },
-  {
-    "start": "2025-03-01T21:57:45Z",
-    "asin": "LHXKLEWH52LWXBSOBOTMRLRJ2CONAJCC",
-    "wpm": 1158.3011583011585,
-    "period": "evening"
   },
   {
     "start": "2025-03-01T21:59:22Z",
@@ -31734,12 +23166,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-03-07T02:29:12Z",
-    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
-    "wpm": 2459.0163934426228,
-    "period": "morning"
-  },
-  {
     "start": "2025-03-07T04:10:07Z",
     "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
     "wpm": 298.11195760185495,
@@ -31780,12 +23206,6 @@
     "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
     "wpm": 277.91059048529763,
     "period": "morning"
-  },
-  {
-    "start": "2025-03-09T12:09:22Z",
-    "asin": "PTBMJPRMFADHGCZ7ESUYHIIFVONVRXUJ",
-    "wpm": 1415.0943396226414,
-    "period": "evening"
   },
   {
     "start": "2025-03-09T17:51:45Z",
@@ -31836,28 +23256,10 @@
     "period": "morning"
   },
   {
-    "start": "2025-03-14T02:47:45Z",
-    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
-    "wpm": 378.78787878787875,
-    "period": "morning"
-  },
-  {
-    "start": "2025-03-14T02:48:31Z",
-    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
-    "wpm": 717.7033492822967,
-    "period": "morning"
-  },
-  {
     "start": "2025-03-14T02:49:00Z",
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
     "wpm": 397.9952830188679,
     "period": "morning"
-  },
-  {
-    "start": "2025-03-14T21:04:13Z",
-    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 1428.5714285714287,
-    "period": "evening"
   },
   {
     "start": "2025-03-14T21:04:33Z",
@@ -31899,12 +23301,6 @@
     "start": "2025-03-16T18:10:45Z",
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
     "wpm": 368.1885125184094,
-    "period": "evening"
-  },
-  {
-    "start": "2025-03-16T23:54:57Z",
-    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 1948.051948051948,
     "period": "evening"
   },
   {
@@ -31956,18 +23352,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-03-20T00:39:48Z",
-    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 5263.157894736842,
-    "period": "morning"
-  },
-  {
-    "start": "2025-03-20T00:39:59Z",
-    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
-    "wpm": 1546.3917525773197,
-    "period": "morning"
-  },
-  {
     "start": "2025-03-20T04:01:25Z",
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
     "wpm": 165.3267634854772,
@@ -31984,12 +23368,6 @@
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
     "wpm": 86.9061413673233,
     "period": "evening"
-  },
-  {
-    "start": "2025-03-22T01:04:52Z",
-    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 1851.8518518518517,
-    "period": "morning"
   },
   {
     "start": "2025-03-22T03:26:47Z",
@@ -32016,40 +23394,10 @@
     "period": "morning"
   },
   {
-    "start": "2025-03-25T20:32:29Z",
-    "asin": "CJJUL3R7HSOXJG3AYG7MQZN3CZZWMZL5",
-    "wpm": 323.97408207343415,
-    "period": "evening"
-  },
-  {
-    "start": "2025-03-25T21:54:08Z",
-    "asin": "TH6GPQAVDDTMCR2XKAXXE5XUWQF5DODY",
-    "wpm": 815.2173913043479,
-    "period": "evening"
-  },
-  {
-    "start": "2025-03-25T21:55:59Z",
-    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
-    "wpm": 3986.7109634551493,
-    "period": "evening"
-  },
-  {
-    "start": "2025-03-25T21:57:11Z",
-    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 2419.3548387096776,
-    "period": "evening"
-  },
-  {
     "start": "2025-03-25T21:58:30Z",
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
     "wpm": 172.7447216890595,
     "period": "evening"
-  },
-  {
-    "start": "2025-03-26T03:31:09Z",
-    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
-    "wpm": 1145.0381679389313,
-    "period": "morning"
   },
   {
     "start": "2025-03-26T03:33:44Z",
@@ -32067,18 +23415,6 @@
     "start": "2025-03-26T05:09:58Z",
     "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
     "wpm": 153.95141977420457,
-    "period": "morning"
-  },
-  {
-    "start": "2025-03-27T01:47:47Z",
-    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
-    "wpm": 1415.0943396226414,
-    "period": "morning"
-  },
-  {
-    "start": "2025-03-27T01:48:23Z",
-    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
-    "wpm": 2027.027027027027,
     "period": "morning"
   },
   {
@@ -32124,30 +23460,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-04-06T16:46:21Z",
-    "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 3750,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-06T16:46:36Z",
-    "asin": "B0CQHL1XV7",
-    "wpm": 6037.151702786377,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-06T16:47:10Z",
-    "asin": "B0CQHL1XV7",
-    "wpm": 1293.103448275862,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-06T16:47:44Z",
-    "asin": "B0CQHL1XV7",
-    "wpm": 4120.879120879121,
-    "period": "evening"
-  },
-  {
     "start": "2025-04-07T02:27:23Z",
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
     "wpm": 813.8351983723296,
@@ -32156,7 +23468,7 @@
   {
     "start": "2025-04-07T02:32:23Z",
     "asin": "TEOQR3X2DN2TSHJ276HTYWLF6WUZXQBC",
-    "wpm": 6178.977272727273,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -32182,18 +23494,6 @@
     "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
     "wpm": 225.2083176938668,
     "period": "evening"
-  },
-  {
-    "start": "2025-04-09T01:22:12Z",
-    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
-    "wpm": 842.6966292134831,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-09T01:22:30Z",
-    "asin": "B0CQHL1XV7",
-    "wpm": 2307.6923076923076,
-    "period": "morning"
   },
   {
     "start": "2025-04-09T01:48:50Z",
@@ -32256,18 +23556,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-04-13T20:09:06Z",
-    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
-    "wpm": 2238.805970149254,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-13T20:09:28Z",
-    "asin": "CDR35CJELKKDYPJWZBMD6CG3XFMVZI4U",
-    "wpm": 1327.4336283185842,
-    "period": "evening"
-  },
-  {
     "start": "2025-04-13T20:13:26Z",
     "asin": "B0D57LWBM6",
     "wpm": 350.79513564078576,
@@ -32292,12 +23580,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-04-14T22:45:11Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 2189.78102189781,
-    "period": "evening"
-  },
-  {
     "start": "2025-04-14T22:46:52Z",
     "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
     "wpm": 136.275146009085,
@@ -32314,42 +23596,6 @@
     "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
     "wpm": 418.6231948259059,
     "period": "morning"
-  },
-  {
-    "start": "2025-04-15T20:39:58Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 1863.354037267081,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-15T20:40:40Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 4195.804195804196,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-15T20:41:40Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 5813.9534883720935,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-15T20:42:12Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 15983.606557377048,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-15T20:43:14Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 8333.333333333334,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-15T21:38:05Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 1442.3076923076922,
-    "period": "evening"
   },
   {
     "start": "2025-04-15T21:38:45Z",
@@ -32370,45 +23616,9 @@
     "period": "morning"
   },
   {
-    "start": "2025-04-16T17:24:46Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
     "start": "2025-04-16T17:25:19Z",
     "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
     "wpm": 663.7168141592921,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T17:34:58Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T17:49:27Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3947.368421052631,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T17:55:39Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 4285.714285714285,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T18:05:05Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3658.536585365854,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T18:05:18Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 4285.714285714285,
     "period": "evening"
   },
   {
@@ -32418,52 +23628,10 @@
     "period": "evening"
   },
   {
-    "start": "2025-04-16T18:47:07Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3157.8947368421054,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T18:50:27Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3225.8064516129034,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T18:58:48Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 4225.352112676056,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-16T19:01:42Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3333.3333333333335,
-    "period": "evening"
-  },
-  {
     "start": "2025-04-16T19:11:44Z",
     "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
     "wpm": 348.83720930232556,
     "period": "evening"
-  },
-  {
-    "start": "2025-04-17T01:59:01Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3879.3103448275865,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-17T03:14:06Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 3629.032258064516,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-17T03:18:13Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 9782.608695652174,
-    "period": "morning"
   },
   {
     "start": "2025-04-17T03:19:44Z",
@@ -32475,12 +23643,6 @@
     "start": "2025-04-17T03:22:46Z",
     "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
     "wpm": 262.17228464419475,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-17T03:39:37Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 418.99441340782124,
     "period": "morning"
   },
   {
@@ -32514,21 +23676,9 @@
     "period": "evening"
   },
   {
-    "start": "2025-04-17T20:33:00Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 5696.20253164557,
-    "period": "evening"
-  },
-  {
     "start": "2025-04-17T20:36:11Z",
     "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
     "wpm": 1072.9613733905578,
-    "period": "evening"
-  },
-  {
-    "start": "2025-04-17T20:39:59Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 4166.666666666667,
     "period": "evening"
   },
   {
@@ -32564,13 +23714,7 @@
   {
     "start": "2025-04-18T01:47:05Z",
     "asin": "TSTOZDLY54TMFJPMV5UY3P7FBETFAS6Y",
-    "wpm": 2159.777055271714,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-18T01:56:17Z",
-    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
-    "wpm": 3037.974683544304,
+    "wpm": 2000,
     "period": "morning"
   },
   {
@@ -32583,30 +23727,6 @@
     "start": "2025-04-18T02:25:13Z",
     "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
     "wpm": 619.9899799599199,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-18T02:45:11Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 1642.3357664233577,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-18T03:06:11Z",
-    "asin": "WVIR53TOCAWTSQCQN5QUVUTPLD2YC7AD",
-    "wpm": 6000,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-18T03:25:25Z",
-    "asin": "II6J4O2WEM4UWTX47RYFLMDPIEDR6GET",
-    "wpm": 785.3403141361256,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-18T03:27:12Z",
-    "asin": "4BEVZWGVCV6GBB2TWCMA4Q54PC2UHGLZ",
-    "wpm": 781.25,
     "period": "morning"
   },
   {
@@ -32628,21 +23748,9 @@
     "period": "morning"
   },
   {
-    "start": "2025-04-21T02:27:38Z",
-    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
-    "wpm": 1666.6666666666667,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-21T02:27:58Z",
-    "asin": "U2Z3ZVHOGQDZ2SJB23WAYVQTZA37NXVN",
-    "wpm": 1027.3972602739725,
-    "period": "morning"
-  },
-  {
     "start": "2025-04-21T22:11:34Z",
     "asin": "B0D3CBLLPH",
-    "wpm": 2451.781627983001,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -32682,24 +23790,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-04-24T01:31:06Z",
-    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
-    "wpm": 2941.176470588235,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-24T01:35:23Z",
-    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
-    "wpm": 3846.153846153846,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-24T01:35:38Z",
-    "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
-    "wpm": 3448.2758620689656,
-    "period": "morning"
-  },
-  {
     "start": "2025-04-24T04:14:03Z",
     "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
     "wpm": 159.49734171097148,
@@ -32709,12 +23799,6 @@
     "start": "2025-04-26T04:05:16Z",
     "asin": "WS7ZNQVX7GBLFJDICPFXB44TVFXYJ3XO",
     "wpm": 650.0541711809317,
-    "period": "morning"
-  },
-  {
-    "start": "2025-04-27T03:29:39Z",
-    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
-    "wpm": 5791.505791505791,
     "period": "morning"
   },
   {
@@ -32752,12 +23836,6 @@
     "asin": "MDA2MPOTKOJLTLOVINZIHHXFP4Q3WPNH",
     "wpm": 308.37759122837076,
     "period": "morning"
-  },
-  {
-    "start": "2025-04-30T20:23:51Z",
-    "asin": "C6ATPLQ37HSITPZJ3VQPW6KVAJUUMK7Y",
-    "wpm": 4109.58904109589,
-    "period": "evening"
   },
   {
     "start": "2025-04-30T20:24:39Z",
@@ -32808,27 +23886,9 @@
     "period": "morning"
   },
   {
-    "start": "2025-05-03T20:37:31Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 802.1390374331552,
-    "period": "evening"
-  },
-  {
-    "start": "2025-05-03T20:38:24Z",
-    "asin": "28C62463866C4CC99233564ED847A1A5",
-    "wpm": 2142.8571428571427,
-    "period": "evening"
-  },
-  {
     "start": "2025-05-03T20:38:42Z",
     "asin": "B0DLLGPNMQ",
     "wpm": 185.07972665148066,
-    "period": "evening"
-  },
-  {
-    "start": "2025-05-04T18:33:25Z",
-    "asin": "B0DLLGPNMQ",
-    "wpm": 659.3406593406594,
     "period": "evening"
   },
   {
@@ -32928,12 +23988,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-05-11T03:42:41Z",
-    "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
-    "wpm": 253.3783783783784,
-    "period": "morning"
-  },
-  {
     "start": "2025-05-13T03:31:03Z",
     "asin": "RESEYEAJK4EJ4ULJAU6NJ6YSAGXJJQBV",
     "wpm": 293.7268340443388,
@@ -32970,12 +24024,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-05-15T00:15:58Z",
-    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
-    "wpm": 842.6966292134831,
-    "period": "morning"
-  },
-  {
     "start": "2025-05-15T00:17:53Z",
     "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
     "wpm": 629.3188548864758,
@@ -33004,12 +24052,6 @@
     "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
     "wpm": 196.48203592814372,
     "period": "evening"
-  },
-  {
-    "start": "2025-05-17T06:36:49Z",
-    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
-    "wpm": 2542.3728813559323,
-    "period": "morning"
   },
   {
     "start": "2025-05-17T14:56:36Z",
@@ -33156,12 +24198,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-05-24T03:40:23Z",
-    "asin": "CLAXYW2N4FTQ76CN6JTRJPY5TJ6LGVCD",
-    "wpm": 1500,
-    "period": "morning"
-  },
-  {
     "start": "2025-05-24T03:44:21Z",
     "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
     "wpm": 350.5582965463516,
@@ -33222,12 +24258,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-05-27T22:08:37Z",
-    "asin": "O6S35RM2ZUUGD5GZ4NVTFU7UOPT7RK4U",
-    "wpm": 1829.268292682927,
-    "period": "evening"
-  },
-  {
     "start": "2025-05-27T22:27:13Z",
     "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
     "wpm": 918.3673469387755,
@@ -33270,27 +24300,9 @@
     "period": "morning"
   },
   {
-    "start": "2025-05-29T19:54:30Z",
-    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
-    "wpm": 6382.978723404255,
-    "period": "evening"
-  },
-  {
-    "start": "2025-05-30T01:19:34Z",
-    "asin": "QYRAXQVBLI3LB5QJ4JUGQRWU5LOQXERK",
-    "wpm": 1485.148514851485,
-    "period": "morning"
-  },
-  {
     "start": "2025-05-30T01:20:44Z",
     "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
     "wpm": 269.29982046678634,
-    "period": "morning"
-  },
-  {
-    "start": "2025-05-30T01:28:09Z",
-    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
-    "wpm": 1136.3636363636363,
     "period": "morning"
   },
   {
@@ -33348,12 +24360,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-06-01T17:05:16Z",
-    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
-    "wpm": 3125,
-    "period": "evening"
-  },
-  {
     "start": "2025-06-01T17:05:34Z",
     "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
     "wpm": 742.9420505200594,
@@ -33363,12 +24369,6 @@
     "start": "2025-06-01T23:26:45Z",
     "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
     "wpm": 288.93780957622454,
-    "period": "evening"
-  },
-  {
-    "start": "2025-06-01T23:27:25Z",
-    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
-    "wpm": 2205.8823529411766,
     "period": "evening"
   },
   {
@@ -33388,12 +24388,6 @@
     "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
     "wpm": 107.93585526315789,
     "period": "morning"
-  },
-  {
-    "start": "2025-06-02T19:12:05Z",
-    "asin": "JNMIUTPQKYQ7HRUKCLKJX5RHPE3OAK4B",
-    "wpm": 3658.536585365854,
-    "period": "evening"
   },
   {
     "start": "2025-06-02T22:16:14Z",
@@ -33456,18 +24450,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-06-11T03:08:48Z",
-    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
-    "wpm": 660.7929515418501,
-    "period": "morning"
-  },
-  {
-    "start": "2025-06-11T03:09:34Z",
-    "asin": "AP5FIAON5SVTMKD5WZJIZMQNHU6IF5Y6",
-    "wpm": 590.5511811023622,
-    "period": "morning"
-  },
-  {
     "start": "2025-06-11T03:15:46Z",
     "asin": "ZPDUB3GM3WAX336MUVRJXWWZQKSYRZ4H",
     "wpm": 360.57692307692304,
@@ -33506,13 +24488,7 @@
   {
     "start": "2025-06-12T23:34:50Z",
     "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
-    "wpm": 4559.8480050664975,
-    "period": "evening"
-  },
-  {
-    "start": "2025-06-12T23:38:10Z",
-    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
-    "wpm": 1520.2702702702702,
+    "wpm": 2000,
     "period": "evening"
   },
   {
@@ -33586,12 +24562,6 @@
     "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
     "wpm": 993.3774834437086,
     "period": "evening"
-  },
-  {
-    "start": "2025-06-16T02:54:12Z",
-    "asin": "JPOXUR4EGOMYIE4NQUVJQIDTMPQQNA4F",
-    "wpm": 1428.5714285714287,
-    "period": "morning"
   },
   {
     "start": "2025-06-16T02:54:46Z",
@@ -33816,12 +24786,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-06-24T04:13:44Z",
-    "asin": "B0D9F3KFPM",
-    "wpm": 602.4096385542169,
-    "period": "morning"
-  },
-  {
     "start": "2025-06-24T04:41:02Z",
     "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
     "wpm": 259.6314907872697,
@@ -33924,34 +24888,16 @@
     "period": "evening"
   },
   {
-    "start": "2025-06-30T20:40:26Z",
-    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
-    "wpm": 1282.051282051282,
-    "period": "evening"
-  },
-  {
     "start": "2025-06-30T20:40:47Z",
     "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
     "wpm": 180.43860460812436,
     "period": "evening"
   },
   {
-    "start": "2025-07-01T02:36:45Z",
-    "asin": "43ORQUG7AE42E3A2GE6TJRETZGVMQIFX",
-    "wpm": 464.39628482972137,
-    "period": "morning"
-  },
-  {
     "start": "2025-07-01T02:47:34Z",
     "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
     "wpm": 320.85561497326205,
     "period": "morning"
-  },
-  {
-    "start": "2025-07-02T16:51:05Z",
-    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
-    "wpm": 3030.30303030303,
-    "period": "evening"
   },
   {
     "start": "2025-07-04T02:35:49Z",
@@ -33988,12 +24934,6 @@
     "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
     "wpm": 365.0904033379694,
     "period": "morning"
-  },
-  {
-    "start": "2025-07-06T17:56:42Z",
-    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
-    "wpm": 1578.9473684210527,
-    "period": "evening"
   },
   {
     "start": "2025-07-06T19:57:10Z",
@@ -34050,12 +24990,6 @@
     "period": "evening"
   },
   {
-    "start": "2025-07-09T00:08:03Z",
-    "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
-    "wpm": 1401.8691588785045,
-    "period": "morning"
-  },
-  {
     "start": "2025-07-09T03:20:45Z",
     "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
     "wpm": 208.44661953960485,
@@ -34102,12 +25036,6 @@
     "asin": "SL7WU7EAKIJMP6UUMD2XUOQFJIPQTNPT",
     "wpm": 961.7006917496203,
     "period": "evening"
-  },
-  {
-    "start": "2025-07-11T05:44:38Z",
-    "asin": "B0DJM99D77",
-    "wpm": 579.1505791505792,
-    "period": "morning"
   },
   {
     "start": "2025-07-11T05:45:26Z",
@@ -34260,39 +25188,15 @@
     "period": "evening"
   },
   {
-    "start": "2025-07-14T23:39:44Z",
-    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
-    "wpm": 267.85714285714283,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-14T23:41:01Z",
     "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
     "wpm": 191.31026273276083,
     "period": "evening"
   },
   {
-    "start": "2025-07-15T03:50:16Z",
-    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
-    "wpm": 1773.049645390071,
-    "period": "morning"
-  },
-  {
     "start": "2025-07-15T03:52:09Z",
     "asin": "B0DJM99D77",
     "wpm": 328.7310979618672,
-    "period": "morning"
-  },
-  {
-    "start": "2025-07-15T04:00:03Z",
-    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
-    "wpm": 967.7419354838709,
-    "period": "morning"
-  },
-  {
-    "start": "2025-07-15T04:06:18Z",
-    "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
-    "wpm": 1219.5121951219512,
     "period": "morning"
   },
   {
@@ -34362,34 +25266,10 @@
     "period": "evening"
   },
   {
-    "start": "2025-07-17T21:13:22Z",
-    "asin": "MZJHLPOQEFK6QOXINYVHNIKWVK53C26Z",
-    "wpm": 2142.8571428571427,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-18T03:22:02Z",
     "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
     "wpm": 242.10068905580732,
     "period": "morning"
-  },
-  {
-    "start": "2025-07-18T16:30:23Z",
-    "asin": "RBEXH5ATPIXTSXDRPADA6TMFIDDTOR4L",
-    "wpm": 1162.7906976744187,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-18T16:31:46Z",
-    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
-    "wpm": 4213.483146067415,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-18T16:32:28Z",
-    "asin": "7KRWAI2AYO7QURIYLICYT2S4DTQWFXK7",
-    "wpm": 1470.5882352941176,
-    "period": "evening"
   },
   {
     "start": "2025-07-18T20:19:17Z",
@@ -34488,45 +25368,15 @@
     "period": "morning"
   },
   {
-    "start": "2025-07-21T04:38:01Z",
-    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
-    "wpm": 2250,
-    "period": "morning"
-  },
-  {
     "start": "2025-07-21T04:38:27Z",
     "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
     "wpm": 124.5995016019936,
     "period": "morning"
   },
   {
-    "start": "2025-07-21T14:21:59Z",
-    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
-    "wpm": 1229.5081967213114,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-21T14:22:16Z",
-    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
-    "wpm": 4411.764705882353,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-21T14:22:31Z",
     "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
     "wpm": 25.342118601115054,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-21T19:55:07Z",
-    "asin": "KGYWKIBH5PNSEB3YPUA5KDHPGPGI5X4V",
-    "wpm": 290.69767441860466,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-21T19:56:43Z",
-    "asin": "B0DJM99D77",
-    "wpm": 974.025974025974,
     "period": "evening"
   },
   {
@@ -34560,12 +25410,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-07-23T21:46:36Z",
-    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
-    "wpm": 1086.9565217391305,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-23T21:47:07Z",
     "asin": "CD2J6YLYY6SMOGLTHM77PUX5YBUTBUKC",
     "wpm": 242.13075060532688,
@@ -34593,12 +25437,6 @@
     "start": "2025-07-26T04:12:36Z",
     "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
     "wpm": 1296.0934647681636,
-    "period": "morning"
-  },
-  {
-    "start": "2025-07-26T04:29:22Z",
-    "asin": "433NYT3NYBLOUOHLMNP7KZE4BASGKFI2",
-    "wpm": 1363.6363636363637,
     "period": "morning"
   },
   {
@@ -34644,12 +25482,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-07-27T18:29:11Z",
-    "asin": "77X5BC7DFTLU4LZPF46IWOWFXBG44XNJ",
-    "wpm": 1271.1864406779662,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-27T18:33:16Z",
     "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
     "wpm": 234.26433734064577,
@@ -34680,12 +25512,6 @@
     "period": "morning"
   },
   {
-    "start": "2025-07-29T15:46:38Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 607.2874493927126,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-29T20:26:23Z",
     "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
     "wpm": 469.1164972634871,
@@ -34698,51 +25524,9 @@
     "period": "morning"
   },
   {
-    "start": "2025-07-30T13:47:20Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 277.2643253234751,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-30T13:48:17Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 617.283950617284,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-30T13:48:44Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 4545.454545454545,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-30T13:49:05Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 1648.3516483516482,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-30T13:49:18Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 6000,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-30T13:49:29Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 2000,
-    "period": "evening"
-  },
-  {
     "start": "2025-07-30T13:49:43Z",
     "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
     "wpm": 129.08777969018934,
-    "period": "evening"
-  },
-  {
-    "start": "2025-07-30T17:21:57Z",
-    "asin": "CYYIMAPVWFZQZ7XVINNTFI6QPBWGZ245",
-    "wpm": 1376.1467889908256,
     "period": "evening"
   },
   {
@@ -34804,24 +25588,6 @@
     "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
     "wpm": 329.89820284026644,
     "period": "morning"
-  },
-  {
-    "start": "2025-08-01T21:01:49Z",
-    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
-    "wpm": 815.2173913043479,
-    "period": "evening"
-  },
-  {
-    "start": "2025-08-01T21:02:13Z",
-    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
-    "wpm": 1442.3076923076922,
-    "period": "evening"
-  },
-  {
-    "start": "2025-08-01T21:03:34Z",
-    "asin": "SEZPDYLSFM2BYZQJNVIF2P5X74LX7RKR",
-    "wpm": 1578.9473684210527,
-    "period": "evening"
   },
   {
     "start": "2025-08-02T04:47:13Z",

--- a/src/services/readingSpeed.js
+++ b/src/services/readingSpeed.js
@@ -1,8 +1,12 @@
+const MAX_WPM = 2000;
+const MIN_DURATION_MILLIS = 60 * 1000;
+
 function calculateReadingSpeeds(sessions) {
   return sessions
     .filter((s) => {
       const ts = s.start_timestamp || s.end_timestamp;
-      return ts && ts !== 'Not Available';
+      const millis = Number(s.total_reading_millis || 0);
+      return ts && ts !== 'Not Available' && millis >= MIN_DURATION_MILLIS;
     })
     .map((s) => {
       const start =
@@ -12,7 +16,7 @@ function calculateReadingSpeeds(sessions) {
       const minutes = Number(s.total_reading_millis || 0) / 60000;
       const pages = Number(s.number_of_page_flips || 0);
       const words = pages * 250;
-      const wpm = minutes > 0 ? words / minutes : 0;
+      const wpm = minutes > 0 ? Math.min(words / minutes, MAX_WPM) : 0;
       const hour = new Date(start).getHours();
       const period = hour < 12 ? 'morning' : 'evening';
       return {


### PR DESCRIPTION
## Summary
- avoid unrealistic speed data by filtering sessions shorter than a minute and capping WPM at 2000
- regenerate reading-speed dataset with capped values

## Testing
- `npm test` *(fails: BookNetwork component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68926dfb3cd88324b92c0f71fefe4b5c