### PR TITLE
fix: use absolute API URL for session locations

### DIFF
--- a/src/services/locationData.js
+++ b/src/services/locationData.js
@@ -5,7 +5,11 @@ export function getSessionLocations() {
 }
 
 export async function fetchSessionLocations() {
-  const res = await fetch('/api/kindle/locations');
+  const baseUrl =
+    import.meta.env?.VITE_API_URL ??
+    process.env.VITE_API_URL ??
+    'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/kindle/locations`);
   if (!res.ok) throw new Error('Failed to fetch locations');
   const data = await res.json();
   if (!Array.isArray(data)) throw new Error('Invalid locations data');


### PR DESCRIPTION
## Summary
- fetch session locations from configurable backend URL with a default to localhost

## Testing
- `npm run server` *(fails: expected to run; terminated)*
- `npm test` *(fails: BookNetwork.test.jsx > BookNetwork component > highlights shortest path when searching by tag; BookNetwork.test.jsx > BookNetwork component > renders higher-degree nodes with larger radii)*

------
https://chatgpt.com/codex/tasks/task_e_68929c132f648324bb279188eadfa364