### PR TITLE
feat: improve heatmap month delineation

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -187,11 +187,19 @@ function YearlyHeatmap({ data, maxMinutes }) {
             y2={bottomY - 12}
             className={boundaryClass}
           />
-          <text x={element.props.x} y={topY - 2} className="text-xs">
+          <text
+            x={element.props.x}
+            y={topY - 4}
+            className="text-sm font-medium"
+          >
             {monthNames[date.getMonth()]}
           </text>
           {cell}
-          <text x={element.props.x} y={bottomY} className="text-xs">
+          <text
+            x={element.props.x}
+            y={bottomY}
+            className="text-sm font-medium"
+          >
             {monthTotals[key]}
           </text>
         </g>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -203,12 +203,12 @@
     fill: hsl(var(--reading-5));
   }
   .month-boundary {
-    stroke: hsl(var(--border));
-    stroke-width: 1;
+    stroke: hsl(var(--foreground) / 0.3);
+    stroke-width: 1.5;
     pointer-events: none;
   }
   .quarter-boundary {
     stroke: hsl(var(--foreground));
-    stroke-width: 1.5;
+    stroke-width: 2;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge month labels in calendar heatmap for better readability
- emphasize month boundaries with stronger strokes and weight

## Testing
- `npm test` *(fails: BookNetwork component tests)*

------
https://chatgpt.com/codex/tasks/task_e_6892a2ee877c8324a08c085fa8de0852