### PR TITLE
feat: add accessibility to timeline bars

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -88,16 +88,26 @@ export default function ReadingTimeline({ sessions = [] }) {
     const renderBars = (domain = initialDomain) => {
       x.domain(domain);
       barsG.selectAll('*').remove();
-      const bars = barsG
-        .selectAll('rect')
+      const barGroups = barsG
+        .selectAll('g')
         .data(parsedSessions)
         .enter()
+        .append('g')
+        .attr('role', 'group');
+
+      const bars = barGroups
         .append('rect')
         .attr('x', (d) => x(d.startDate))
         .attr('y', (d) => d.lane * LANE_HEIGHT + LANE_PADDING)
         .attr('width', (d) => Math.max(1, x(d.endDate) - x(d.startDate)))
         .attr('height', BAR_HEIGHT)
-        .attr('fill', (d) => colorScale(d.genre || 'Unknown'));
+        .attr('fill', (d) => colorScale(d.genre || 'Unknown'))
+        .attr('tabindex', 0)
+        .attr(
+          'aria-label',
+          (d) =>
+            `${d.title}, ${d.duration.toFixed(1)} minutes, ${d.highlights} highlights`,
+        );
 
       bars
         .append('title')

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -126,6 +126,14 @@ describe('ReadingTimeline', () => {
     expect(rects[1].getAttribute('fill')).toBe('hsl(var(--chart-2))');
   });
 
+  it('makes each bar focusable with an aria-label', () => {
+    const { container } = render(<ReadingTimeline sessions={sessions} />);
+    const svg = container.querySelector('svg');
+    const rects = svg.querySelectorAll('rect[tabindex="0"]');
+    expect(rects).toHaveLength(sessions.length);
+    expect(rects[0].getAttribute('aria-label')).toContain('Test Book 1');
+  });
+
   it('renders a legend for genres with matching colors', () => {
     const { getByRole } = render(<ReadingTimeline sessions={sessions} />);
     const list = getByRole('list', { name: /genres/i });


### PR DESCRIPTION
## Summary
- make reading timeline bars keyboard-focusable and screen-reader friendly
- cover aria-label behavior with tests

## Testing
- `CI=true npm test -- --run` *(fails: BookNetwork test suite)*

------
https://chatgpt.com/codex/tasks/task_e_689273f1d6008324a4e91ed07764c5a0