### PR TITLE
refactor: convert location service to esm

### DIFF
--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 const { parse } = require('csv-parse');
 const { aggregateDailyReading } = require('../../src/services/readingStats');
 const { aggregateReadingSessions } = require('../../src/services/readingSessions');
@@ -7,7 +8,6 @@ const { calculateReadingSpeeds } = require('../../src/services/readingSpeed');
 const { buildGenreHierarchy } = require('../../src/services/genreHierarchy');
 const { calculateGenreTransitions } = require('../../src/services/genreTransitions');
 const { buildHighlightIndex, getExpansions } = require('../../src/services/highlightIndex');
-const { getSessionLocations } = require('../../src/services/locationData');
 const { buildBookGraph } = require('../../src/services/bookGraph');
 
 async function parseCsv(filePath) {
@@ -244,7 +244,11 @@ async function getHighlightExpansions(keyword) {
   return getExpansions(trie, keyword);
 }
 
-function getLocations() {
+async function getLocations() {
+  const moduleUrl = pathToFileURL(
+    path.join(__dirname, '../../src/services/locationData.js')
+  ).href;
+  const { getSessionLocations } = await import(moduleUrl);
   return getSessionLocations();
 }
 

--- a/src/services/__tests__/locationData.test.js
+++ b/src/services/__tests__/locationData.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-const { getSessionLocations } = require('../locationData');
+import { getSessionLocations } from '../locationData';
 
 describe('location data serialization', () => {
   it('provides numeric latitude and longitude', () => {

--- a/src/services/locationData.js
+++ b/src/services/locationData.js
@@ -1,15 +1,13 @@
-const sessionLocations = require('../data/kindle/locations.json');
+import sessionLocations from '../data/kindle/locations.json' with { type: 'json' };
 
-function getSessionLocations() {
+export function getSessionLocations() {
   return sessionLocations;
 }
 
-async function fetchSessionLocations() {
+export async function fetchSessionLocations() {
   const res = await fetch('/api/kindle/locations');
   if (!res.ok) throw new Error('Failed to fetch locations');
   const data = await res.json();
   if (!Array.isArray(data)) throw new Error('Invalid locations data');
   return data;
 }
-
-module.exports = { getSessionLocations, fetchSessionLocations };


### PR DESCRIPTION
## Summary
- convert location service to ESM and expose named exports
- migrate location data test to ESM import
- dynamically import location data in Kindle service

## Testing
- `npx vitest run server/api/kindle.test.js`
- `npx vitest run src/services/__tests__/locationData.test.js`
- `npm run dev` *(fails: none)*
- `curl -s http://localhost:3000/api/kindle/locations | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689296ffc7248324a4622e9e52dc2963