### PR TITLE
Align CalendarHeatmap weeks to Monday

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -9,7 +9,13 @@ import {
   TooltipProvider,
 } from '@/ui/tooltip';
 import { Skeleton } from '@/ui/skeleton';
-import { getISOWeek, getISOWeekYear, getMonth, getYear } from 'date-fns';
+import {
+  getISOWeek,
+  getISOWeekYear,
+  getMonth,
+  getYear,
+  getISODay,
+} from 'date-fns';
 
 const monthNames = [
   'Jan',
@@ -62,7 +68,9 @@ function YearlyHeatmap({ data, maxMinutes }) {
   const endDate = new Date(Math.max(...dates));
 
   const startWithEmptyDays = new Date(startDate);
-  startWithEmptyDays.setDate(startWithEmptyDays.getDate() - startDate.getDay());
+  startWithEmptyDays.setDate(
+    startWithEmptyDays.getDate() - ((getISODay(startDate) + 6) % 7)
+  );
 
   const dataByMonth = data.reduce((acc, d) => {
     const dt = new Date(d.date);
@@ -91,7 +99,7 @@ function YearlyHeatmap({ data, maxMinutes }) {
     const dt = new Date(d.date);
     const weekKey = `${getISOWeekYear(dt)}-${getISOWeek(dt)}`;
     if (!weekSeries[weekKey]) weekSeries[weekKey] = Array(7).fill(0);
-    const dayIdx = (dt.getDay() + 6) % 7; // Monday=0
+    const dayIdx = getISODay(dt) - 1; // Monday=0
     weekSeries[weekKey][dayIdx] = d.minutes;
   });
 
@@ -129,7 +137,7 @@ function YearlyHeatmap({ data, maxMinutes }) {
     if (date.getDate() === 1) {
       const key = `${date.getFullYear()}-${date.getMonth()}`;
       const size = Number(element.props.height) || 10;
-      const topY = element.props.y - date.getDay() * size;
+      const topY = element.props.y - (getISODay(date) - 1) * size;
       const bottomY = topY + size * 7 + 12;
       return (
         <g key={dateKey}>
@@ -152,7 +160,7 @@ function YearlyHeatmap({ data, maxMinutes }) {
     <TooltipProvider>
       <div>
         <Heatmap
-          startDate={startDate}
+          startDate={startWithEmptyDays}
           endDate={endDate}
           values={values}
           classForValue={classForValue}

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -74,6 +74,17 @@ describe('CalendarHeatmap', () => {
     });
   });
 
+  it('aligns weeks starting on Monday', () => {
+    const { container } = render(<CalendarHeatmap />);
+    const monday = container.querySelector('rect[data-date="2024-01-01"]');
+    const sunday = container.querySelector('rect[data-date="2024-01-07"]');
+    expect(monday).not.toBeNull();
+    expect(sunday).not.toBeNull();
+    const yMonday = parseFloat(monday.getAttribute('y'));
+    const ySunday = parseFloat(sunday.getAttribute('y'));
+    expect(yMonday).toBeLessThan(ySunday);
+  });
+
   it('shows tooltip with date, minutes, and sparkline', async () => {
     const user = userEvent.setup();
     const { container } = render(<CalendarHeatmap />);


### PR DESCRIPTION
## Summary
- use ISO weekday calculations so CalendarHeatmap weeks start on Monday
- ensure week indices and month labels respect Monday-as-0 indexing
- add test confirming heatmap grid aligns Monday before Sunday

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68927b0225408324bfad5b907cef85d3