### PR TITLE
feat: improve reading calendar visuals

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -174,8 +174,19 @@ function YearlyHeatmap({ data, maxMinutes }) {
       const size = Number(element.props.height) || 10;
       const topY = element.props.y - (getISODay(date) - 1) * size;
       const bottomY = topY + size * 7 + 12;
+      const lineX = element.props.x - 1;
+      const boundaryClass = `month-boundary${
+        date.getMonth() % 3 === 0 ? ' quarter-boundary' : ''
+      }`;
       return (
         <g key={dateKey}>
+          <line
+            x1={lineX}
+            y1={topY}
+            x2={lineX}
+            y2={bottomY - 12}
+            className={boundaryClass}
+          />
           <text x={element.props.x} y={topY - 2} className="text-xs">
             {monthNames[date.getMonth()]}
           </text>
@@ -189,7 +200,8 @@ function YearlyHeatmap({ data, maxMinutes }) {
     return <g key={dateKey}>{cell}</g>;
   };
 
-    const legendScale = [1, 2, 3, 4, 5];
+  const legendScale = [1, 2, 3, 4, 5];
+  const step = Math.ceil(maxMinutes / 5) || 1;
 
   return (
     <TooltipProvider>
@@ -203,14 +215,29 @@ function YearlyHeatmap({ data, maxMinutes }) {
           showMonthLabels={false}
         />
         <div
-          className="flex items-center gap-1 mt-2 text-xs"
+          className="flex flex-wrap items-center gap-2 mt-2 text-xs"
           data-testid="reading-legend"
         >
-          <span>Less</span>
-          {legendScale.map((level) => (
-            <div key={level} className={`w-3 h-3 reading-scale-${level}`} />
-          ))}
-          <span>More</span>
+          <div className="flex items-center gap-1" data-no-data>
+            <div className="w-3 h-3 border" />
+            <span>No data</span>
+          </div>
+          {legendScale.map((level) => {
+            const min = step * (level - 1);
+            const max = step * level;
+            return (
+              <div
+                key={level}
+                className="flex items-center gap-1"
+                data-legend-level
+              >
+                <div className={`w-3 h-3 reading-scale-${level}`} />
+                <span>
+                  {min}-{max} min
+                </span>
+              </div>
+            );
+          })}
         </div>
       </div>
     </TooltipProvider>

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -48,15 +48,25 @@ describe('CalendarHeatmap', () => {
     const legend = getByTestId('reading-legend');
     expect(legend).not.toBeNull();
 
-      const rects = container.querySelectorAll('svg.react-calendar-heatmap rect');
-      expect(container.querySelector('rect.reading-scale-2')).not.toBeNull();
-      expect(container.querySelector('rect.reading-scale-3')).not.toBeNull();
-      expect(container.querySelector('rect.reading-scale-5')).not.toBeNull();
+    expect(container.querySelector('rect.reading-scale-2')).not.toBeNull();
+    expect(container.querySelector('rect.reading-scale-3')).not.toBeNull();
+    expect(container.querySelector('rect.reading-scale-5')).not.toBeNull();
 
-      const swatches = legend.querySelectorAll('div');
-      expect(swatches.length).toBe(5);
-      expect(swatches[0].classList.contains('reading-scale-1')).toBe(true);
-      expect(swatches[4].classList.contains('reading-scale-5')).toBe(true);
+    const swatches = legend.querySelectorAll('[data-legend-level]');
+    expect(swatches.length).toBe(5);
+    expect(
+      swatches[0].querySelector('div').classList.contains('reading-scale-1')
+    ).toBe(true);
+    expect(
+      swatches[4].querySelector('div').classList.contains('reading-scale-5')
+    ).toBe(true);
+    expect(legend.querySelector('[data-no-data]')).not.toBeNull();
+  });
+
+  it('renders month and quarter boundaries', () => {
+    const { container } = render(<CalendarHeatmap />);
+    expect(container.querySelector('line.month-boundary')).not.toBeNull();
+    expect(container.querySelector('line.quarter-boundary')).not.toBeNull();
   });
 
   it('renders month labels and totals', () => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -36,12 +36,12 @@
       --chart-8: 238 90% 60%;
       --chart-9: 242 80% 65%;
       --chart-10: 246 70% 70%;
-      /* Reading intensity tokens */
-      --reading-1: 210 100% 90%;
-      --reading-2: 210 100% 80%;
-      --reading-3: 210 100% 70%;
-      --reading-4: 210 100% 60%;
-      --reading-5: 210 100% 50%;
+      /* Reading intensity tokens - viridis scale */
+      --reading-1: 237.4 35% 39.2%;
+      --reading-2: 193.2 54.3% 36.1%;
+      --reading-3: 163.9 66.3% 39.6%;
+      --reading-4: 100.8 58.2% 56.9%;
+      --reading-5: 53.9 98.2% 56.9%;
       --sidebar: 0 0% 98%;
       --sidebar-foreground: 240 5.3% 26.1%;
     --sidebar-primary: 240 5.9% 10%;
@@ -90,12 +90,12 @@
     --chart-8: 238 90% 70%;
     --chart-9: 242 80% 75%;
     --chart-10: 246 70% 80%;
-    /* Reading intensity tokens */
-    --reading-1: 210 60% 20%;
-    --reading-2: 210 70% 30%;
-    --reading-3: 210 80% 40%;
-    --reading-4: 210 90% 50%;
-    --reading-5: 210 100% 60%;
+    /* Reading intensity tokens - viridis scale */
+    --reading-1: 237.4 35% 39.2%;
+    --reading-2: 193.2 54.3% 36.1%;
+    --reading-3: 163.9 66.3% 39.6%;
+    --reading-4: 100.8 58.2% 56.9%;
+    --reading-5: 53.9 98.2% 56.9%;
     --sidebar: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;
@@ -196,5 +196,14 @@ html, body {
   .reading-scale-5 {
     background-color: hsl(var(--reading-5));
     fill: hsl(var(--reading-5));
+  }
+  .month-boundary {
+    stroke: hsl(var(--border));
+    stroke-width: 1;
+    pointer-events: none;
+  }
+  .quarter-boundary {
+    stroke: hsl(var(--foreground));
+    stroke-width: 1.5;
   }
 }


### PR DESCRIPTION
## Summary
- restyle reading heatmap with color‑blind‑safe viridis palette
- draw month and quarter boundaries across the calendar
- expand legend with exact minute ranges and a "No data" indicator

## Testing
- `npm test` *(fails: BookNetwork component renders)*
- `npx vitest src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68929144c4448324a6a7d7eec95bf4c5