### PR TITLE
feat: enhance genre hierarchy charts

### DIFF
--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
 import GenreIcicle from '@/components/genre/GenreIcicle.jsx';
 import { Skeleton } from '@/ui/skeleton';
+import { AnimatePresence, motion } from 'framer-motion';
 
 export default function GenreSunburstPage() {
   const [view, setView] = useState('sunburst');
@@ -40,16 +41,34 @@ export default function GenreSunburstPage() {
           Icicle
         </button>
       </div>
-      {isLoading ? (
-        <Skeleton
-          className="h-[400px] w-full"
-          data-testid="genre-hierarchy-skeleton"
-        />
-      ) : view === 'sunburst' ? (
-        <GenreSunburst data={data} />
-      ) : (
-        <GenreIcicle data={data} />
-      )}
+      <AnimatePresence mode="wait">
+        {isLoading ? (
+          <Skeleton
+            className="h-[400px] w-full"
+            data-testid="genre-hierarchy-skeleton"
+          />
+        ) : view === 'sunburst' ? (
+          <motion.div
+            key="sunburst"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <GenreSunburst data={data} />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="icicle"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <GenreIcicle data={data} />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
@@ -22,10 +22,10 @@ describe('GenreSunburstPage', () => {
     expect(screen.queryByTestId('icicle-layout')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /icicle/i }));
-    expect(screen.getByTestId('icicle-layout')).toBeInTheDocument();
+    expect(await screen.findByTestId('icicle-layout')).toBeInTheDocument();
     expect(screen.queryByTestId('sunburst-layout')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /sunburst/i }));
-    expect(screen.getByTestId('sunburst-layout')).toBeInTheDocument();
+    expect(await screen.findByTestId('sunburst-layout')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add interior labels and ancestor context for sunburst drilldowns
- show vertical labels and ghosted ancestors in icicle view
- crossfade between sunburst and icicle layouts

## Testing
- `npx vitest run src/components/genre/__tests__/GenreSunburst.test.jsx src/pages/charts/__tests__/GenreSunburstPage.test.jsx`
- `npm test` *(fails: BookNetwork component, ReadingStackSplit, GenreSunburstPage, LocationEfficiencyComparison)*

------
https://chatgpt.com/codex/tasks/task_e_6892930fdb088324ac43175e2f2207aa