### PR TITLE
feat(timeline): highlight long sessions and reduce axis clutter

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useMemo, useState } from 'react';
 import { select } from 'd3-selection';
-import { scaleTime, scaleOrdinal } from 'd3-scale';
+import { scaleTime, scaleOrdinal, scaleLinear } from 'd3-scale';
 import { brushX } from 'd3-brush';
 import { axisBottom } from 'd3-axis';
 import { timeMonth } from 'd3-time';
@@ -82,10 +82,14 @@ export default function ReadingTimeline({ sessions = [] }) {
       .attr('class', 'x-axis')
       .attr('transform', `translate(0,${BRUSH_HEIGHT + height})`);
     const xAxis = axisBottom(x)
-      .ticks(timeMonth.every(1))
+      .ticks(timeMonth.every(3))
       .tickFormat(timeFormat('%b'))
       .tickSize(-height)
       .tickSizeOuter(0);
+
+    const opacityScale = scaleLinear()
+      .domain([shortest.duration, longest.duration])
+      .range([0.3, 1]);
 
     const renderBars = (domain = initialDomain) => {
       x.domain(domain);
@@ -104,6 +108,7 @@ export default function ReadingTimeline({ sessions = [] }) {
         .attr('width', (d) => Math.max(1, x(d.endDate) - x(d.startDate)))
         .attr('height', BAR_HEIGHT)
         .attr('fill', (d) => colorScale(d.genre || 'Unknown'))
+        .attr('fill-opacity', (d) => opacityScale(d.duration))
         .attr('tabindex', 0)
         .attr(
           'aria-label',

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -143,6 +143,15 @@ describe('ReadingTimeline', () => {
     expect(rects[1].getAttribute('fill')).toBe('hsl(var(--chart-2))');
   });
 
+  it('encodes duration using opacity', () => {
+    const { container } = render(<ReadingTimeline sessions={sessions} />);
+    const svg = container.querySelector('svg');
+    const rects = svg.querySelectorAll('rect[height="30"]');
+    const op1 = Number(rects[0].getAttribute('fill-opacity'));
+    const op2 = Number(rects[1].getAttribute('fill-opacity'));
+    expect(op2).toBeGreaterThan(op1);
+  });
+
   it('makes each bar focusable with an aria-label', () => {
     const { container } = render(<ReadingTimeline sessions={sessions} />);
     const svg = container.querySelector('svg');


### PR DESCRIPTION
## Summary
- encode session length via bar opacity in ReadingTimeline
- show quarterly month ticks to avoid x-axis label overlap
- cover opacity encoding with unit test

## Testing
- `npm test` *(fails: BookNetwork component renders higher-degree nodes etc.)*
- `npm test src/components/timeline/__tests__/ReadingTimeline.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892929970d4832480916b2b9f034122