### PR TITLE
feat: add accessible view toggle

### DIFF
--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
 import GenreIcicle from '@/components/genre/GenreIcicle.jsx';
 import { Skeleton } from '@/ui/skeleton';
+import { cn } from '@/lib/utils';
 
 export default function GenreSunburstPage() {
   const [view, setView] = useState('sunburst');
@@ -40,14 +41,24 @@ export default function GenreSunburstPage() {
         <button
           type="button"
           onClick={() => setView('sunburst')}
-          className="px-2 py-1 border rounded"
+          aria-pressed={view === 'sunburst'}
+          disabled={isLoading}
+          className={cn(
+            'px-2 py-1 border rounded',
+            view === 'sunburst' && 'bg-primary text-white',
+          )}
         >
           Sunburst
         </button>
         <button
           type="button"
           onClick={() => setView('icicle')}
-          className="px-2 py-1 border rounded"
+          aria-pressed={view === 'icicle'}
+          disabled={isLoading}
+          className={cn(
+            'px-2 py-1 border rounded',
+            view === 'icicle' && 'bg-primary text-white',
+          )}
         >
           Icicle
         </button>

--- a/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
@@ -28,16 +28,43 @@ describe('GenreSunburstPage', () => {
 
     const user = userEvent.setup();
     render(<GenreSunburstPage />);
+    const sunburstButton = screen.getByRole('button', { name: /sunburst/i });
+    const icicleButton = screen.getByRole('button', { name: /icicle/i });
 
     expect(await screen.findByTestId('sunburst-layout')).toBeInTheDocument();
+    expect(sunburstButton).toHaveAttribute('aria-pressed', 'true');
+    expect(sunburstButton).toHaveClass('bg-primary', 'text-white');
+    expect(icicleButton).toHaveAttribute('aria-pressed', 'false');
+    expect(icicleButton).not.toHaveClass('bg-primary');
+    expect(icicleButton).not.toHaveClass('text-white');
     expect(screen.queryByTestId('icicle-layout')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /icicle/i }));
+    await user.click(icicleButton);
     expect(screen.getByTestId('icicle-layout')).toBeInTheDocument();
+    expect(icicleButton).toHaveAttribute('aria-pressed', 'true');
+    expect(icicleButton).toHaveClass('bg-primary', 'text-white');
+    expect(sunburstButton).toHaveAttribute('aria-pressed', 'false');
+    expect(sunburstButton).not.toHaveClass('bg-primary');
+    expect(sunburstButton).not.toHaveClass('text-white');
     expect(screen.queryByTestId('sunburst-layout')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /sunburst/i }));
+    await user.click(sunburstButton);
     expect(screen.getByTestId('sunburst-layout')).toBeInTheDocument();
+    expect(sunburstButton).toHaveAttribute('aria-pressed', 'true');
+    expect(sunburstButton).toHaveClass('bg-primary', 'text-white');
+    expect(icicleButton).toHaveAttribute('aria-pressed', 'false');
+    expect(icicleButton).not.toHaveClass('bg-primary');
+    expect(icicleButton).not.toHaveClass('text-white');
+  });
+
+  it('disables view buttons while loading', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}));
+
+    render(<GenreSunburstPage />);
+    const sunburstButton = screen.getByRole('button', { name: /sunburst/i });
+    const icicleButton = screen.getByRole('button', { name: /icicle/i });
+    expect(sunburstButton).toBeDisabled();
+    expect(icicleButton).toBeDisabled();
   });
 
   it('renders an error message when the fetch fails', async () => {


### PR DESCRIPTION
## Summary
- add aria-pressed and active styles to GenreSunburst/Icicle view buttons
- disable toggles while loading
- test view toggle aria and styles

## Testing
- `npm test` *(fails: 2 failed test files, 6 failed tests)*
- `npm test src/pages/charts/__tests__/GenreSunburstPage.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892ac30ca0483249231d5734ea55de0