### PR TITLE
Map Kindle ASINs to readable titles across charts

### DIFF
--- a/server/api/kindle.test.js
+++ b/server/api/kindle.test.js
@@ -47,6 +47,12 @@ describe('GET /api/kindle', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('name', 'root');
     expect(res.body).toHaveProperty('children');
+    function leaves(node) {
+      if (!node.children) return [node];
+      return node.children.flatMap(leaves);
+    }
+    const leafNames = leaves(res.body).map((n) => n.name);
+    expect(leafNames.some((n) => /\s/.test(n))).toBe(true);
   });
 
   it('returns genre transitions data', async () => {
@@ -75,6 +81,7 @@ describe('GET /api/kindle', () => {
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0]).toHaveProperty('latitude');
     expect(res.body[0]).toHaveProperty('longitude');
+    expect(res.body[0].title).not.toMatch(/^[A-Z0-9]{10}$/);
   });
 
   it('returns book graph data', async () => {

--- a/src/services/__tests__/locationData.test.js
+++ b/src/services/__tests__/locationData.test.js
@@ -9,5 +9,6 @@ describe('location data serialization', () => {
     const item = data[0];
     expect(typeof item.latitude).toBe('number');
     expect(typeof item.longitude).toBe('number');
+    expect(item.title).not.toMatch(/^[A-Z0-9]{10}$/);
   });
 });

--- a/src/services/genreHierarchy.js
+++ b/src/services/genreHierarchy.js
@@ -1,3 +1,5 @@
+const asinTitleMap = require('../data/kindle/asin-title-map.json');
+
 function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
   const genreByAsin = {};
   for (const g of genres) {
@@ -22,7 +24,8 @@ function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
   for (const s of sessions) {
     const asin = s.asin || s.ASIN;
     if (!asin) continue;
-    const title = s.title || s['Product Name'] || asin;
+    const rawTitle = s.title || s['Product Name'] || asin;
+    const title = asinTitleMap[asin] || asinTitleMap[rawTitle] || rawTitle;
     const minutes = Number(s.duration || s.minutes || 0);
     if (!books[asin]) {
       books[asin] = {

--- a/src/services/locationData.js
+++ b/src/services/locationData.js
@@ -1,7 +1,11 @@
 import sessionLocations from '../data/kindle/locations.json' with { type: 'json' };
+import asinTitleMap from '../data/kindle/asin-title-map.json' with { type: 'json' };
 
 export function getSessionLocations() {
-  return sessionLocations;
+  return sessionLocations.map((l) => ({
+    ...l,
+    title: asinTitleMap[l.title] ?? l.title,
+  }));
 }
 
 export async function fetchSessionLocations() {
@@ -13,5 +17,8 @@ export async function fetchSessionLocations() {
   if (!res.ok) throw new Error('Failed to fetch locations');
   const data = await res.json();
   if (!Array.isArray(data)) throw new Error('Invalid locations data');
-  return data;
+  return data.map((l) => ({
+    ...l,
+    title: asinTitleMap[l.title] ?? l.title,
+  }));
 }


### PR DESCRIPTION
## Summary
- resolve Kindle session locations and genre hierarchy names using an ASIN→title map
- verify API responses return human-readable titles for locations and genre leaf nodes
- test that local location data is already title-mapped

## Testing
- `npm test` *(fails: BookNetwork component, GenreSankey tests)*

------
https://chatgpt.com/codex/tasks/task_e_68929e12dd7c83248a15ba92240b07c9