### PR TITLE
Refactor weather run fetch with Promise.all

### DIFF
--- a/src/lib/__tests__/weatherApi.test.ts
+++ b/src/lib/__tests__/weatherApi.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getWeatherForRuns } from '../weatherApi'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function mockFetch(delays: number[], rejectIndex?: number) {
+  let call = 0
+  const fetchMock = vi.fn(() => {
+    const idx = call++
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (idx === rejectIndex) {
+          reject(new Error('fail'))
+          return
+        }
+        resolve({
+          json: async () => ({
+            hourly: {
+              temperature_2m: [0],
+              relative_humidity_2m: [0],
+              weathercode: [0],
+              windspeed_10m: [0],
+            },
+          }),
+        })
+      }, delays[idx])
+    })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+}
+
+describe('getWeatherForRuns', () => {
+  it('returns weather data in the original order', async () => {
+    const runs = [
+      { date: '2024-01-01', lat: 0, lon: 0 },
+      { date: '2024-01-02', lat: 0, lon: 0 },
+      { date: '2024-01-03', lat: 0, lon: 0 },
+    ]
+    mockFetch([30, 10, 20])
+    const result = await getWeatherForRuns(runs)
+    expect(result.map((r) => r.date)).toEqual(runs.map((r) => r.date))
+  })
+
+  it('continues when a run fails and keeps order of the rest', async () => {
+    const runs = [
+      { date: '2024-01-01', lat: 0, lon: 0 },
+      { date: '2024-01-02', lat: 0, lon: 0 },
+      { date: '2024-01-03', lat: 0, lon: 0 },
+    ]
+    mockFetch([30, 10, 20], 1)
+    const result = await getWeatherForRuns(runs)
+    expect(result.map((r) => r.date)).toEqual([
+      '2024-01-01',
+      '2024-01-03',
+    ])
+  })
+})

--- a/src/lib/weatherApi.ts
+++ b/src/lib/weatherApi.ts
@@ -39,15 +39,11 @@ export async function getDailyWeather(
 export async function getWeatherForRuns(
   runs: { date: string; lat: number; lon: number }[],
 ): Promise<DailyWeather[]> {
-  const result: DailyWeather[] = []
-  for (const run of runs) {
-    try {
-      result.push(await getDailyWeather(run.lat, run.lon, run.date))
-    } catch {
-      // ignore errors so dashboards still load
-    }
-  }
-  return result
+  const promises = runs.map((run) =>
+    getDailyWeather(run.lat, run.lon, run.date).catch(() => null),
+  )
+  const results = await Promise.all(promises)
+  return results.filter((r): r is DailyWeather => r !== null)
 }
 
 export async function getWeatherForecast(


### PR DESCRIPTION
## Summary
- refactor getWeatherForRuns to use Promise.all and ignore failed requests
- add tests ensuring run weather data preserves input order and skips failures

## Testing
- `npm test` *(fails: BookNetwork, GenreSankey, BookNetwork tests etc)*

------
https://chatgpt.com/codex/tasks/task_e_689280f0ba5c8324ae34a756b5bea7e3