### PR TITLE
Import MarkerCluster CSS for Leaflet clustering

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import App from "./App";
 import "./styles/globals.css";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "leaflet/dist/leaflet.css";
+import "leaflet.markercluster/dist/MarkerCluster.css";
+import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import { InterventionPreferencesProvider } from "@/hooks/useInterventionPreferences";
 import { FocusHistoryProvider } from "@/hooks/useFocusHistory";
 


### PR DESCRIPTION
## Summary
- import MarkerCluster CSS in main entry point to style Leaflet marker clusters

## Testing
- `npm test` *(fails: BookNetwork component tests)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892770c857c8324b08ff6158d2f3df6