### PR TITLE
refactor: use compromise term data for pos

### DIFF
--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -28,8 +28,8 @@ const posColors = {
 
 function analyzeWord(word) {
   const sentiment = sentimentAnalyzer.analyze(word).score;
-  const data = nlp(word).terms().data()[0];
-  const pos = data?.terms?.[0]?.tags?.[0] || 'Unknown';
+  const term = nlp(word).terms().data()[0];
+  const pos = term?.tags?.[0] || 'Unknown';
   return { sentiment, pos };
 }
 


### PR DESCRIPTION
## Summary
- use Compromise's term tags to derive part-of-speech in WordTree

## Testing
- `npm test -- --run` *(fails: BookNetwork component tests)*
- `node -e "import nlp from 'compromise'; console.log(['cat','run','quick','slowly'].map(w=>({[w]:nlp(w).out('tags')[0][w]})))"`

------
https://chatgpt.com/codex/tasks/task_e_689296fb8de88324b0e9a153833d9fc4