### PR TITLE
style: center reading speed violin and add card

### DIFF
--- a/src/pages/charts/ReadingSpeedViolin.jsx
+++ b/src/pages/charts/ReadingSpeedViolin.jsx
@@ -4,8 +4,10 @@ import ReadingSpeedViolin from '@/components/stats/ReadingSpeedViolin.jsx';
 export default function ReadingSpeedViolinPage() {
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Reading Speed Distribution</h1>
-      <ReadingSpeedViolin />
+      <h1 className="text-2xl font-bold mb-6 text-center">Reading Speed Distribution</h1>
+      <div className="max-w-4xl mx-auto bg-white shadow rounded p-6">
+        <ReadingSpeedViolin />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center the heading on Reading Speed Distribution page
- wrap ReadingSpeedViolin in a white card container

## Testing
- `npm test` *(fails: BookNetwork, GenreSankey, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6892a7f4b86c832494efdd6f0a65ce3a