### PR TITLE
feat: improve calendar heatmap legend responsiveness

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -215,7 +215,7 @@ function YearlyHeatmap({ data, maxMinutes }) {
           showMonthLabels={false}
         />
         <div
-          className="flex flex-wrap items-center gap-2 mt-2 text-xs"
+          className="flex flex-wrap items-center gap-2 md:gap-3 mt-2 text-xs md:text-sm"
           data-testid="reading-legend"
         >
           <div className="flex items-center gap-1" data-no-data>


### PR DESCRIPTION
## Summary
- adjust calendar heatmap legend to use responsive text sizing
- add larger gap on medium screens to prevent wrapping

## Testing
- `npx vitest run src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68929a52b4e4832485ef785212bb66c4