### PR TITLE
docs: add genre sunburst description

### DIFF
--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -36,7 +36,11 @@ export default function GenreSunburstPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Genre Hierarchy</h1>
+      <h1 className="text-xl font-bold mb-2">Genre Hierarchy</h1>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Each slice represents time spent reading in that genre, with deeper levels
+        revealing sub-genres.
+      </p>
       <div className="mb-4 space-x-2">
         <button
           type="button"

--- a/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
@@ -57,6 +57,20 @@ describe('GenreSunburstPage', () => {
     expect(icicleButton).not.toHaveClass('text-white');
   });
 
+  it('displays chart description', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    render(<GenreSunburstPage />);
+    expect(
+      screen.getByText(
+        /each slice represents time spent reading in that genre/i
+      )
+    ).toBeInTheDocument();
+  });
+
   it('disables view buttons while loading', () => {
     vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}));
 


### PR DESCRIPTION
## Summary
- describe the Genre Hierarchy chart below the heading
- test rendering of the new descriptive text

## Testing
- `npm test src/pages/charts/__tests__/GenreSunburstPage.test.jsx`
- `npm test` *(fails: src/components/__tests__/BookNetwork.test.jsx, src/components/genre/__tests__/GenreSankey.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6892b038ad2c8324b71bf8be189d899d