### PR TITLE
feat(nav): add active link transitions

### DIFF
--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+import { cn } from "@/lib/utils";
+
+interface NavItemsProps {
+  className?: string;
+  onNavigate?: () => void;
+}
+
+export default function NavItems({ className, onNavigate }: NavItemsProps) {
+  return (
+    <ul className={cn(className)}>
+      <li>
+        <NavLink
+          to="/"
+          onClick={onNavigate}
+          className={({ isActive }) =>
+            cn(
+              linkBase,
+              isActive && linkActive
+            )
+          }
+        >
+          <span className="transition-colors group-hover:text-primary">Dashboard</span>
+        </NavLink>
+      </li>
+      {dashboardRoutes.map((group) => {
+        const Icon = group.icon;
+        const firstItem = group.items[0];
+        return (
+          <li key={group.label} className="relative group">
+            <NavLink
+              to={firstItem?.to ?? "#"}
+              onClick={onNavigate}
+              className={({ isActive }) =>
+                cn(linkBase, isActive && linkActive)
+              }
+            >
+              {Icon && (
+                <Icon
+                  className="h-4 w-4 transition-transform group-hover:scale-105"
+                  aria-hidden="true"
+                />
+              )}
+              <span className="transition-colors group-hover:text-primary">
+                {group.label}
+              </span>
+            </NavLink>
+            <ul className="absolute z-10 hidden w-48 flex-col gap-2 bg-white p-4 shadow-md group-hover:flex">
+              {group.items.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    onClick={onNavigate}
+                    className={({ isActive }) =>
+                      cn(
+                        "block px-2 py-1 text-sm transition-colors hover:text-primary",
+                        isActive && "active text-primary"
+                      )
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+const linkBase =
+  "group relative flex items-center gap-2 px-2 py-1 text-sm transition-colors hover:text-primary after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform hover:after:scale-x-100";
+
+const linkActive = "active text-primary after:scale-x-100";

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { NavLink } from "react-router-dom";
 import { Menu } from "lucide-react";
-import { dashboardRoutes } from "@/routes";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { Sheet, SheetContent, SheetTrigger, SheetClose } from "@/ui/sheet";
+import { Sheet, SheetContent, SheetTrigger } from "@/ui/sheet";
+import NavItems from "./NavItems";
 
 export default function TopNavigation() {
   const [open, setOpen] = useState(false);
@@ -25,67 +24,13 @@ export default function TopNavigation() {
           </button>
         </SheetTrigger>
         <SheetContent side="left" className="p-4">
-          <ul className="flex flex-col gap-4">
-            <li>
-              <SheetClose asChild>
-                <NavLink to="/" className="block px-2 py-1 text-sm">
-                  Dashboard
-                </NavLink>
-              </SheetClose>
-            </li>
-            {dashboardRoutes.map((group) => {
-              const Icon = group.icon;
-              const firstItem = group.items[0];
-              return (
-                <li key={group.label}>
-                  <SheetClose asChild>
-                    <NavLink
-                      to={firstItem?.to ?? "#"}
-                      className="flex items-center gap-2 px-2 py-1 text-sm"
-                    >
-                      {Icon && (
-                        <Icon className="h-4 w-4" aria-hidden="true" />
-                      )}
-                      <span>{group.label}</span>
-                    </NavLink>
-                  </SheetClose>
-                </li>
-              );
-            })}
-          </ul>
+          <NavItems
+            className="flex flex-col gap-4"
+            onNavigate={() => setOpen(false)}
+          />
         </SheetContent>
       </Sheet>
-      <ul className="hidden md:flex gap-4">
-        <li>
-          <NavLink to="/" className="block px-2 py-1 text-sm">
-            Dashboard
-          </NavLink>
-        </li>
-        {dashboardRoutes.map((group) => {
-          const Icon = group.icon;
-          const firstItem = group.items[0];
-          return (
-            <li key={group.label} className="relative group">
-              <NavLink
-                to={firstItem?.to ?? "#"}
-                className="flex items-center gap-2 px-2 py-1 text-sm"
-              >
-                {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
-                <span>{group.label}</span>
-              </NavLink>
-              <ul className="absolute z-10 hidden w-48 flex-col gap-2 bg-white p-4 shadow-md group-hover:flex">
-                {group.items.map((item) => (
-                  <li key={item.to}>
-                    <NavLink to={item.to} className="block px-2 py-1 text-sm">
-                      {item.label}
-                    </NavLink>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          );
-        })}
-      </ul>
+      <NavItems className="hidden md:flex gap-4" />
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- extract NavItems component with active NavLink state
- add hover transitions and underline effects for nav items
- reuse NavItems in TopNavigation for mobile and desktop

## Testing
- `npm test` *(fails: 2 failed, 89 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6892afa8f00c83248d8dae7e38e8d55c