### PR TITLE
feat: fetch session locations asynchronously

### DIFF
--- a/src/components/map/__tests__/ReadingMap.test.jsx
+++ b/src/components/map/__tests__/ReadingMap.test.jsx
@@ -44,6 +44,18 @@ vi.mock('../HeatmapLayer', () => ({
   default: () => null,
 }));
 
+vi.mock('@/services/locationData', () => ({
+  fetchSessionLocations: () =>
+    Promise.resolve([
+      {
+        start: '2020-01-01T00:00:00Z',
+        title: 'Test',
+        latitude: 0,
+        longitude: 0,
+      },
+    ]),
+}));
+
 describe('ReadingMap', () => {
   it('renders map with controls', async () => {
     render(<ReadingMap />);

--- a/src/services/locationData.js
+++ b/src/services/locationData.js
@@ -4,4 +4,12 @@ function getSessionLocations() {
   return sessionLocations;
 }
 
-module.exports = { getSessionLocations };
+async function fetchSessionLocations() {
+  const res = await fetch('/api/kindle/locations');
+  if (!res.ok) throw new Error('Failed to fetch locations');
+  const data = await res.json();
+  if (!Array.isArray(data)) throw new Error('Invalid locations data');
+  return data;
+}
+
+module.exports = { getSessionLocations, fetchSessionLocations };


### PR DESCRIPTION
## Summary
- add async `fetchSessionLocations` helper
- load session locations via fetch with fallback messaging
- mock location fetch in `ReadingMap` tests

## Testing
- `npm test src/components/map/__tests__/ReadingMap.test.jsx src/services/__tests__/locationData.test.js`
- `npm test` *(fails: BookNetwork component tests)*

------
https://chatgpt.com/codex/tasks/task_e_6892794e03748324b5d4221f0f7d1f51