### PR TITLE
feat: async CSV parsing for kindle service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "class-variance-authority": "^0.7.0",
         "compromise": "^14.14.4",
         "cors": "^2.8.5",
+        "csv-parse": "^6.1.0",
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",
         "d3-chord": "^3.0.1",
@@ -5712,6 +5713,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
       "license": "MIT"
     },
     "node_modules/cwise": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "^0.7.0",
     "compromise": "^14.14.4",
     "cors": "^2.8.5",
+    "csv-parse": "^6.1.0",
     "d3-axis": "^3.0.0",
     "d3-brush": "^3.0.0",
     "d3-chord": "^3.0.1",

--- a/server/api/kindle.js
+++ b/server/api/kindle.js
@@ -15,93 +15,93 @@ const {
 
 const router = express.Router();
 
-router.get('/events', (req, res) => {
+router.get('/events', async (req, res) => {
   try {
-    res.json(getEvents());
+    res.json(await getEvents());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load events' });
   }
 });
 
-router.get('/points', (req, res) => {
+router.get('/points', async (req, res) => {
   try {
-    res.json(getPoints());
+    res.json(await getPoints());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load points' });
   }
 });
 
-router.get('/achievements', (req, res) => {
+router.get('/achievements', async (req, res) => {
   try {
-    res.json(getAchievements());
+    res.json(await getAchievements());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load achievements' });
   }
 });
 
-router.get('/daily-stats', (req, res) => {
+router.get('/daily-stats', async (req, res) => {
   try {
-    res.json(getDailyStats());
+    res.json(await getDailyStats());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load daily stats' });
   }
 });
 
-router.get('/sessions', (req, res) => {
+router.get('/sessions', async (req, res) => {
   try {
-    res.json(getSessions());
+    res.json(await getSessions());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load sessions' });
   }
 });
 
-router.get('/genre-hierarchy', (req, res) => {
+router.get('/genre-hierarchy', async (req, res) => {
   try {
-    res.json(getGenreHierarchy());
+    res.json(await getGenreHierarchy());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load genre hierarchy' });
   }
 });
 
-router.get('/genre-transitions', (req, res) => {
+router.get('/genre-transitions', async (req, res) => {
   try {
     const { start, end } = req.query;
-    const transitions = getGenreTransitions(start, end);
+    const transitions = await getGenreTransitions(start, end);
     res.json(transitions);
   } catch (err) {
     res.status(500).json({ error: 'Failed to load genre transitions' });
   }
 });
 
-router.get('/highlights/search', (req, res) => {
+router.get('/highlights/search', async (req, res) => {
   const { keyword } = req.query;
   if (!keyword) return res.status(400).json({ error: 'keyword query required' });
   try {
-    res.json(getHighlightExpansions(keyword));
+    res.json(await getHighlightExpansions(keyword));
   } catch (err) {
     res.status(500).json({ error: 'Failed to search highlights' });
   }
 });
 
-router.get('/locations', (req, res) => {
+router.get('/locations', async (req, res) => {
   try {
-    res.json(getLocations());
+    res.json(await getLocations());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load locations' });
   }
 });
 
-router.get('/reading-speed', (req, res) => {
+router.get('/reading-speed', async (req, res) => {
   try {
-    res.json(getReadingSpeed());
+    res.json(await getReadingSpeed());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load reading speed' });
   }
 });
 
-router.get('/book-graph', (req, res) => {
+router.get('/book-graph', async (req, res) => {
   try {
-    res.json(getBookGraph());
+    res.json(await getBookGraph());
   } catch (err) {
     res.status(500).json({ error: 'Failed to load book graph' });
   }

--- a/server/services/kindleService.test.js
+++ b/server/services/kindleService.test.js
@@ -8,34 +8,34 @@ afterEach(() => {
 });
 
 describe('kindleService', () => {
-  it('getEvents parses CSV into array of records', () => {
-    const csv = 'Timestamp,Activity\n2025-01-01T00:00:00Z,OPENED';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(csv);
-    const result = getEvents();
+  it('getEvents parses CSV with quoted commas', async () => {
+    const csv = 'Timestamp,Activity\n2025-01-01T00:00:00Z,"OPENED, page 1"';
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(csv);
+    const result = await getEvents();
     expect(result).toEqual([
-      { Timestamp: '2025-01-01T00:00:00Z', Activity: 'OPENED' },
+      { Timestamp: '2025-01-01T00:00:00Z', Activity: 'OPENED, page 1' },
     ]);
   });
 
-  it('getPoints returns first row as object', () => {
-    const csv = 'Available Balance (Points),Marketplace,Pending Balance (Points)\n10,www.amazon.com,0';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(csv);
-    const result = getPoints();
+  it('getPoints returns first row as object', async () => {
+    const csv = 'Available Balance (Points),Marketplace,Pending Balance (Points)\n10,"www.amazon.com,uk",0';
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(csv);
+    const result = await getPoints();
     expect(result).toEqual({
       'Available Balance (Points)': '10',
-      Marketplace: 'www.amazon.com',
+      Marketplace: 'www.amazon.com,uk',
       'Pending Balance (Points)': '0',
     });
   });
 
-  it('getAchievements parses CSV into array', () => {
-    const csv = 'AchievementGroupName,AchievementName,EarnDate,Marketplace,Quantity\nGroup,Gold,2024-01-01Z,www.amazon.com,1';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(csv);
-    const result = getAchievements();
+  it('getAchievements parses CSV with quoted fields', async () => {
+    const csv = 'AchievementGroupName,AchievementName,EarnDate,Marketplace,Quantity\nGroup,"Gold, Level",2024-01-01Z,"www.amazon.com","1"';
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(csv);
+    const result = await getAchievements();
     expect(result).toEqual([
       {
         AchievementGroupName: 'Group',
-        AchievementName: 'Gold',
+        AchievementName: 'Gold, Level',
         EarnDate: '2024-01-01Z',
         Marketplace: 'www.amazon.com',
         Quantity: '1',


### PR DESCRIPTION
## Summary
- replace manual CSV parsing with async `csv-parse` that respects quoted values
- convert Kindle service and API routes to async/await and non-blocking fs.promises
- test CSV parsing with commas and quotes

## Testing
- `npx vitest server/services/kindleService.test.js server/api/kindle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689280da6f048324931c858a353b9726