### PR TITLE
feat: filter kindle genre transitions by date

### DIFF
--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -34,10 +34,6 @@ export default function GenreSankey() {
   }, []);
 
   useEffect(() => {
-    if (start && end) fetchData();
-  }, [start, end]);
-
-  useEffect(() => {
     const svg = select(svgRef.current);
     svg.selectAll('*').remove();
     if (!data || data.length === 0) return;

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -38,6 +38,7 @@ describe('GenreSankey', () => {
     fireEvent.change(screen.getByLabelText('End'), {
       target: { value: '2024-01-31' },
     });
+    expect(global.fetch).not.toHaveBeenCalled();
     fireEvent.click(screen.getByText('Apply'));
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- fetch genre transitions with start/end range and refresh diagram on Apply
- test filtered fetch to ensure new links render

## Testing
- `npx vitest run src/components/genre/__tests__/GenreSankey.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68926dcd91cc8324a789b994f63d18da