### PR TITLE
refactor: extract nav items component with popover dropdown

### DIFF
--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import type { DashboardRouteGroup } from "@/routes";
+import { cn } from "@/lib/utils";
+import { SheetClose } from "@/ui/sheet";
+import { Popover, PopoverTrigger, PopoverContent } from "@/ui/popover";
+
+interface NavItemsProps {
+  groups: DashboardRouteGroup[];
+  orientation?: "vertical" | "horizontal";
+  className?: string;
+}
+
+export default function NavItems({
+  groups,
+  orientation = "vertical",
+  className,
+}: NavItemsProps) {
+  const vertical = orientation === "vertical";
+
+  const renderLink = (
+    to: string,
+    label: string,
+    Icon?: React.ComponentType<{ className?: string }> ,
+  ) => {
+    const link = (
+      <NavLink to={to} className="flex items-center gap-2 px-2 py-1 text-sm">
+        {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
+        <span>{label}</span>
+      </NavLink>
+    );
+    return vertical ? <SheetClose asChild>{link}</SheetClose> : link;
+  };
+
+  return (
+    <ul className={cn(vertical ? "flex flex-col gap-4" : "flex gap-4", className)}>
+      <li>{renderLink("/", "Dashboard")}</li>
+      {groups.map((group) => {
+        const Icon = group.icon;
+        const firstItem = group.items[0];
+        if (vertical) {
+          return (
+            <li key={group.label}>
+              {renderLink(firstItem?.to ?? "#", group.label, Icon)}
+            </li>
+          );
+        }
+        return (
+          <li key={group.label}>
+            <Popover>
+              <PopoverTrigger asChild>
+                {renderLink(firstItem?.to ?? "#", group.label, Icon)}
+              </PopoverTrigger>
+              <PopoverContent className="w-48 flex flex-col gap-2 bg-white p-4 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2">
+                {group.items.map((item) => (
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    className="block px-2 py-1 text-sm"
+                  >
+                    {item.label}
+                  </NavLink>
+                ))}
+              </PopoverContent>
+            </Popover>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { NavLink } from "react-router-dom";
 import { Menu } from "lucide-react";
 import { dashboardRoutes } from "@/routes";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/ui/sheet";
+import { Sheet, SheetContent, SheetTrigger } from "@/ui/sheet";
+import NavItems from "./NavItems";
 
 export default function TopNavigation() {
   const [open, setOpen] = useState(false);
@@ -25,67 +25,14 @@ export default function TopNavigation() {
           </button>
         </SheetTrigger>
         <SheetContent side="left" className="p-4">
-          <ul className="flex flex-col gap-4">
-            <li>
-              <SheetClose asChild>
-                <NavLink to="/" className="block px-2 py-1 text-sm">
-                  Dashboard
-                </NavLink>
-              </SheetClose>
-            </li>
-            {dashboardRoutes.map((group) => {
-              const Icon = group.icon;
-              const firstItem = group.items[0];
-              return (
-                <li key={group.label}>
-                  <SheetClose asChild>
-                    <NavLink
-                      to={firstItem?.to ?? "#"}
-                      className="flex items-center gap-2 px-2 py-1 text-sm"
-                    >
-                      {Icon && (
-                        <Icon className="h-4 w-4" aria-hidden="true" />
-                      )}
-                      <span>{group.label}</span>
-                    </NavLink>
-                  </SheetClose>
-                </li>
-              );
-            })}
-          </ul>
+          <NavItems groups={dashboardRoutes} orientation="vertical" />
         </SheetContent>
       </Sheet>
-      <ul className="hidden md:flex gap-4">
-        <li>
-          <NavLink to="/" className="block px-2 py-1 text-sm">
-            Dashboard
-          </NavLink>
-        </li>
-        {dashboardRoutes.map((group) => {
-          const Icon = group.icon;
-          const firstItem = group.items[0];
-          return (
-            <li key={group.label} className="relative group">
-              <NavLink
-                to={firstItem?.to ?? "#"}
-                className="flex items-center gap-2 px-2 py-1 text-sm"
-              >
-                {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
-                <span>{group.label}</span>
-              </NavLink>
-              <ul className="absolute z-10 hidden w-48 flex-col gap-2 bg-white p-4 shadow-md group-hover:flex">
-                {group.items.map((item) => (
-                  <li key={item.to}>
-                    <NavLink to={item.to} className="block px-2 py-1 text-sm">
-                      {item.label}
-                    </NavLink>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          );
-        })}
-      </ul>
+      <NavItems
+        groups={dashboardRoutes}
+        orientation="horizontal"
+        className="hidden md:flex"
+      />
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- add NavItems component to map dashboard routes for mobile and desktop
- replace hover-based desktop dropdown with Radix popover and transitions
- update TopNavigation to render NavItems in sheet and desktop nav

## Testing
- `npm test` *(fails: 3 test files failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6892aae08cc4832485ec8cfa2884a30c