### PR TITLE
feat: allow calendar tooltip activation on click

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -155,6 +155,11 @@ function YearlyHeatmap({ data }) {
       <Tooltip>
         <TooltipTrigger
           asChild
+          onClick={(e) =>
+            e.target.dispatchEvent(
+              new MouseEvent('mouseover', { bubbles: true })
+            )
+          }
           onFocus={(e) =>
             e.target.dispatchEvent(
               new MouseEvent('mouseover', { bubbles: true })

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
@@ -102,6 +102,17 @@ describe('CalendarHeatmap', () => {
     within(tooltip).getByText('Jan 2, 2024');
     within(tooltip).getByText('10 min');
     within(tooltip).getByTestId('sparkline');
+  });
+
+  it('dispatches mouseover when clicking a cell', () => {
+    const { container } = render(<CalendarHeatmap />);
+    const day = container.querySelector('rect[data-date="2024-01-02"]');
+    expect(day).not.toBeNull();
+    const spy = vi.spyOn(day, 'dispatchEvent');
+    fireEvent.click(day);
+    expect(
+      spy.mock.calls.some(([evt]) => evt.type === 'mouseover')
+    ).toBe(true);
   });
 
   it('shows tooltip when navigating with keyboard', async () => {


### PR DESCRIPTION
## Summary
- open CalendarHeatmap tooltips when a day cell is clicked
- test click behavior by ensuring a mouseover event is dispatched

## Testing
- `npm test` *(fails: src/components/__tests__/BookNetwork.test.jsx, src/components/genre/__tests__/GenreSankey.test.jsx)*
- `npx vitest src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892acbc6b6483248753a0f782fffbd9