### PR TITLE
Handle state visit API failures

### DIFF
--- a/src/components/maps/StateVisitCallout.tsx
+++ b/src/components/maps/StateVisitCallout.tsx
@@ -27,7 +27,7 @@ interface StateVisitCalloutProps {
 export default function StateVisitCallout({
   onSelectState,
 }: StateVisitCalloutProps) {
-  const { data: visits, loading } = useStateVisits();
+  const { data: visits, loading, error, refetch } = useStateVisits();
 
   const latest = useMemo(() => {
     if (!visits) return null;
@@ -60,7 +60,15 @@ export default function StateVisitCallout({
   }, [visits]);
 
   if (loading) return <Skeleton className="h-4 w-full" />;
-  if (!visits) return null;
+  if (error || !visits)
+    return (
+      <div className="text-xs">
+        Failed to load state visits.
+        <button className="underline" onClick={refetch}>
+          Retry
+        </button>
+      </div>
+    );
   if (!latest) return null;
 
   const { type, stateCode, stateName, formattedDate, formattedMiles } = latest;

--- a/src/components/maps/StateVisitSummary.tsx
+++ b/src/components/maps/StateVisitSummary.tsx
@@ -22,17 +22,15 @@ export default function StateVisitSummary() {
 
   if (loading) return <Skeleton className="h-4 w-full" />;
 
-  if (error)
+  if (error || !states)
     return (
       <div className="text-xs">
-        Failed to load state visits.{" "}
+        Failed to load state visits.
         <button className="underline" onClick={refetch}>
           Retry
         </button>
       </div>
     );
-
-  if (!summary) return null;
 
   return (
     <div className="flex gap-2 flex-wrap text-xs mb-2">

--- a/src/hooks/__tests__/useStateVisits.test.ts
+++ b/src/hooks/__tests__/useStateVisits.test.ts
@@ -1,0 +1,22 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { getStateVisits } from "@/lib/api";
+import { useStateVisits } from "../useStateVisits";
+
+vi.mock("@/lib/api", () => ({
+  __esModule: true,
+  getStateVisits: vi.fn(),
+}));
+
+describe("useStateVisits", () => {
+  it("returns null data and an error when the API fails", async () => {
+    const err = new Error("API error");
+    (getStateVisits as any).mockRejectedValue(err);
+    const { result } = renderHook(() => useStateVisits());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toEqual(err);
+  });
+});

--- a/src/hooks/useStateVisits.ts
+++ b/src/hooks/useStateVisits.ts
@@ -21,13 +21,13 @@ export function useStateVisits(): UseStateVisitsResult {
       const result = await getStateVisits();
       if (!result) {
         setError(new Error("Failed to load state visits"));
-        setData([]);
+        setData(null);
       } else {
         setData(result);
       }
     } catch (e) {
       setError(e as Error);
-      setData([]);
+      setData(null);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- ensure `useStateVisits` keeps data `null` when the API fails
- guard map components when state visits fail to load
- test hook error handling when state visit API rejects

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_689280e589208324b9ea5879cffd1222