### PR TITLE
Lower default bandwidth for reading speed violin plot

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -18,7 +18,7 @@ export default function ReadingSpeedViolin() {
   const [error, setError] = useState(null);
   const [showMorning, setShowMorning] = useState(true);
   const [showEvening, setShowEvening] = useState(true);
-  const [bandwidth, setBandwidth] = useState(500);
+  const [bandwidth, setBandwidth] = useState(150);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -244,9 +244,9 @@ export default function ReadingSpeedViolin() {
           Bandwidth
           <input
             type="range"
-            min="100"
-            max="3000"
-            step="100"
+            min="50"
+            max="1000"
+            step="50"
             value={bandwidth}
             onChange={(e) => setBandwidth(Number(e.target.value))}
           />

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -16,20 +16,29 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('ReadingSpeedViolin', () => {
-  it('renders controls and chart', async () => {
-    render(<ReadingSpeedViolin />);
-    expect(screen.getByLabelText('Morning')).toBeInTheDocument();
-    expect(screen.getByLabelText('Evening')).toBeInTheDocument();
-    expect(screen.getByLabelText('Bandwidth')).toBeInTheDocument();
-    await waitFor(() => {
-      const paths = document.querySelectorAll('path');
-      expect(paths.length).toBeGreaterThan(0);
+  describe('ReadingSpeedViolin', () => {
+    it('renders controls and chart', async () => {
+      render(<ReadingSpeedViolin />);
+      expect(screen.getByLabelText('Morning')).toBeInTheDocument();
+      expect(screen.getByLabelText('Evening')).toBeInTheDocument();
+      expect(screen.getByLabelText('Bandwidth')).toBeInTheDocument();
+      await waitFor(() => {
+        const paths = document.querySelectorAll('path');
+        expect(paths.length).toBeGreaterThan(0);
+      });
     });
-  });
 
-  it('applies period-specific colors', async () => {
-    const { container } = render(<ReadingSpeedViolin />);
+    it('uses lower default bandwidth and slider range', () => {
+      render(<ReadingSpeedViolin />);
+      const slider = screen.getByLabelText('Bandwidth');
+      expect(slider).toHaveValue('150');
+      expect(slider).toHaveAttribute('min', '50');
+      expect(slider).toHaveAttribute('max', '1000');
+      expect(slider).toHaveAttribute('step', '50');
+    });
+
+    it('applies period-specific colors', async () => {
+      const { container } = render(<ReadingSpeedViolin />);
 
     await waitFor(() => {
       expect(container.querySelectorAll('rect').length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- lower default KDE bandwidth so reading speed violins show more detail
- tighten bandwidth slider to 50-1000 with smaller step
- cover new default and slider range with test

## Testing
- `npm test` *(fails: BookNetwork component renders higher-degree nodes with larger radii; BookNetwork component renders higher-degree nodes with larger radii)*
- `node -e "const d3={mean:require('d3-array').mean};const scale=require('d3-scale');const data=require('./src/data/kindle/reading-speed.json');const morning=data.filter(d=>d.period==='morning').map(d=>d.wpm);const allValues=data.map(d=>d.wpm);const y=scale.scaleLinear().domain([Math.min(...allValues),Math.max(...allValues)]).range([300,0]);const yTicks=y.ticks(40);const kernel=k=>v=>{v/=k;return Math.abs(v)<=1?0.75*(1-v*v)/k:0};const kde=(kernel,X)=>V=>X.map(x=>[x,d3.mean(V,v=>kernel(x-v))]);const density=kde(kernel(150),yTicks)(morning);console.log(density.slice(0,10));"`

------
https://chatgpt.com/codex/tasks/task_e_6892970719b48324921919306c8235d7