### PR TITLE
Make calendar heatmap responsive

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -213,6 +213,8 @@ function YearlyHeatmap({ data, maxMinutes }) {
           classForValue={classForValue}
           transformDayElement={transformDayElement}
           showMonthLabels={false}
+          className="w-full h-auto"
+          style={{ width: '100%' }}
         />
         <div
           className="flex flex-wrap items-center gap-2 mt-2 text-xs"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -167,9 +167,14 @@
     --font-slab: "Georgia", "Times New Roman", serif;
   }
 
-html, body {
-  @apply bg-background text-foreground;
-}
+  html, body {
+    @apply bg-background text-foreground;
+  }
+
+  .react-calendar-heatmap {
+    width: 100%;
+    height: auto;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- Ensure calendar heatmap SVG scales with its container
- Allow react-calendar-heatmap SVG to expand with parent

## Testing
- `npm test` *(fails: BookNetwork component > renders higher-degree nodes with larger radii)*

------
https://chatgpt.com/codex/tasks/task_e_689296d44348832481452d9a6626a988