### PR TITLE
feat(stats): add offline fallback for reading speed

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -28,7 +28,12 @@ export default function ReadingSpeedViolin() {
         const json = await res.json();
         setData(json);
       } catch (err) {
-        setError('Error loading reading speed data');
+        try {
+          const local = await import('@/data/kindle/reading-speed.json');
+          setData(local.default);
+        } catch {
+          setError('Error loading reading speed data');
+        }
       } finally {
         setLoading(false);
       }
@@ -208,6 +213,9 @@ export default function ReadingSpeedViolin() {
     <div style={{ position: 'relative' }}>
       {loading && <p>Loading reading speed data...</p>}
       {error && !loading && <p role="alert">{error}</p>}
+      {!loading && !error && data.length === 0 && (
+        <p>No reading speed data available.</p>
+      )}
       <div>
         <label>
           <input

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -60,4 +60,16 @@ describe('ReadingSpeedViolin', () => {
       expect(colors).toContain(el.getAttribute('fill'));
     });
   });
+
+  it('falls back to local data when fetch fails', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('Network error'));
+    render(<ReadingSpeedViolin />);
+
+    await waitFor(() => {
+      const paths = document.querySelectorAll('path');
+      expect(paths.length).toBeGreaterThan(0);
+    });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- handle offline fallback for ReadingSpeedViolin data
- display message when no reading speed data loads
- test reading speed chart offline fallback

## Testing
- `npm test` *(fails: BookNetwork tests)*
- `npx vitest run src/components/stats/__tests__/ReadingSpeedViolin.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892970270848324b3c60f5d7a0cc77b