### PR TITLE
feat: label timeline axis and add grid lines

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -11,7 +11,7 @@ const BAR_HEIGHT = 30;
 const LANE_PADDING = 5;
 const LANE_HEIGHT = BAR_HEIGHT + LANE_PADDING;
 const BRUSH_HEIGHT = 10;
-const AXIS_HEIGHT = 20;
+const AXIS_HEIGHT = 40;
 
 
 export default function ReadingTimeline({ sessions = [] }) {
@@ -83,7 +83,9 @@ export default function ReadingTimeline({ sessions = [] }) {
       .attr('transform', `translate(0,${BRUSH_HEIGHT + height})`);
     const xAxis = axisBottom(x)
       .ticks(timeMonth.every(1))
-      .tickFormat(timeFormat('%b'));
+      .tickFormat(timeFormat('%b'))
+      .tickSize(-height)
+      .tickSizeOuter(0);
 
     const renderBars = (domain = initialDomain) => {
       x.domain(domain);
@@ -107,6 +109,18 @@ export default function ReadingTimeline({ sessions = [] }) {
         );
 
       axisG.call(xAxis);
+      axisG
+        .selectAll('.tick line')
+        .attr('stroke', '#ccc')
+        .attr('stroke-opacity', 0.3);
+      axisG.selectAll('.axis-label').remove();
+      axisG
+        .append('text')
+        .attr('class', 'axis-label')
+        .attr('x', WIDTH / 2)
+        .attr('y', AXIS_HEIGHT - 5)
+        .attr('text-anchor', 'middle')
+        .text('Date');
 
       barsG.selectAll('.annotation').remove();
       const annotate = (session, cls, label) => {

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -64,6 +64,12 @@ describe('ReadingTimeline', () => {
     let rect = svg.querySelector('rect');
     const initialWidth = Number(rect.getAttribute('width'));
 
+    let axisLabel = svg.querySelector('.x-axis .axis-label');
+    expect(axisLabel).toBeInTheDocument();
+    expect(axisLabel.textContent).toBe('Date');
+    let tickLines = svg.querySelectorAll('.x-axis .tick line');
+    expect(Number(tickLines[0].getAttribute('y2'))).toBeLessThan(0);
+
     act(() => {
       select(svg.querySelector('.brush')).call(brush.move, [0, viewWidth / 2]);
     });
@@ -71,6 +77,11 @@ describe('ReadingTimeline', () => {
     rect = svg.querySelector('rect');
     const zoomWidth = Number(rect.getAttribute('width'));
     expect(zoomWidth).toBeGreaterThan(initialWidth);
+
+    axisLabel = svg.querySelector('.x-axis .axis-label');
+    expect(axisLabel).toBeInTheDocument();
+    tickLines = svg.querySelectorAll('.x-axis .tick line');
+    expect(Number(tickLines[0].getAttribute('y2'))).toBeLessThan(0);
 
     const resetBtn = getByRole('button', { name: /reset/i });
     expect(resetBtn).toBeEnabled();
@@ -91,6 +102,12 @@ describe('ReadingTimeline', () => {
     expect(ticks.length).toBeGreaterThan(0);
     // axis uses monthly ticks with abbreviated month names
     expect(ticks[0].textContent).toMatch(/^[A-Za-z]{3}$/);
+    const axisLabel = svg.querySelector('.x-axis .axis-label');
+    expect(axisLabel).toBeInTheDocument();
+    expect(axisLabel.textContent).toBe('Date');
+    const tickLines = svg.querySelectorAll('.x-axis .tick line');
+    expect(tickLines.length).toBeGreaterThan(0);
+    expect(Number(tickLines[0].getAttribute('y2'))).toBeLessThan(0);
 
     const rects = svg.querySelectorAll('rect[height="30"]');
     const longestAnnot = svg.querySelector('.annotation-longest');


### PR DESCRIPTION
## Summary
- show month/date label on ReadingTimeline x-axis
- add tick-aligned grid lines for clearer alignment
- test axis label and grid lines in zoomed and full views

## Testing
- `npm test` *(fails: 2 failed, 87 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68927b96455883249be5da234eebe36c