### PR TITLE
Replace ASINs with titles in genre hierarchy

### DIFF
--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -3,17 +3,31 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import GenreSankey from '../GenreSankey';
 import { vi } from 'vitest';
+import transitions from '../../../data/kindle/genre-transitions.json';
 
 describe('GenreSankey', () => {
   const originalFetch = global.fetch;
+  const originalGetBoundingClientRect =
+    HTMLDivElement.prototype.getBoundingClientRect;
 
   beforeEach(() => {
     vi.resetAllMocks();
-    global.fetch = originalFetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(transitions),
+    });
+    HTMLDivElement.prototype.getBoundingClientRect = () => ({
+      width: 600,
+      height: 400,
+      top: 0,
+      left: 0,
+      bottom: 400,
+      right: 600,
+    });
   });
 
   afterAll(() => {
     global.fetch = originalFetch;
+    HTMLDivElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 
   it('renders a skeleton before data resolves', async () => {

--- a/src/data/kindle/genre-hierarchy.json
+++ b/src/data/kindle/genre-hierarchy.json
@@ -11,7 +11,7 @@
               "name": "Moore, Graham",
               "children": [
                 {
-                  "name": "B01A4AXM3W",
+                  "name": "The Last Days of Night: A Novel",
                   "value": 44.16499999999999
                 }
               ]
@@ -20,7 +20,7 @@
               "name": "Freeman, Brian",
               "children": [
                 {
-                  "name": "B01LXZZ1L5",
+                  "name": "Marathon (A Jonathan Stride Novel Book 8)",
                   "value": 95.80166666666666
                 }
               ]
@@ -29,67 +29,67 @@
               "name": "Child, Lee",
               "children": [
                 {
-                  "name": "B000OZ0NXA",
+                  "name": "Killing Floor (Jack Reacher, Book 1)",
                   "value": 581.6266666666668
                 },
                 {
-                  "name": "B001FXK8XU",
+                  "name": "Tripwire (Jack Reacher Book 3)",
                   "value": 542.8783333333332
                 },
                 {
-                  "name": "B004DI7JNG",
+                  "name": "Lee Child's Jack Reacher Books 1-6",
                   "value": 279.3416666666666
                 },
                 {
-                  "name": "B000FBJDF2",
+                  "name": "Persuader: A Jack Reacher Novel",
                   "value": 528.0316666666666
                 },
                 {
-                  "name": "B000FC1MBO",
+                  "name": "The Enemy: A Reacher Novel (Jack Reacher Book 8)",
                   "value": 523.5350000000001
                 },
                 {
-                  "name": "B000FCK5PI",
+                  "name": "One Shot: A Reacher novel (Jack Reacher Book 9)",
                   "value": 10.028333333333334
                 },
                 {
-                  "name": "B000GCFG7E",
+                  "name": "The Hard Way: A Reacher Novel (Jack Reacher Book 10)",
                   "value": 129.06
                 },
                 {
-                  "name": "B000QCQ8Y4",
+                  "name": "Bad Luck and Trouble: A Jack Reacher Novel",
                   "value": 4.126666666666667
                 },
                 {
-                  "name": "B000YJ54DU",
+                  "name": "Nothing to Lose: A Jack Reacher Novel",
                   "value": 43.90333333333333
                 },
                 {
-                  "name": "B001NLL8LA",
+                  "name": "Gone Tomorrow: A Jack Reacher Novel",
                   "value": 565.4583333333333
                 },
                 {
-                  "name": "B0036S4CWA",
+                  "name": "61 Hours: A Reacher Novel (Jack Reacher Book 14)",
                   "value": 35.57333333333333
                 },
                 {
-                  "name": "B003EY7IWC",
+                  "name": "Worth Dying For: A Jack Reacher Novel",
                   "value": 2.185
                 },
                 {
-                  "name": "B004P8JPS6",
+                  "name": "The Affair: A Jack Reacher Novel",
                   "value": 1.7733333333333334
                 },
                 {
-                  "name": "B07NCNVZ5P",
+                  "name": "Blue Moon: A Jack Reacher Novel",
                   "value": 65.32166666666666
                 },
                 {
-                  "name": "B08SBMCSQQ",
+                  "name": "Better Off Dead: A Jack Reacher Novel",
                   "value": 114.37666666666667
                 },
                 {
-                  "name": "B0CW1J3Y5G",
+                  "name": "Safe Enough: Crime Stories by the Author of Jack Reacher",
                   "value": 297.3883333333332
                 }
               ]
@@ -98,7 +98,7 @@
               "name": "Mason, Tim",
               "children": [
                 {
-                  "name": "B07GNX99VJ",
+                  "name": "The Darwin Affair: A Novel",
                   "value": 15.1
                 }
               ]
@@ -107,7 +107,7 @@
               "name": "Lovesey, Peter",
               "children": [
                 {
-                  "name": "B081Y4J7LD",
+                  "name": "The Finisher (A Detective Peter Diamond Mystery Book 19)",
                   "value": 405.7883333333334
                 }
               ]
@@ -116,7 +116,7 @@
               "name": "Nesbo, Jo",
               "children": [
                 {
-                  "name": "B08478T2CK",
+                  "name": "The Kingdom: A novel",
                   "value": 309.9333333333333
                 }
               ]
@@ -125,7 +125,7 @@
               "name": "Graff, Andrew J.",
               "children": [
                 {
-                  "name": "B08BLMJ576",
+                  "name": "Raft of Stars: A Novel",
                   "value": 71.28999999999999
                 }
               ]
@@ -134,15 +134,15 @@
               "name": "French, Tana",
               "children": [
                 {
-                  "name": "B08681BNKV",
+                  "name": "The Searcher: A Novel",
                   "value": 642.4683333333334
                 },
                 {
-                  "name": "B000U913EI",
+                  "name": "In the Woods (Dublin Murder Squad, Book 1)",
                   "value": 666.2116666666666
                 },
                 {
-                  "name": "B0C7729CF8",
+                  "name": "The Hunter: A Novel",
                   "value": 437.49333333333334
                 }
               ]
@@ -151,7 +151,7 @@
               "name": "Thor, Brad",
               "children": [
                 {
-                  "name": "B000FC0R7O",
+                  "name": "The Lions of Lucerne (Scot Harvath Book 1)",
                   "value": 685.5416666666669
                 }
               ]
@@ -160,11 +160,11 @@
               "name": "Towles, Amor",
               "children": [
                 {
-                  "name": "B08WRH53MY",
+                  "name": "The Lincoln Highway: A Novel",
                   "value": 213.3216666666667
                 },
                 {
-                  "name": "B01COJUEZ0",
+                  "name": "A Gentleman in Moscow: A Novel",
                   "value": 212.31500000000003
                 }
               ]
@@ -173,7 +173,7 @@
               "name": "Hawley, Noah",
               "children": [
                 {
-                  "name": "B093ZQCS29",
+                  "name": "Anthem",
                   "value": 151.365
                 }
               ]
@@ -182,11 +182,11 @@
               "name": "Korelitz, Jean Hanff",
               "children": [
                 {
-                  "name": "B08JKC299M",
+                  "name": "The Plot: A Novel (The Book Series 1)",
                   "value": 441.45
                 },
                 {
-                  "name": "B0CQHM2KL5",
+                  "name": "The Sequel: A Novel (The Book Series 2)",
                   "value": 68.95666666666666
                 }
               ]
@@ -195,15 +195,15 @@
               "name": "Prose, Nita",
               "children": [
                 {
-                  "name": "B091Y4KGFH",
+                  "name": "The Maid: A GMA Book Club Pick: A Novel (Molly the Maid 1)",
                   "value": 509.62333333333333
                 },
                 {
-                  "name": "B0C5LRCM2F",
+                  "name": "The Mystery Guest: A Maid Novel (Molly the Maid Book 2)",
                   "value": 447.73166666666657
                 },
                 {
-                  "name": "B0D9F3KFPM",
+                  "name": "The Maid's Secret: A Maid Novel (Molly the Maid Book 3)",
                   "value": 185.95166666666665
                 }
               ]
@@ -212,11 +212,11 @@
               "name": "Goldman, Matt",
               "children": [
                 {
-                  "name": "B01NBJMMRR",
+                  "name": "Gone to Dust: A Novel (Nils Shapiro Book 1)",
                   "value": 452.68
                 },
                 {
-                  "name": "B0756J4NRG",
+                  "name": "Broken Ice: A Novel (Nils Shapiro Book 2)",
                   "value": 475.62666666666667
                 }
               ]
@@ -225,11 +225,11 @@
               "name": "Michaelides, Alex",
               "children": [
                 {
-                  "name": "B07D2C6J4K",
+                  "name": "The Silent Patient",
                   "value": 377.4833333333334
                 },
                 {
-                  "name": "B0BXTB6HSN",
+                  "name": "The Fury",
                   "value": 286.355
                 }
               ]
@@ -238,15 +238,15 @@
               "name": "Foley, Lucy",
               "children": [
                 {
-                  "name": "B098QS47D3",
+                  "name": "The Paris Apartment: A Novel",
                   "value": 573.1766666666665
                 },
                 {
-                  "name": "B07WG8L7WC",
+                  "name": "The Guest List: A Novel",
                   "value": 355.515
                 },
                 {
-                  "name": "B0CL3FMNKJ",
+                  "name": "The Midnight Feast: An NPR Best Book of the Year",
                   "value": 352.715
                 }
               ]
@@ -255,11 +255,11 @@
               "name": "Heller, Peter",
               "children": [
                 {
-                  "name": "B08P98PVY2",
+                  "name": "The Guide: A novel",
                   "value": 456.0283333333333
                 },
                 {
-                  "name": "B0BL6YQ61Y",
+                  "name": "The Last Ranger: A novel",
                   "value": 4.36
                 }
               ]
@@ -268,15 +268,15 @@
               "name": "Osman, Richard",
               "children": [
                 {
-                  "name": "B084M663VB",
+                  "name": "The Thursday Murder Club: A Novel (Thursday Murder Club Mysteries Book 1)",
                   "value": 568.7666666666667
                 },
                 {
-                  "name": "B0BQLKNTYR",
+                  "name": "The Last Devil to Die: A Thursday Murder Club Mystery (Thursday Murder Club Mysteries Book 4)",
                   "value": 476.5700000000001
                 },
                 {
-                  "name": "B0CQJHF3HQ",
+                  "name": "We Solve Murders: A Novel",
                   "value": 249.33999999999997
                 }
               ]
@@ -285,7 +285,7 @@
               "name": "Kestrel, James",
               "children": [
                 {
-                  "name": "B08THH7R49",
+                  "name": "Five Decembers",
                   "value": 608.4116666666667
                 }
               ]
@@ -294,7 +294,7 @@
               "name": "Hawkins, Paula",
               "children": [
                 {
-                  "name": "B08PC3SZHX",
+                  "name": "A Slow Fire Burning: A Novel",
                   "value": 15.158333333333335
                 }
               ]
@@ -303,11 +303,11 @@
               "name": "Swanson, Peter",
               "children": [
                 {
-                  "name": "B097769VDM",
+                  "name": "Nine Lives: A Novel",
                   "value": 330.81333333333333
                 },
                 {
-                  "name": "B0B3989NDF",
+                  "name": "The Kind Worth Saving: A Novel",
                   "value": 363.6016666666667
                 }
               ]
@@ -316,11 +316,11 @@
               "name": "Krueger, William Kent",
               "children": [
                 {
-                  "name": "B000FC0QBQ",
+                  "name": "Iron Lake (20th Anniversary Edition): A Novel (Cork O'Connor Mystery Series Book 1)",
                   "value": 465.36
                 },
                 {
-                  "name": "B008J2G5Y6",
+                  "name": "Ordinary Grace: A Novel",
                   "value": 363.7549999999999
                 }
               ]
@@ -329,7 +329,7 @@
               "name": "Lipsyte, Sam",
               "children": [
                 {
-                  "name": "B09RX2WQ3M",
+                  "name": "No One Left to Come Looking for You: A Novel",
                   "value": 34.260000000000005
                 }
               ]
@@ -338,7 +338,7 @@
               "name": "Braverman, Blair",
               "children": [
                 {
-                  "name": "B09R21YVLM",
+                  "name": "Small Game: A Novel",
                   "value": 308.5966666666667
                 }
               ]
@@ -347,7 +347,7 @@
               "name": "Nguyen, Viet Thanh",
               "children": [
                 {
-                  "name": "B00PSSG4MM",
+                  "name": "The Sympathizer: A Novel (Pulitzer Prize for Fiction)",
                   "value": 64.08666666666667
                 }
               ]
@@ -356,7 +356,7 @@
               "name": "Butler, Nickolas",
               "children": [
                 {
-                  "name": "B08NT2VSWF",
+                  "name": "Godspeed",
                   "value": 482.96166666666664
                 }
               ]
@@ -365,7 +365,7 @@
               "name": "Santlofer, Jonathan",
               "children": [
                 {
-                  "name": "B08QXTPXPH",
+                  "name": "The Last Mona Lisa: A Novel",
                   "value": 464.37166666666667
                 }
               ]
@@ -374,7 +374,7 @@
               "name": "Kirwan, J.F.",
               "children": [
                 {
-                  "name": "B01HLY0Z0W",
+                  "name": "66 Metres: A chilling thriller that will keep you on the edge of your seat! (Nadia Laksheva Spy Thriller Series, Book 1)",
                   "value": 66.44333333333333
                 }
               ]
@@ -383,7 +383,7 @@
               "name": "McAllister, Gillian",
               "children": [
                 {
-                  "name": "B09NW4FN2R",
+                  "name": "Wrong Place Wrong Time: A Novel",
                   "value": 174.90166666666667
                 }
               ]
@@ -392,7 +392,7 @@
               "name": "Coben, Harlan",
               "children": [
                 {
-                  "name": "B07TYBQJBM",
+                  "name": "The Boy from the Woods",
                   "value": 5.81
                 }
               ]
@@ -401,7 +401,7 @@
               "name": "Raybourn, Deanna",
               "children": [
                 {
-                  "name": "B09N6VX4K7",
+                  "name": "Killers of a Certain Age",
                   "value": 461.0533333333333
                 }
               ]
@@ -410,7 +410,7 @@
               "name": "Laestadius, Ann-Helén",
               "children": [
                 {
-                  "name": "B0B3Y8DJFJ",
+                  "name": "Stolen",
                   "value": 289.6716666666667
                 }
               ]
@@ -419,11 +419,11 @@
               "name": "Tuomainen, Antti",
               "children": [
                 {
-                  "name": "B075SPBQDV",
+                  "name": "The Man Who Died",
                   "value": 369.0233333333333
                 },
                 {
-                  "name": "B07HB5DKQX",
+                  "name": "Palm Beach, Finland",
                   "value": 210.0883333333333
                 }
               ]
@@ -432,7 +432,7 @@
               "name": "Herron, Mick",
               "children": [
                 {
-                  "name": "B004HW7DZ2",
+                  "name": "Slow Horses (Slough House Book 1)",
                   "value": 32.053333333333335
                 }
               ]
@@ -441,7 +441,7 @@
               "name": "Carlsson, Christoffer",
               "children": [
                 {
-                  "name": "B09XL59MJX",
+                  "name": "Blaze Me a Sun: A Novel About a Crime (Halland Suite)",
                   "value": 564.275
                 }
               ]
@@ -450,7 +450,7 @@
               "name": "Catton, Eleanor",
               "children": [
                 {
-                  "name": "B09Y46DSD7",
+                  "name": "Birnam Wood: A Novel",
                   "value": 37.695
                 }
               ]
@@ -459,7 +459,7 @@
               "name": "Elkin, Stanley",
               "children": [
                 {
-                  "name": "B00AG8GXVQ",
+                  "name": "Mrs. Ted Bliss",
                   "value": 29.568333333333335
                 }
               ]
@@ -468,7 +468,7 @@
               "name": "Moriarty, Liane",
               "children": [
                 {
-                  "name": "B08PG6CKZJ",
+                  "name": "Apples Never Fall",
                   "value": 933.9666666666666
                 }
               ]
@@ -477,7 +477,7 @@
               "name": "Hallett, Janice",
               "children": [
                 {
-                  "name": "B098433CGQ",
+                  "name": "The Appeal: A Novel",
                   "value": 18.08
                 }
               ]
@@ -486,7 +486,7 @@
               "name": "Frazier, Charles",
               "children": [
                 {
-                  "name": "B0B6JSJQLH",
+                  "name": "The Trackers: A Search for a Fugitive in Depression-Era America",
                   "value": 31.251666666666665
                 }
               ]
@@ -495,7 +495,7 @@
               "name": "Bayard, Louis",
               "children": [
                 {
-                  "name": "B000GCFX6S",
+                  "name": "The Pale Blue Eye: A Novel",
                   "value": 518.7533333333333
                 }
               ]
@@ -504,7 +504,7 @@
               "name": "Williams, Katie",
               "children": [
                 {
-                  "name": "B0BHCXVWGT",
+                  "name": "My Murder: A Novel",
                   "value": 401.1783333333333
                 }
               ]
@@ -513,19 +513,19 @@
               "name": "Ware, Ruth",
               "children": [
                 {
-                  "name": "B0BHTN6TL6",
+                  "name": "Zero Days",
                   "value": 521.99
                 },
                 {
-                  "name": "B084G9Z5C3",
+                  "name": "One by One",
                   "value": 502.2683333333335
                 },
                 {
-                  "name": "B0CL5G23ZF",
+                  "name": "One Perfect Couple",
                   "value": 14.121666666666666
                 },
                 {
-                  "name": "B0DJM99D77",
+                  "name": "The Woman in Suite 11: A Novel",
                   "value": 36.38166666666667
                 }
               ]
@@ -534,11 +534,11 @@
               "name": "Lehane, Dennis",
               "children": [
                 {
-                  "name": "B0B7NDZNDV",
+                  "name": "Small Mercies: A Detective Mystery",
                   "value": 481.30833333333334
                 },
                 {
-                  "name": "B000JMKNV0",
+                  "name": "Shutter Island",
                   "value": 443.2433333333333
                 }
               ]
@@ -547,7 +547,7 @@
               "name": "Hendricks, Greer",
               "children": [
                 {
-                  "name": "B092T947PJ",
+                  "name": "The Golden Couple: A Novel",
                   "value": 484.8983333333333
                 }
               ]
@@ -556,7 +556,7 @@
               "name": "Smirnoff, Karin",
               "children": [
                 {
-                  "name": "B0BLY7J9DC",
+                  "name": "The Girl in the Eagle's Talons: A Lisbeth Salander Novel (The Girl with the Dragon Tattoo (Lisbeth Salander / Millennium) Book 7)",
                   "value": 106.08333333333331
                 }
               ]
@@ -565,7 +565,7 @@
               "name": "Clarke, Amy Suiter",
               "children": [
                 {
-                  "name": "B09721CTG1",
+                  "name": "Lay Your Body Down: A Novel of Suspense",
                   "value": 25.30666666666667
                 }
               ]
@@ -574,7 +574,7 @@
               "name": "Sims, Laura",
               "children": [
                 {
-                  "name": "B0BJNKTFGH",
+                  "name": "How Can I Help You",
                   "value": 320.6449999999999
                 }
               ]
@@ -583,7 +583,7 @@
               "name": "Rankin, Ian",
               "children": [
                 {
-                  "name": "B0CBW58P3J",
+                  "name": "The Rise: A Short Story",
                   "value": 124.39333333333333
                 }
               ]
@@ -592,7 +592,7 @@
               "name": "Rosenfield, Kat",
               "children": [
                 {
-                  "name": "B08SMFSLVQ",
+                  "name": "No One Will Miss Her: A Dark and Compelling Mystery with a Devious Plot, Get Ready to Unravel the Secrets!",
                   "value": 40.305
                 }
               ]
@@ -601,7 +601,7 @@
               "name": "Gillmor, Don",
               "children": [
                 {
-                  "name": "B0BKH7G2X8",
+                  "name": "Breaking and Entering",
                   "value": 430.30833333333334
                 }
               ]
@@ -610,7 +610,7 @@
               "name": "Kim, Un-su",
               "children": [
                 {
-                  "name": "B07CWDMQ45",
+                  "name": "The Plotters: A Novel",
                   "value": 211.09833333333333
                 }
               ]
@@ -619,7 +619,7 @@
               "name": "Hepworth, Sally",
               "children": [
                 {
-                  "name": "B09Y467GZY",
+                  "name": "The Soulmate: A Novel",
                   "value": 316.82666666666665
                 }
               ]
@@ -628,7 +628,7 @@
               "name": "Feeney, Alice",
               "children": [
                 {
-                  "name": "B0BST5X6GS",
+                  "name": "Good Bad Girl: A Novel",
                   "value": 21.9
                 }
               ]
@@ -637,7 +637,7 @@
               "name": "Offutt, Chris",
               "children": [
                 {
-                  "name": "B08TF1VTGX",
+                  "name": "The Killing Hills (The Mick Hardin Novels Book 1)",
                   "value": 316.4533333333333
                 }
               ]
@@ -646,7 +646,7 @@
               "name": "Jewell, Lisa",
               "children": [
                 {
-                  "name": "B0BDMPQ2FC",
+                  "name": "None of This Is True: A Novel",
                   "value": 425.35833333333335
                 }
               ]
@@ -655,11 +655,11 @@
               "name": "Higashino, Keigo",
               "children": [
                 {
-                  "name": "B0044781ZQ",
+                  "name": "The Devotion of Suspect X: A Detective Galileo Novel (Detective Galileo Series Book 1)",
                   "value": 528.2566666666667
                 },
                 {
-                  "name": "B007RMYE9M",
+                  "name": "Salvation of a Saint: A Detective Galileo Novel (Detective Galileo Series Book 2)",
                   "value": 79.30666666666666
                 }
               ]
@@ -668,7 +668,7 @@
               "name": "Pease, Amy",
               "children": [
                 {
-                  "name": "B0C7RPT9B3",
+                  "name": "Northwoods: A Novel",
                   "value": 486.71833333333336
                 }
               ]
@@ -677,7 +677,7 @@
               "name": "Stevenson, Benjamin",
               "children": [
                 {
-                  "name": "B0C6KMGND1",
+                  "name": "Everyone on This Train Is a Suspect: A Novel (The Ernest Cunningham Mysteries Book 2)",
                   "value": 224.99833333333336
                 }
               ]
@@ -686,7 +686,7 @@
               "name": "Osborne, Cayce",
               "children": [
                 {
-                  "name": "B0BJP5QFFM",
+                  "name": "I Know What You Did: A Novel",
                   "value": 372.79833333333335
                 }
               ]
@@ -695,7 +695,7 @@
               "name": "Onda, Riku",
               "children": [
                 {
-                  "name": "B07QN87LQB",
+                  "name": "The Aosawa Murders",
                   "value": 152.375
                 }
               ]
@@ -704,7 +704,7 @@
               "name": "Maxwell, Jessa",
               "children": [
                 {
-                  "name": "B0B3Y9JVMK",
+                  "name": "The Golden Spoon: A Novel",
                   "value": 461.8300000000001
                 }
               ]
@@ -713,7 +713,7 @@
               "name": "Finn, A. J",
               "children": [
                 {
-                  "name": "B078R46LCY",
+                  "name": "End of Story: An Enthralling Thriller with a Suspenseful Plot, Get Lost in the Pages and Unravel the Mystery",
                   "value": 143.125
                 }
               ]
@@ -722,7 +722,7 @@
               "name": "Draine, Betsy",
               "children": [
                 {
-                  "name": "B0DMDYK6Y6",
+                  "name": "The Bones of Bascom Hall",
                   "value": 343.39833333333337
                 }
               ]
@@ -731,7 +731,7 @@
               "name": "Manchette, Jean-Patrick",
               "children": [
                 {
-                  "name": "B081M4F8GH",
+                  "name": "No Room at the Morgue",
                   "value": 245.14666666666665
                 }
               ]
@@ -740,7 +740,7 @@
               "name": "Lamb, Wally",
               "children": [
                 {
-                  "name": "B0DHDF2RDL",
+                  "name": "The River Is Waiting (Oprah's Book Club): A Novel",
                   "value": 698.1083333333333
                 }
               ]
@@ -759,7 +759,7 @@
               "name": "de Grasse Tyson, Neil",
               "children": [
                 {
-                  "name": "B01MAWT2MO",
+                  "name": "Astrophysics for People in a Hurry (Astrophysics for People in a Hurry Series)",
                   "value": 117.32500000000002
                 }
               ]
@@ -768,7 +768,7 @@
               "name": "Prum, Richard O.",
               "children": [
                 {
-                  "name": "B01KE61LPW",
+                  "name": "The Evolution of Beauty: How Darwin's Forgotten Theory of Mate Choice Shapes the Animal World - and Us",
                   "value": 0.3016666666666667
                 }
               ]
@@ -777,7 +777,7 @@
               "name": "McEvoy, J.P.",
               "children": [
                 {
-                  "name": "B00KFEK0I8",
+                  "name": "Introducing Quantum Theory: A Graphic Guide (Graphic Guides)",
                   "value": 0.9933333333333333
                 }
               ]
@@ -786,7 +786,7 @@
               "name": "Miller, Lulu",
               "children": [
                 {
-                  "name": "B07THBZ4VD",
+                  "name": "Why Fish Don't Exist: A Story of Loss, Love, and the Hidden Order of Life",
                   "value": 0.2633333333333333
                 }
               ]
@@ -795,7 +795,7 @@
               "name": "Mary, Roach",
               "children": [
                 {
-                  "name": "B08XP24KR8",
+                  "name": "Fuzz: When Nature Breaks the Law",
                   "value": 237.88500000000002
                 }
               ]
@@ -804,7 +804,7 @@
               "name": "Ellenberg, Jordan",
               "children": [
                 {
-                  "name": "B08PF965W9",
+                  "name": "Shape: The Hidden Geometry of Information, Biology, Strategy, Democracy, and EverythingElse",
                   "value": 291.785
                 }
               ]
@@ -813,7 +813,7 @@
               "name": "Dettmer, Philipp",
               "children": [
                 {
-                  "name": "B08XTNHRR5",
+                  "name": "Immune: A Journey into the Mysterious System That Keeps You Alive",
                   "value": 35.50833333333334
                 }
               ]
@@ -822,7 +822,7 @@
               "name": "Gregg, Justin",
               "children": [
                 {
-                  "name": "B09QKTFZGR",
+                  "name": "If Nietzsche Were a Narwhal: What Animal Intelligence Reveals About Human Stupidity",
                   "value": 41.63666666666666
                 }
               ]
@@ -831,7 +831,7 @@
               "name": "McRaney, David",
               "children": [
                 {
-                  "name": "B093R2CP2V",
+                  "name": "How Minds Change: The Surprising Science of Belief, Opinion, and Persuasion",
                   "value": 66.98666666666666
                 }
               ]
@@ -840,7 +840,7 @@
               "name": "Leopold, Aldo",
               "children": [
                 {
-                  "name": "B00BUP18U0",
+                  "name": "Aldo Leopold: A Sand County Almanac & Other Writings on Conservation and Ecology (LOA #238) (Library of America)",
                   "value": 98.54999999999998
                 }
               ]
@@ -849,7 +849,7 @@
               "name": "Gee, Henry",
               "children": [
                 {
-                  "name": "B092T8QDYW",
+                  "name": "A (Very) Short History of Life on Earth: 4.6 Billion Years in 12 Pithy Chapters",
                   "value": 105.345
                 }
               ]
@@ -880,31 +880,31 @@
                   "value": 0.11833333333333333
                 },
                 {
-                  "name": "B079ZLBXV6",
+                  "name": "Smithsonian Magazine",
                   "value": 3.48
                 },
                 {
-                  "name": "B074ST9DGK",
+                  "name": "Run Strong, Stay Hungry: 9 Keys to Staying in the Race",
                   "value": 16.913333333333334
                 },
                 {
-                  "name": "B07B2L77BJ",
+                  "name": "Gourmet Traveller",
                   "value": 7.851666666666667
                 },
                 {
-                  "name": "B07B6W7GRQ",
+                  "name": "New York Magazine",
                   "value": 16.186666666666667
                 },
                 {
-                  "name": "B07B6NPXHV",
+                  "name": "National Geographic Magazine",
                   "value": 6.523333333333333
                 },
                 {
-                  "name": "B079ZQBV4H",
+                  "name": "Travel + Leisure Magazine",
                   "value": 0.8216666666666667
                 },
                 {
-                  "name": "B07B9GK76Z",
+                  "name": "Popular Mechanics",
                   "value": 4.326666666666667
                 },
                 {
@@ -916,35 +916,35 @@
                   "value": 7.266666666666667
                 },
                 {
-                  "name": "B003ODIZL6",
+                  "name": "The New Oxford American Dictionary",
                   "value": 9.431666666666667
                 },
                 {
-                  "name": "B085GKR5BL",
+                  "name": "Running the Dream: One Summer Living, Training, and Racing with a Team of World-Class Runners Half My Age",
                   "value": 0.7033333333333334
                 },
                 {
-                  "name": "B081NHX6LN",
+                  "name": "Win at All Costs: Inside Nike Running and Its Culture of Deception",
                   "value": 48.406666666666666
                 },
                 {
-                  "name": "B07ZG57WBH",
+                  "name": "Inside a Marathon: An All-Access Pass to a Top-10 Finish at NYC, Featuring a new Boston Marathon Chapter",
                   "value": 36.946666666666665
                 },
                 {
-                  "name": "B089T77W63",
+                  "name": "The Silence: A Novel",
                   "value": 1.6133333333333333
                 },
                 {
-                  "name": "B00AHC9PZW",
+                  "name": "The Art of Living: Epictetus's Timeless Wisdom on Virtue, Happiness, and Tranquility for a Fulfilling and Ethical Life",
                   "value": 5.625
                 },
                 {
-                  "name": "B08NHG3PKK",
+                  "name": "The Golden Sayings of Epictetus illustrated",
                   "value": 0.9450000000000001
                 },
                 {
-                  "name": "B086HB336Y",
+                  "name": "Belfry Hockey",
                   "value": 15.72
                 },
                 {
@@ -952,35 +952,35 @@
                   "value": 15.483333333333333
                 },
                 {
-                  "name": "B098GBS3BH",
+                  "name": "Runner's World",
                   "value": 3.6300000000000003
                 },
                 {
-                  "name": "B095YHMBSL",
+                  "name": "Esquire",
                   "value": 4.216666666666667
                 },
                 {
-                  "name": "B0987XFGZF",
+                  "name": "Scientific American Magazine",
                   "value": 3.7266666666666666
                 },
                 {
-                  "name": "B09D3K2MCY",
+                  "name": "Esquire",
                   "value": 5.303333333333334
                 },
                 {
-                  "name": "B072KZWHW4",
+                  "name": "The Manual: A Philosopher's Guide to Life",
                   "value": 0.335
                 },
                 {
-                  "name": "B08LDL3PJ3",
+                  "name": "Racing the Clock: Running Across a Lifetime",
                   "value": 313.185
                 },
                 {
-                  "name": "B07FKB3V5S",
+                  "name": "The Extended Mind: The Power of Thinking Outside the Brain",
                   "value": 3016.8483333333334
                 },
                 {
-                  "name": "B09F8RV343",
+                  "name": "Runner's World",
                   "value": 21.60333333333333
                 },
                 {
@@ -992,127 +992,127 @@
                   "value": 0.3
                 },
                 {
-                  "name": "B005NY4QGM",
+                  "name": "The Color Purple",
                   "value": 26.674999999999997
                 },
                 {
-                  "name": "B09KKPHDHC",
+                  "name": "Runner's World",
                   "value": 27.856666666666666
                 },
                 {
-                  "name": "B08WC6VC8S",
+                  "name": "One Track Mind: What Running 150 Miles in a Day Can Teach You About Life",
                   "value": 18.558333333333334
                 },
                 {
-                  "name": "B0865Z9S5L",
+                  "name": "The Lost Art of Running: A Journey to Rediscover the Forgotten Essence of Human Movement",
                   "value": 21.056666666666665
                 },
                 {
-                  "name": "B00MYEQGFI",
+                  "name": "Hal Koerner's Field Guide to Ultrarunning: Training for an Ultramarathon, from 50K to 100 Miles and Beyond",
                   "value": 0.6716666666666666
                 },
                 {
-                  "name": "B09GYVRQWF",
+                  "name": "How To Be A Goalie Parent: A Guide For Goalie Parents Of All Levels",
                   "value": 19.42666666666667
                 },
                 {
-                  "name": "B07LGLF1JG",
+                  "name": "Goalie Mindset Secrets: 7 Must Have Goalie Mindset Secrets You Don't Learn in School!",
                   "value": 32.58833333333333
                 },
                 {
-                  "name": "B09887KBTZ",
+                  "name": "Klondikers: Dawson City’s Stanley Cup Challenge and How a Nation Fell in Love with Hockey",
                   "value": 107.91666666666667
                 },
                 {
-                  "name": "B093B4BGRK",
+                  "name": "AGENT GATZ: A Great Gatsby Prequel, Episode 1: All Aboard",
                   "value": 0.2533333333333333
                 },
                 {
-                  "name": "B013X9F1IK",
+                  "name": "Runners of North America: A Definitive Guide to the Species (Runner's World)",
                   "value": 5.576666666666667
                 },
                 {
-                  "name": "B0814JSV96",
+                  "name": "Science of Running: Analyse your Technique, Prevent Injury, Revolutionize your Training",
                   "value": 1.03
                 },
                 {
-                  "name": "B001NXK1XO",
+                  "name": "The Drunkard's Walk: How Randomness Rules Our Lives",
                   "value": 4.944999999999999
                 },
                 {
-                  "name": "B08478YC6V",
+                  "name": "Ex Libris: 100+ Books to Read and Reread",
                   "value": 5.81
                 },
                 {
-                  "name": "B07PK5RMPM",
+                  "name": "Ten Marathons: Searching for the Soft Ground in a Hard World",
                   "value": 1.6149999999999998
                 },
                 {
-                  "name": "B09T9H87RB",
+                  "name": "Runner's World",
                   "value": 11.916666666666666
                 },
                 {
-                  "name": "B094GQBBPQ",
+                  "name": "Very Cold People: A Novel",
                   "value": 18.828333333333333
                 },
                 {
-                  "name": "B08FLLBBP9",
+                  "name": "The Buddha and the Bee: Biking through America's Forgotten Roadways on an Accidental Journey of Discovery",
                   "value": 25.001666666666665
                 },
                 {
-                  "name": "B0018ND8B6",
+                  "name": "Over the Edge of the World: Magellan's Terrifying Circumnavigation of the Globe",
                   "value": 65.56
                 },
                 {
-                  "name": "B09Z1Y1MG9",
+                  "name": "Runner's World",
                   "value": 14.485
                 },
                 {
-                  "name": "B07GVCBVYC",
+                  "name": "The Shallows: A Nils Shapiro Novel",
                   "value": 0.31666666666666665
                 },
                 {
-                  "name": "B07WYSF921",
+                  "name": "Dead West: A Novel (Nils Shapiro Book 4)",
                   "value": 2.1566666666666667
                 },
                 {
-                  "name": "B09Q1SQ567",
+                  "name": "Killer Be Killed, Episode 2: Officer Bella Cappicci",
                   "value": 0.20833333333333334
                 },
                 {
-                  "name": "B09QCX4JK7",
+                  "name": "Killer Be Killed, Episode 3: Night Visitor",
                   "value": 0.11
                 },
                 {
-                  "name": "B096DH95W8",
+                  "name": "Run Like a Pro (Even If You're Slow): Elite Tools and Tips for Runners at Every Level",
                   "value": 17.688333333333333
                 },
                 {
-                  "name": "B09P37M6P3",
+                  "name": "Runner's World",
                   "value": 0.28833333333333333
                 },
                 {
-                  "name": "B0B5GC1ZR5",
+                  "name": "Runner's World",
                   "value": 19.503333333333334
                 },
                 {
-                  "name": "B097T5JR84",
+                  "name": "Dirtbag, Massachusetts: A Confessional",
                   "value": 23.92
                 },
                 {
-                  "name": "B09HCD24DJ",
+                  "name": "The Angel of Rome: And Other Stories",
                   "value": 45.40833333333334
                 },
                 {
-                  "name": "B09G9C2WRT",
+                  "name": "The Novelist: A Novel",
                   "value": 10.631666666666666
                 },
                 {
-                  "name": "B0BCPF7HGJ",
+                  "name": "Runner's World",
                   "value": 5.425000000000001
                 },
                 {
-                  "name": "B09NLPTNQ2",
+                  "name": "The Bullet That Missed: A Thursday Murder Club Mystery (Thursday Murder Club Mysteries Book 3)",
                   "value": 0.34500000000000003
                 },
                 {
@@ -1128,7 +1128,7 @@
                   "value": 86.43499999999999
                 },
                 {
-                  "name": "B003BRBCFG",
+                  "name": "Boundary Waters: A Novel (Cork O'Connor Mystery Series Book 2)",
                   "value": 51.565
                 },
                 {
@@ -1136,11 +1136,11 @@
                   "value": 261.0833333333333
                 },
                 {
-                  "name": "B0BKPPPQNV",
+                  "name": "Runner's World",
                   "value": 15.879999999999999
                 },
                 {
-                  "name": "B09QPJKSXM",
+                  "name": "Cheap Land Colorado: Off-Gridders at America's Edge",
                   "value": 27.756666666666668
                 },
                 {
@@ -1148,95 +1148,95 @@
                   "value": 22.433333333333337
                 },
                 {
-                  "name": "B09RX45W14",
+                  "name": "The Song of the Cell: An Exploration of Medicine and the New Human",
                   "value": 50.58000000000001
                 },
                 {
-                  "name": "B0BQVLNL73",
+                  "name": "Runner's World",
                   "value": 12.745
                 },
                 {
-                  "name": "B0BWMMN631",
+                  "name": "Runner's World",
                   "value": 12.084999999999999
                 },
                 {
-                  "name": "B07MXCRB2F",
+                  "name": "A Girl in Winter",
                   "value": 0.26666666666666666
                 },
                 {
-                  "name": "B0C3QHMLGL",
+                  "name": "Runner's World",
                   "value": 9.93
                 },
                 {
-                  "name": "B0BBCB6PFC",
+                  "name": "Gone to the Wolves: A Novel",
                   "value": 94.24333333333334
                 },
                 {
-                  "name": "B0B5SR4KBR",
+                  "name": "Choosing to Run: A Memoir",
                   "value": 19.986666666666668
                 },
                 {
-                  "name": "B0BHY38ZPH",
+                  "name": "Hope: A Novel",
                   "value": 40.205
                 },
                 {
-                  "name": "B0BGJ3W5D3",
+                  "name": "The Theory of Everything Else: A Voyage Into the World of the Weird",
                   "value": 30.845000000000002
                 },
                 {
-                  "name": "B0B7NGCGHG",
+                  "name": "Knowing What We Know: The Transmission of Knowledge: From Ancient Wisdom to Modern Magic",
                   "value": 9.245000000000001
                 },
                 {
-                  "name": "B0BP2HWMP6",
+                  "name": "Is Math Real?: How Simple Questions Lead Us to Mathematics' Deepest Truths",
                   "value": 5.783333333333333
                 },
                 {
-                  "name": "B0BBC9K8C3",
+                  "name": "The Bee Sting: A Novel",
                   "value": 28.24666666666667
                 },
                 {
-                  "name": "B0BP6S1S57",
+                  "name": "Fever House: A Novel (Fever House Duology Book 1)",
                   "value": 49.20166666666667
                 },
                 {
-                  "name": "B0CHWJCN94",
+                  "name": "The Awesome Game: One Man's Incredible, Globe-Crushing Hockey Odyssey",
                   "value": 22.758333333333333
                 },
                 {
-                  "name": "B09YRR8DB6",
+                  "name": "What's Gotten Into You: The Story of Your Body's Atoms, from the Big Bang Through Last Night's Dinner",
                   "value": 87.19166666666666
                 },
                 {
-                  "name": "B0B6B4WPSF",
+                  "name": "Eastbound",
                   "value": 5.033333333333333
                 },
                 {
-                  "name": "B09S3WWY98",
+                  "name": "The Purple Runner",
                   "value": 18.18166666666667
                 },
                 {
-                  "name": "B09Q2F1X14",
+                  "name": "The Stranger (Camus Novel)",
                   "value": 2.6333333333333333
                 },
                 {
-                  "name": "B003XT60E0",
+                  "name": "Blood Meridian: Or the Evening Redness in the West (Vintage International)",
                   "value": 64.70833333333334
                 },
                 {
-                  "name": "B0BL6271NP",
+                  "name": "The End of August: A Novel",
                   "value": 42.041666666666664
                 },
                 {
-                  "name": "B0C7RK8P8K",
+                  "name": "Last Acts: A Novel",
                   "value": 14.063333333333334
                 },
                 {
-                  "name": "B002C7Z57C",
+                  "name": "The Denial of Death",
                   "value": 8.368333333333332
                 },
                 {
-                  "name": "B0CGTHLBT9",
+                  "name": "The Winner: A Novel",
                   "value": 29.623333333333335
                 },
                 {
@@ -1272,7 +1272,7 @@
                   "value": 209.655
                 },
                 {
-                  "name": "B0CQ38FNR9",
+                  "name": "Cold Victory",
                   "value": 20.233333333333334
                 },
                 {
@@ -1384,11 +1384,11 @@
                   "value": 505.74666666666667
                 },
                 {
-                  "name": "B0CN8TPKSP",
+                  "name": "Burn: A novel",
                   "value": 19.286666666666665
                 },
                 {
-                  "name": "B0CZXNTCFX",
+                  "name": "The Frontrunner",
                   "value": 1.0216666666666667
                 },
                 {
@@ -1396,7 +1396,7 @@
                   "value": 0.42166666666666663
                 },
                 {
-                  "name": "B0CH9KQYHS",
+                  "name": "Godwin: A Novel",
                   "value": 18.053333333333335
                 },
                 {
@@ -1424,7 +1424,7 @@
                   "value": 34.5
                 },
                 {
-                  "name": "B0CQHL1XV7",
+                  "name": "CABIN: Off the Grid Adventures with a Clueless Craftsman",
                   "value": 64.145
                 },
                 {
@@ -1512,7 +1512,7 @@
                   "value": 40.821666666666665
                 },
                 {
-                  "name": "B0D3CBLLPH",
+                  "name": "Win the Inside Game: How to Move from Surviving to Thriving, and Free Yourself Up to Perform",
                   "value": 5.098333333333334
                 },
                 {
@@ -1528,7 +1528,7 @@
                   "value": 275.86
                 },
                 {
-                  "name": "B0DLLGPNMQ",
+                  "name": "Gone Gone",
                   "value": 18.31833333333333
                 },
                 {
@@ -1536,7 +1536,7 @@
                   "value": 66.87833333333333
                 },
                 {
-                  "name": "B09SKWT6SF",
+                  "name": "The Murder of Roger Ackroyd",
                   "value": 2.375
                 },
                 {
@@ -1584,7 +1584,7 @@
                   "value": 268.0033333333334
                 },
                 {
-                  "name": "B0DJ7XG2MQ",
+                  "name": "King of Ashes: A Novel",
                   "value": 8.221666666666666
                 },
                 {
@@ -1663,7 +1663,7 @@
               "name": "Bach, Sebastian",
               "children": [
                 {
-                  "name": "B00NLLYN4Y",
+                  "name": "18 and Life on Skid Row",
                   "value": 24.360000000000003
                 }
               ]
@@ -1672,7 +1672,7 @@
               "name": "Beaujour, Tom",
               "children": [
                 {
-                  "name": "B08BYBNGMW",
+                  "name": "Nöthin' But a Good Time: The Uncensored History of the '80s Hard Rock Explosion",
                   "value": 813.7466666666667
                 }
               ]
@@ -1691,7 +1691,7 @@
               "name": "Isaacson, Walter",
               "children": [
                 {
-                  "name": "B071Y385Q1",
+                  "name": "Leonardo da Vinci",
                   "value": 37.318333333333335
                 }
               ]
@@ -1700,7 +1700,7 @@
               "name": "Styron, William",
               "children": [
                 {
-                  "name": "B00BBPVYUS",
+                  "name": "Darkness Visible: A Memoir of Madness",
                   "value": 80.41333333333333
                 }
               ]
@@ -1709,7 +1709,7 @@
               "name": "Shubaly, Mishka",
               "children": [
                 {
-                  "name": "B07YXS82KD",
+                  "name": "This Van Could Be Your Life",
                   "value": 48.910000000000004
                 }
               ]
@@ -1718,7 +1718,7 @@
               "name": "Rath, Tom",
               "children": [
                 {
-                  "name": "B07YXSLVX7",
+                  "name": "It's Not About You: A Brief Guide to a Meaningful Life",
                   "value": 2.3583333333333334
                 }
               ]
@@ -1727,7 +1727,7 @@
               "name": "Yousafzai, Malala",
               "children": [
                 {
-                  "name": "B00CH3DBNQ",
+                  "name": "I Am Malala: The Girl Who Stood Up for Education and Was Shot by the Taliban",
                   "value": 195.965
                 }
               ]
@@ -1736,7 +1736,7 @@
               "name": "Bourdain, Anthony",
               "children": [
                 {
-                  "name": "B083SN8RF7",
+                  "name": "World Travel: An Irreverent Guide",
                   "value": 6.423333333333333
                 }
               ]
@@ -1745,7 +1745,7 @@
               "name": "Magary, Drew",
               "children": [
                 {
-                  "name": "B08SJQSWYM",
+                  "name": "The Night the Lights Went Out: A Memoir of Life After Brain Damage",
                   "value": 17.656666666666666
                 }
               ]
@@ -1754,7 +1754,7 @@
               "name": "Kolker, Robert",
               "children": [
                 {
-                  "name": "B07TZYFR71",
+                  "name": "Hidden Valley Road: Inside the Mind of an American Family",
                   "value": 555.6616666666667
                 }
               ]
@@ -1763,7 +1763,7 @@
               "name": "Mcgrath, Ben ",
               "children": [
                 {
-                  "name": "B098PXP11K",
+                  "name": "Riverman: An American Odyssey",
                   "value": 354.3983333333333
                 }
               ]
@@ -1772,7 +1772,7 @@
               "name": "Thielen, Amy",
               "children": [
                 {
-                  "name": "B01LWWK7WR",
+                  "name": "Give a Girl a Knife: A Memoir",
                   "value": 456.0983333333333
                 }
               ]
@@ -1781,7 +1781,7 @@
               "name": "Philpott, Mary Laura",
               "children": [
                 {
-                  "name": "B09841WSGD",
+                  "name": "Bomb Shelter: Love, Time, and Other Explosives",
                   "value": 23.175
                 }
               ]
@@ -1790,7 +1790,7 @@
               "name": "Schulz, Kathryn",
               "children": [
                 {
-                  "name": "B09285Y1V4",
+                  "name": "Lost & Found: A Memoir",
                   "value": 8.288333333333334
                 }
               ]
@@ -1799,7 +1799,7 @@
               "name": "Garner, Dwight",
               "children": [
                 {
-                  "name": "B0BQGHJM5L",
+                  "name": "The Upstairs Delicatessen: On Eating, Reading, Reading About Eating, and Eating While Reading",
                   "value": 341.57500000000005
                 }
               ]
@@ -1808,7 +1808,7 @@
               "name": "Jones, Amanda",
               "children": [
                 {
-                  "name": "B0CQFXKTPW",
+                  "name": "That Librarian: The Fight Against Book Banning in America",
                   "value": 0.8383333333333334
                 }
               ]
@@ -1817,7 +1817,7 @@
               "name": "Wynn-Williams, Sarah",
               "children": [
                 {
-                  "name": "B0DY9TZD8Z",
+                  "name": "Careless People: A Cautionary Tale of Power, Greed, and Lost Idealism",
                   "value": 6.181666666666667
                 }
               ]
@@ -1836,7 +1836,7 @@
               "name": "Riordan, Rick",
               "children": [
                 {
-                  "name": "B00280LYIM",
+                  "name": "Percy Jackson and the Olympians, Book Four: The Battle of the Labyrinth",
                   "value": 75.29166666666667
                 }
               ]
@@ -1845,7 +1845,7 @@
               "name": "DuPrau, Jeanne",
               "children": [
                 {
-                  "name": "B000QCS932",
+                  "name": "The Prophet of Yonwood (The City of Ember Book 4)",
                   "value": 35.65333333333333
                 }
               ]
@@ -1864,7 +1864,7 @@
               "name": "Chernow, Ron",
               "children": [
                 {
-                  "name": "B06W2J89PV",
+                  "name": "Grant",
                   "value": 255.6933333333333
                 }
               ]
@@ -1873,11 +1873,11 @@
               "name": "Larson, Erik",
               "children": [
                 {
-                  "name": "B07TRVW6VX",
+                  "name": "The Splendid and the Vile: A Saga of Churchill, Family, and Defiance During the Blitz",
                   "value": 44.41333333333333
                 },
                 {
-                  "name": "B0CDKLBD2W",
+                  "name": "The Demon of Unrest: A Saga of Hubris, Heartbreak, and Heroism at the Dawn of the Civil War",
                   "value": 234.21999999999997
                 }
               ]
@@ -1886,7 +1886,7 @@
               "name": "Coe, Alexis",
               "children": [
                 {
-                  "name": "B07TPFTG1S",
+                  "name": "You Never Forget Your First: A Biography of George Washington",
                   "value": 278.2966666666667
                 }
               ]
@@ -1895,7 +1895,7 @@
               "name": "Bryson, Bill",
               "children": [
                 {
-                  "name": "B00C8S9VKM",
+                  "name": "One Summer: America, 1927",
                   "value": 48.989999999999995
                 }
               ]
@@ -1904,7 +1904,7 @@
               "name": "Orlean, Susan",
               "children": [
                 {
-                  "name": "B07CL5ZLHX",
+                  "name": "The Library Book",
                   "value": 364.2649999999999
                 }
               ]
@@ -1913,7 +1913,7 @@
               "name": "Duncan, Dennis",
               "children": [
                 {
-                  "name": "B098TZ17NC",
+                  "name": "Index, A History of the: A Bookish Adventure from Medieval Manuscripts to the Digital Age",
                   "value": 177.19166666666666
                 }
               ]
@@ -1922,7 +1922,7 @@
               "name": "Millard, Candice",
               "children": [
                 {
-                  "name": "B09BTJNJCX",
+                  "name": "River of the Gods: Genius, Courage, and Betrayal in the Search for the Source of the Nile",
                   "value": 328.52
                 }
               ]
@@ -1931,7 +1931,7 @@
               "name": "Brown, Daniel James",
               "children": [
                 {
-                  "name": "B00AEBETU2",
+                  "name": "The Boys in the Boat: Nine Americans and Their Epic Quest for Gold at the 1936 Berlin Olympics",
                   "value": 17.14666666666667
                 }
               ]
@@ -1940,7 +1940,7 @@
               "name": "Hämäläinen, Pekka",
               "children": [
                 {
-                  "name": "B0B193DJYK",
+                  "name": "Indigenous Continent: The Epic Contest for North America",
                   "value": 6.5183333333333335
                 }
               ]
@@ -1949,7 +1949,7 @@
               "name": "Smith, Clint",
               "children": [
                 {
-                  "name": "B08KQ4W18H",
+                  "name": "How the Word Is Passed: A Reckoning with the History of Slavery Across America",
                   "value": 29.779999999999998
                 }
               ]
@@ -1958,7 +1958,7 @@
               "name": "Grann, David",
               "children": [
                 {
-                  "name": "B0B6Z4SVTH",
+                  "name": "The Wager: A Tale of Shipwreck, Mutiny and Murder",
                   "value": 107.67666666666668
                 }
               ]
@@ -1967,7 +1967,7 @@
               "name": "Popkin, Jim",
               "children": [
                 {
-                  "name": "B09XBGYWSR",
+                  "name": "Code Name Blue Wren: The True Story of America's Most Dangerous Female Spy—and the Sister She Betrayed",
                   "value": 84.015
                 }
               ]
@@ -1976,7 +1976,7 @@
               "name": "Stille, Alexander",
               "children": [
                 {
-                  "name": "B0BBC769LV",
+                  "name": "The Sullivanians: Sex, Psychotherapy, and the Wild Life of an American Commune",
                   "value": 83.77499999999999
                 }
               ]
@@ -1985,7 +1985,7 @@
               "name": "Dunlop, Fuchsia",
               "children": [
                 {
-                  "name": "B0BWGKNK7G",
+                  "name": "Invitation to a Banquet: A History of Chinese Food",
                   "value": 299.78000000000003
                 }
               ]
@@ -1994,7 +1994,7 @@
               "name": "Zinn, Howard",
               "children": [
                 {
-                  "name": "B003B4IW2U",
+                  "name": "A Young People's History of the United States (For Young People Series)",
                   "value": 5.3116666666666665
                 }
               ]
@@ -2003,7 +2003,7 @@
               "name": "Bale, Anthony Paul ",
               "children": [
                 {
-                  "name": "B0C97G1ZR6",
+                  "name": "A Travel Guide to the Middle Ages: The World Through Medieval Eyes",
                   "value": 253.60000000000002
                 }
               ]
@@ -2012,7 +2012,7 @@
               "name": "Sides, Hampton",
               "children": [
                 {
-                  "name": "B0CC1J32NG",
+                  "name": "The Wide Wide Sea: Imperial Ambition, First Contact and the Fateful Final Voyage of Captain James Cook",
                   "value": 664.4766666666667
                 }
               ]
@@ -2031,7 +2031,7 @@
               "name": "Burns, David D. ",
               "children": [
                 {
-                  "name": "B009UW5X4C",
+                  "name": "Feeling Good: Overcome Depression and Anxiety with Proven Techniques",
                   "value": 30.696666666666665
                 }
               ]
@@ -2040,7 +2040,7 @@
               "name": "Gottlieb, Lori",
               "children": [
                 {
-                  "name": "B07BZ4F75T",
+                  "name": "Maybe You Should Talk to Someone: A Therapist, HER Therapist, and Our Lives Revealed",
                   "value": 351.7866666666667
                 }
               ]
@@ -2049,7 +2049,7 @@
               "name": "Clavell, Alexander",
               "children": [
                 {
-                  "name": "B081ZXQB52",
+                  "name": "366 Stoic Quotes: A Year Of Stoicism From Ancient And Modern Stoics - A Daily Guide Of Stoic Meditations",
                   "value": 53.27
                 }
               ]
@@ -2058,7 +2058,7 @@
               "name": "Irvine, William B.",
               "children": [
                 {
-                  "name": "B07P9DC6TY",
+                  "name": "The Stoic Challenge: A Philosopher's Guide to Becoming Tougher, Calmer, and More Resilient",
                   "value": 8.743333333333334
                 }
               ]
@@ -2067,7 +2067,7 @@
               "name": "Chapman, Gary",
               "children": [
                 {
-                  "name": "B00OICLVBI",
+                  "name": "The 5 Love Languages: The Secret to Love that Lasts",
                   "value": 21.338333333333335
                 }
               ]
@@ -2076,7 +2076,7 @@
               "name": "Tolstoy, Leo",
               "children": [
                 {
-                  "name": "B003L77UKC",
+                  "name": "A Calendar of Wisdom: Daily Thoughts to Nourish the Soul, Written and Se",
                   "value": 127.35499999999999
                 }
               ]
@@ -2085,7 +2085,7 @@
               "name": "Martin, Clancy",
               "children": [
                 {
-                  "name": "B0B1Y1ZKFX",
+                  "name": "How Not to Kill Yourself: A Portrait of the Suicidal Mind",
                   "value": 26.791666666666664
                 }
               ]
@@ -2094,7 +2094,7 @@
               "name": "Burkeman, Oliver",
               "children": [
                 {
-                  "name": "B08FGV64B1",
+                  "name": "Four Thousand Weeks: Time Management for Mortals",
                   "value": 45.31333333333334
                 }
               ]
@@ -2113,7 +2113,7 @@
               "name": "Moore, Christopher",
               "children": [
                 {
-                  "name": "B07192GP7F",
+                  "name": "Noir: A Darkly Humorous Mystery with a Touch of the Supernatural in Post-WWII San Francisco",
                   "value": 154.37000000000003
                 }
               ]
@@ -2122,11 +2122,11 @@
               "name": "Mandel, Emily St. John",
               "children": [
                 {
-                  "name": "B07RL58ZDG",
+                  "name": "The Glass Hotel: A novel",
                   "value": 361.03499999999985
                 },
                 {
-                  "name": "B099DRHTLX",
+                  "name": "Sea of Tranquility: A novel",
                   "value": 305.2583333333333
                 }
               ]
@@ -2135,7 +2135,7 @@
               "name": "Alam, Rumaan",
               "children": [
                 {
-                  "name": "B083JKGK15",
+                  "name": "Leave the World Behind: A Read with Jenna Pick",
                   "value": 306.15166666666664
                 }
               ]
@@ -2144,7 +2144,7 @@
               "name": "Clarke, Susanna",
               "children": [
                 {
-                  "name": "B0865TSTWM",
+                  "name": "Piranesi",
                   "value": 34.99666666666667
                 }
               ]
@@ -2153,7 +2153,7 @@
               "name": "Bell, Matt",
               "children": [
                 {
-                  "name": "B08L3P3VGQ",
+                  "name": "Appleseed: A Novel",
                   "value": 681.6850000000001
                 }
               ]
@@ -2162,7 +2162,7 @@
               "name": "Shepherd, Peng",
               "children": [
                 {
-                  "name": "B08G1NJK2R",
+                  "name": "The Cartographers: A Novel",
                   "value": 435.6783333333333
                 }
               ]
@@ -2171,7 +2171,7 @@
               "name": "Osman, Richard",
               "children": [
                 {
-                  "name": "B08YRM9NBM",
+                  "name": "The Man Who Died Twice: A Thursday Murder Club Mystery (Thursday Murder Club Mysteries Book 2)",
                   "value": 638.4150000000001
                 }
               ]
@@ -2180,7 +2180,7 @@
               "name": "Weir, Andy",
               "children": [
                 {
-                  "name": "B07VDJBKNJ",
+                  "name": "Randomize (Forward collection)",
                   "value": 36.69833333333333
                 }
               ]
@@ -2189,7 +2189,7 @@
               "name": "le Carré, John",
               "children": [
                 {
-                  "name": "B006CUDDUG",
+                  "name": "The Spy Who Came in from the Cold: A George Smiley Novel (George Smiley Novels Book 3)",
                   "value": 44.09
                 }
               ]
@@ -2198,7 +2198,7 @@
               "name": "Schwab, V. E.",
               "children": [
                 {
-                  "name": "B084357H23",
+                  "name": "The Invisible Life of Addie LaRue",
                   "value": 722.335
                 }
               ]
@@ -2207,7 +2207,7 @@
               "name": "Stevenson, Benjamin",
               "children": [
                 {
-                  "name": "B09Y94K74X",
+                  "name": "Everyone in My Family Has Killed Someone: A Novel (The Ernest Cunningham Mysteries Book 1)",
                   "value": 439.21666666666675
                 }
               ]
@@ -2216,7 +2216,7 @@
               "name": "Aoyama, Michiko",
               "children": [
                 {
-                  "name": "B0BT82YGGF",
+                  "name": "What You Are Looking For Is in the Library: A Touching Narrative of Self-Discovery, Community Bonds and the Joys of Reading in Tokyo's Libraries",
                   "value": 2.6683333333333334
                 }
               ]
@@ -2225,7 +2225,7 @@
               "name": "Scalzi, John",
               "children": [
                 {
-                  "name": "B0B9KVXCQ6",
+                  "name": "Starter Villain",
                   "value": 18.738333333333333
                 }
               ]
@@ -2234,7 +2234,7 @@
               "name": "Kuang, R. F",
               "children": [
                 {
-                  "name": "B0B9SN8K6H",
+                  "name": "Yellowface: A Chilling Novel of Racism and Cultural Appropriation from the author of Katabasis",
                   "value": 296.54666666666657
                 }
               ]
@@ -2243,7 +2243,7 @@
               "name": "Bardugo, Leigh",
               "children": [
                 {
-                  "name": "B07LF64DZ2",
+                  "name": "Ninth House (Ninth House Series Book 1)",
                   "value": 45.715
                 }
               ]
@@ -2252,7 +2252,7 @@
               "name": "Goodhand, James",
               "children": [
                 {
-                  "name": "B0C4PX8RD7",
+                  "name": "The Day Tripper: A Powerful Time Travel Redemption Story of Small Actions Leading to Big Consequences",
                   "value": 461.825
                 }
               ]
@@ -2261,7 +2261,7 @@
               "name": "Cronin, Justin",
               "children": [
                 {
-                  "name": "B0B8GZ58DK",
+                  "name": "The Ferryman: A Novel",
                   "value": 6.466666666666667
                 }
               ]
@@ -2280,7 +2280,7 @@
               "name": "Hall, Chad W. ",
               "children": [
                 {
-                  "name": "B0143V938Q",
+                  "name": "The Coaching Mindset: 8 Ways to Think Like a Coach",
                   "value": 0.6733333333333333
                 }
               ]
@@ -2289,7 +2289,7 @@
               "name": "Kross, Ethan",
               "children": [
                 {
-                  "name": "B087PL8YVQ",
+                  "name": "Chatter: The Voice in Our Head, Why It Matters, and How to Harness It",
                   "value": 5.595
                 }
               ]
@@ -2308,7 +2308,7 @@
               "name": "Bernhard, Susan",
               "children": [
                 {
-                  "name": "B07BDKJVWS",
+                  "name": "Winter Loon: A Novel",
                   "value": 229.80666666666667
                 }
               ]
@@ -2317,7 +2317,7 @@
               "name": "Halliday, Lisa",
               "children": [
                 {
-                  "name": "B074ZDRGBC",
+                  "name": "Asymmetry: A Novel",
                   "value": 71.865
                 }
               ]
@@ -2326,11 +2326,11 @@
               "name": "Mason, Daniel",
               "children": [
                 {
-                  "name": "B078W5XGZD",
+                  "name": "The Winter Soldier",
                   "value": 0.5116666666666666
                 },
                 {
-                  "name": "B0BPX7SF89",
+                  "name": "North Woods: A Novel",
                   "value": 188.73333333333332
                 }
               ]
@@ -2339,7 +2339,7 @@
               "name": "Offill, Jenny",
               "children": [
                 {
-                  "name": "B077WWXZ41",
+                  "name": "Weather: A novel",
                   "value": 84.57
                 }
               ]
@@ -2348,11 +2348,11 @@
               "name": "Stradal, J. Ryan",
               "children": [
                 {
-                  "name": "B07L2J8P4S",
+                  "name": "The Lager Queen of Minnesota: A Novel",
                   "value": 0.305
                 },
                 {
-                  "name": "B0B6Z3LN2D",
+                  "name": "Saturday Night at the Lakeside Supper Club: A Novel",
                   "value": 365.8316666666666
                 }
               ]
@@ -2361,7 +2361,7 @@
               "name": "Donoghue, Emma",
               "children": [
                 {
-                  "name": "B086JN68M6",
+                  "name": "The Pull of the Stars: A Novel",
                   "value": 134.38666666666666
                 }
               ]
@@ -2370,7 +2370,7 @@
               "name": "Defoe, Daniel",
               "children": [
                 {
-                  "name": "B0084B57VO",
+                  "name": "A Journal of the Plague Year, written by a citizen who continued all the while in London",
                   "value": 8.288333333333334
                 }
               ]
@@ -2379,11 +2379,11 @@
               "name": "O'Farrell, Maggie",
               "children": [
                 {
-                  "name": "B07ZN51NL3",
+                  "name": "Hamnet",
                   "value": 14.233333333333334
                 },
                 {
-                  "name": "B09RTYQW2S",
+                  "name": "The Marriage Portrait: Reese's Book Club: A novel",
                   "value": 227.17166666666662
                 }
               ]
@@ -2392,7 +2392,7 @@
               "name": "MacDonald, Andrew David",
               "children": [
                 {
-                  "name": "B07THQLGBT",
+                  "name": "When We Were Vikings",
                   "value": 8.703333333333333
                 }
               ]
@@ -2401,7 +2401,7 @@
               "name": "Frazier, Jean Kyoung",
               "children": [
                 {
-                  "name": "B07YRWHGYD",
+                  "name": "Pizza Girl: A Novel",
                   "value": 201.625
                 }
               ]
@@ -2410,7 +2410,7 @@
               "name": "Yu, Charles",
               "children": [
                 {
-                  "name": "B07R5KC59C",
+                  "name": "Interior Chinatown: A Novel (National Book Award Winner)",
                   "value": 130.26166666666666
                 }
               ]
@@ -2419,7 +2419,7 @@
               "name": "Millet, Lydia",
               "children": [
                 {
-                  "name": "B07ZTTH5VD",
+                  "name": "A Children's Bible: A Novel",
                   "value": 210.41333333333336
                 }
               ]
@@ -2428,7 +2428,7 @@
               "name": "Evans, Danielle",
               "children": [
                 {
-                  "name": "B084V823SR",
+                  "name": "The Office of Historical Corrections: A Novella and Stories",
                   "value": 61.74166666666667
                 }
               ]
@@ -2437,7 +2437,7 @@
               "name": "Gyasi, Yaa",
               "children": [
                 {
-                  "name": "B07ZC6W6SV",
+                  "name": "Transcendent Kingdom: A Read with Jenna Pick: A novel",
                   "value": 285.815
                 }
               ]
@@ -2446,7 +2446,7 @@
               "name": "Winkler, Anthony C.",
               "children": [
                 {
-                  "name": "B008TY8BQ4",
+                  "name": "God Carlos",
                   "value": 210.7733333333333
                 }
               ]
@@ -2455,7 +2455,7 @@
               "name": "Lerner, Ben",
               "children": [
                 {
-                  "name": "B07MYXB26N",
+                  "name": "The Topeka School: A Novel",
                   "value": 121.355
                 }
               ]
@@ -2464,7 +2464,7 @@
               "name": "Erdrich, Louise",
               "children": [
                 {
-                  "name": "B07SKWFVYW",
+                  "name": "The Night Watchman: Pulitzer Prize Winning Fiction",
                   "value": 389.6816666666667
                 }
               ]
@@ -2473,7 +2473,7 @@
               "name": "Wagamese, Richard",
               "children": [
                 {
-                  "name": "B07C3XLBHG",
+                  "name": "Indian Horse: A Novel",
                   "value": 158.16333333333333
                 }
               ]
@@ -2482,7 +2482,7 @@
               "name": "Lin, Tao",
               "children": [
                 {
-                  "name": "B08PK59474",
+                  "name": "Leave Society (Vintage Contemporaries)",
                   "value": 81.49666666666668
                 }
               ]
@@ -2491,7 +2491,7 @@
               "name": "Franzen, Jonathan",
               "children": [
                 {
-                  "name": "B08N8Z99MK",
+                  "name": "Crossroads: A Novel",
                   "value": 687.5266666666666
                 }
               ]
@@ -2500,7 +2500,7 @@
               "name": "Doerr, Anthony",
               "children": [
                 {
-                  "name": "B08TRMSR3Z",
+                  "name": "Cloud Cuckoo Land: A Novel",
                   "value": 639.1366666666665
                 }
               ]
@@ -2509,7 +2509,7 @@
               "name": "Shteyngart, Gary",
               "children": [
                 {
-                  "name": "B08VRP55V1",
+                  "name": "Our Country Friends: A Novel",
                   "value": 563.2516666666667
                 }
               ]
@@ -2518,7 +2518,7 @@
               "name": "Kasulke, Calvin",
               "children": [
                 {
-                  "name": "B08PY1XTB8",
+                  "name": "Several People Are Typing: A GMA Book Club Pick",
                   "value": 128.16
                 }
               ]
@@ -2527,7 +2527,7 @@
               "name": "Labatut, Benjamín",
               "children": [
                 {
-                  "name": "B08QM8VHRT",
+                  "name": "When We Cease to Understand the World",
                   "value": 267.76666666666665
                 }
               ]
@@ -2536,7 +2536,7 @@
               "name": "Otsuka, Julie",
               "children": [
                 {
-                  "name": "B095MMJYSR",
+                  "name": "The Swimmers: A novel (CARNEGIE MEDAL FOR EXCELLENCE WINNER)",
                   "value": 170.82666666666665
                 }
               ]
@@ -2545,7 +2545,7 @@
               "name": "Magary, Drew",
               "children": [
                 {
-                  "name": "B00JX43A0G",
+                  "name": "The Rover (Kindle Single)",
                   "value": 26.981666666666666
                 }
               ]
@@ -2554,7 +2554,7 @@
               "name": "Haslett, Adam",
               "children": [
                 {
-                  "name": "B0151YQYYU",
+                  "name": "Imagine Me Gone",
                   "value": 484.47333333333336
                 }
               ]
@@ -2563,7 +2563,7 @@
               "name": "Barry, Quan",
               "children": [
                 {
-                  "name": "B095MPSYWY",
+                  "name": "When I'm Gone, Look for Me in the East: A Novel",
                   "value": 402.4766666666668
                 }
               ]
@@ -2572,7 +2572,7 @@
               "name": "Lee, Chang-rae",
               "children": [
                 {
-                  "name": "B08HL86V91",
+                  "name": "My Year Abroad: A Novel",
                   "value": 27.181666666666665
                 }
               ]
@@ -2581,7 +2581,7 @@
               "name": "Greer, Andrew Sean",
               "children": [
                 {
-                  "name": "B01MSICPW3",
+                  "name": "Less (Winner of the Pulitzer Prize): A Novel (The Arthur Less Books Book 1)",
                   "value": 9.538333333333334
                 }
               ]
@@ -2590,7 +2590,7 @@
               "name": "Escoffery, Jonathan",
               "children": [
                 {
-                  "name": "B09NTJPTKN",
+                  "name": "If I Survive You",
                   "value": 110.26499999999999
                 }
               ]
@@ -2599,7 +2599,7 @@
               "name": "Mikhail Bulgakov",
               "children": [
                 {
-                  "name": "B0BH8GTQYX",
+                  "name": "Heart of a Dog",
                   "value": 187.3733333333333
                 }
               ]
@@ -2608,7 +2608,7 @@
               "name": "Thurber, Bob",
               "children": [
                 {
-                  "name": "B07WK8JZ9N",
+                  "name": "In Fifty Words!: Micro Fictions",
                   "value": 28.276666666666667
                 }
               ]
@@ -2617,7 +2617,7 @@
               "name": "Talty, Morgan",
               "children": [
                 {
-                  "name": "B09NH4DJBP",
+                  "name": "Night of the Living Rez",
                   "value": 278.205
                 }
               ]
@@ -2626,7 +2626,7 @@
               "name": "Bulgakov, Mikhail",
               "children": [
                 {
-                  "name": "B08KH4LZDM",
+                  "name": "The Master & Margarita",
                   "value": 226.86833333333337
                 }
               ]
@@ -2635,7 +2635,7 @@
               "name": "Bennett, Claire-Louise",
               "children": [
                 {
-                  "name": "B097XBXQ1T",
+                  "name": "Checkout 19: A Novel",
                   "value": 18.453333333333333
                 }
               ]
@@ -2644,7 +2644,7 @@
               "name": "McCarthy, Cormac",
               "children": [
                 {
-                  "name": "B09T9D8QY7",
+                  "name": "The Passenger",
                   "value": 229.32833333333335
                 }
               ]
@@ -2653,7 +2653,7 @@
               "name": "Batuman, Elif",
               "children": [
                 {
-                  "name": "B01HNJIJ3U",
+                  "name": "The Idiot: A Novel",
                   "value": 147.60000000000002
                 }
               ]
@@ -2662,7 +2662,7 @@
               "name": "Kingsolver, Barbara",
               "children": [
                 {
-                  "name": "B09QMHZ53K",
+                  "name": "Demon Copperhead: A Pulitzer Prize Winner",
                   "value": 759.8516666666667
                 }
               ]
@@ -2671,7 +2671,7 @@
               "name": "Rundell, Katherine",
               "children": [
                 {
-                  "name": "B09NTK9WDQ",
+                  "name": "Super-Infinite: The Transformations of John Donne",
                   "value": 355.51833333333326
                 }
               ]
@@ -2680,7 +2680,7 @@
               "name": "Jackson, Jenny",
               "children": [
                 {
-                  "name": "B0B3HPSFJ7",
+                  "name": "Pineapple Street: A GMA Book Club Pick: A Novel",
                   "value": 356.04333333333335
                 }
               ]
@@ -2689,7 +2689,7 @@
               "name": "Moshfegh, Ottessa",
               "children": [
                 {
-                  "name": "B09GW3P1KJ",
+                  "name": "Lapvona: A Novel",
                   "value": 57.95333333333333
                 }
               ]
@@ -2698,7 +2698,7 @@
               "name": "Kirshenbaum, Binnie",
               "children": [
                 {
-                  "name": "B07GD51NCJ",
+                  "name": "Rabbits for Food",
                   "value": 335.0616666666667
                 }
               ]
@@ -2707,7 +2707,7 @@
               "name": "Vila-Matas, Enrique",
               "children": [
                 {
-                  "name": "B07GJBCLHN",
+                  "name": "Mac's Problem",
                   "value": 8.353333333333333
                 }
               ]
@@ -2716,7 +2716,7 @@
               "name": "deWitt, Patrick",
               "children": [
                 {
-                  "name": "B0BH4QWM85",
+                  "name": "The Librarianist: A Novel",
                   "value": 330.86666666666656
                 }
               ]
@@ -2725,7 +2725,7 @@
               "name": "Moore, Lorrie",
               "children": [
                 {
-                  "name": "B0BG13PH57",
+                  "name": "I Am Homeless If This Is Not My Home: A novel",
                   "value": 162.63666666666668
                 }
               ]
@@ -2734,7 +2734,7 @@
               "name": "Patchett, Ann",
               "children": [
                 {
-                  "name": "B0BL126WSH",
+                  "name": "Tom Lake: A Reese’s Book Club Pick",
                   "value": 67.50333333333333
                 }
               ]
@@ -2743,7 +2743,7 @@
               "name": "Evison, Jonathan",
               "children": [
                 {
-                  "name": "B08T6CL58V",
+                  "name": "Small World: A Novel",
                   "value": 714.8283333333334
                 }
               ]
@@ -2752,7 +2752,7 @@
               "name": "Russo, Richard",
               "children": [
                 {
-                  "name": "B0BKKVQPLB",
+                  "name": "Somebody's Fool: A novel (North Bath Trilogy Book 3)",
                   "value": 300.06666666666666
                 }
               ]
@@ -2761,7 +2761,7 @@
               "name": "Groff, Lauren",
               "children": [
                 {
-                  "name": "B0BTVBH6G3",
+                  "name": "The Vaster Wilds: A Novel",
                   "value": 343.14
                 }
               ]
@@ -2770,7 +2770,7 @@
               "name": "Smith, Zadie",
               "children": [
                 {
-                  "name": "B0BP66G6B7",
+                  "name": "The Fraud: A Novel",
                   "value": 195.4133333333333
                 }
               ]
@@ -2779,7 +2779,7 @@
               "name": "Fosse, Jon",
               "children": [
                 {
-                  "name": "B09RMQJCZJ",
+                  "name": "Aliss at the Fire — WINNER OF THE 2023 NOBEL PRIZE IN LITERATURE",
                   "value": 18.408333333333335
                 }
               ]
@@ -2788,7 +2788,7 @@
               "name": "Diaz, Hernan",
               "children": [
                 {
-                  "name": "B09BV2JNWV",
+                  "name": "Trust (Pulitzer Prize Winner)",
                   "value": 510.0216666666667
                 }
               ]
@@ -2797,7 +2797,7 @@
               "name": "Hill, Nathan",
               "children": [
                 {
-                  "name": "B0BR511292",
+                  "name": "Wellness: A Novel (Oprah's Book Club)",
                   "value": 585.6399999999998
                 }
               ]
@@ -2806,7 +2806,7 @@
               "name": "Napolitano, Ann",
               "children": [
                 {
-                  "name": "B0B7R4Q5DJ",
+                  "name": "Hello Beautiful (Oprah's Book Club): A Novel",
                   "value": 558.1083333333335
                 }
               ]
@@ -2815,7 +2815,7 @@
               "name": "Pickett, Alex",
               "children": [
                 {
-                  "name": "B0927NRBFB",
+                  "name": "The Restaurant Inspector",
                   "value": 129.6183333333333
                 }
               ]
@@ -2824,7 +2824,7 @@
               "name": "Verghese, Abraham",
               "children": [
                 {
-                  "name": "B0BJSGV831",
+                  "name": "The Covenant of Water (Oprah's Book Club)",
                   "value": 879.6683333333334
                 }
               ]
@@ -2833,7 +2833,7 @@
               "name": "Akbar, Kaveh",
               "children": [
                 {
-                  "name": "B0C3C886FY",
+                  "name": "Martyr!: A novel",
                   "value": 447.3
                 }
               ]
@@ -2842,7 +2842,7 @@
               "name": "Graff, Andrew J.",
               "children": [
                 {
-                  "name": "B0C592RHNC",
+                  "name": "True North: A Novel",
                   "value": 546.5533333333333
                 }
               ]
@@ -2851,7 +2851,7 @@
               "name": "Yagi, Emi",
               "children": [
                 {
-                  "name": "B09LHBX5KV",
+                  "name": "Diary of a Void: A Novel",
                   "value": 232.18833333333336
                 }
               ]
@@ -2860,7 +2860,7 @@
               "name": "Lianke, Yan",
               "children": [
                 {
-                  "name": "B0B72HGHW8",
+                  "name": "Heart Sutra",
                   "value": 47.09833333333333
                 }
               ]
@@ -2869,7 +2869,7 @@
               "name": "Bob-Waksberg, Raphael",
               "children": [
                 {
-                  "name": "B07HDT9JFX",
+                  "name": "Someone Who Will Love You in All Your Damaged Glory: Stories",
                   "value": 41.415
                 }
               ]
@@ -2878,7 +2878,7 @@
               "name": "Lynch, Paul",
               "children": [
                 {
-                  "name": "B0CLQVQSVL",
+                  "name": "Prophet Song: A Novel (Booker Prize Winner)",
                   "value": 21.755
                 }
               ]
@@ -2887,7 +2887,7 @@
               "name": "Enrigue, Álvaro",
               "children": [
                 {
-                  "name": "B0C1YCKNK1",
+                  "name": "You Dreamed of Empires: A Novel",
                   "value": 490.74999999999994
                 }
               ]
@@ -2896,7 +2896,7 @@
               "name": "McBride, James",
               "children": [
                 {
-                  "name": "B0BPNP7YQB",
+                  "name": "The Heaven & Earth Grocery Store: A Novel",
                   "value": 246.03166666666664
                 }
               ]
@@ -2905,7 +2905,7 @@
               "name": "Wiman, Christian",
               "children": [
                 {
-                  "name": "B0BQGJVCMT",
+                  "name": "Zero at the Bone: Fifty Entries Against Despair",
                   "value": 23.566666666666666
                 }
               ]
@@ -2914,7 +2914,7 @@
               "name": "Orange, Tommy",
               "children": [
                 {
-                  "name": "B0C772ZLMQ",
+                  "name": "Wandering Stars: A novel",
                   "value": 351.61333333333357
                 }
               ]
@@ -2923,7 +2923,7 @@
               "name": "Miri, Yu",
               "children": [
                 {
-                  "name": "B081914PR7",
+                  "name": "Tokyo Ueno Station (National Book Award Winner): A Novel",
                   "value": 61.81166666666667
                 }
               ]
@@ -2932,7 +2932,7 @@
               "name": "Paisner, Daniel",
               "children": [
                 {
-                  "name": "B09X34KMRM",
+                  "name": "Balloon Dog",
                   "value": 488.18500000000006
                 }
               ]
@@ -2941,7 +2941,7 @@
               "name": "Enger, Leif",
               "children": [
                 {
-                  "name": "B0CH1NHWNW",
+                  "name": "I Cheerfully Refuse",
                   "value": 144.69333333333333
                 }
               ]
@@ -2950,7 +2950,7 @@
               "name": "Haig, Matt",
               "children": [
                 {
-                  "name": "B0CGZFPKTZ",
+                  "name": "The Life Impossible: A Novel",
                   "value": 210.22500000000002
                 }
               ]
@@ -2959,7 +2959,7 @@
               "name": "Patterson, James",
               "children": [
                 {
-                  "name": "B0CDWDLCNS",
+                  "name": "The Secret Lives of Booksellers and Librarians: True Stories of the Magic of Reading (Heroes Among Us Book 4)",
                   "value": 11.546666666666667
                 }
               ]
@@ -2968,7 +2968,7 @@
               "name": "Harvey, Samantha",
               "children": [
                 {
-                  "name": "B0BZ5Y513V",
+                  "name": "Orbital: A Novel (Booker Prize Winner)",
                   "value": 263.08833333333337
                 }
               ]
@@ -2977,7 +2977,7 @@
               "name": "Torres, Justin",
               "children": [
                 {
-                  "name": "B0BQGDMFH6",
+                  "name": "Blackouts: A Novel",
                   "value": 8.911666666666667
                 }
               ]
@@ -2986,7 +2986,7 @@
               "name": "Melville, Herman",
               "children": [
                 {
-                  "name": "B000JML2Z6",
+                  "name": "Bartleby, the Scrivener A Story of Wall-Street",
                   "value": 0.7316666666666667
                 }
               ]
@@ -2995,7 +2995,7 @@
               "name": "Williams, John",
               "children": [
                 {
-                  "name": "B003K15IF8",
+                  "name": "Stoner (New York Review Books Classics)",
                   "value": 571.6816666666666
                 }
               ]
@@ -3004,7 +3004,7 @@
               "name": "Tellegen, Toon",
               "children": [
                 {
-                  "name": "B0D57LWBM6",
+                  "name": "The Hedgehog’s Dilemma",
                   "value": 13.611666666666668
                 }
               ]
@@ -3013,7 +3013,7 @@
               "name": "Pattee, Emma",
               "children": [
                 {
-                  "name": "B0CWFMT5SC",
+                  "name": "Tilt: A Novel",
                   "value": 11.095
                 }
               ]
@@ -3032,7 +3032,7 @@
               "name": "Goldman, Justin",
               "children": [
                 {
-                  "name": "B00O2RPEE4",
+                  "name": "The Power Within: Discovering the Path to Elite Goaltending",
                   "value": 42.56333333333334
                 }
               ]
@@ -3041,7 +3041,7 @@
               "name": "Magness, Steve",
               "children": [
                 {
-                  "name": "B00II6SY4W",
+                  "name": "The Science of Running: How to find your limit and train to maximize your performance",
                   "value": 0.3883333333333333
                 }
               ]
@@ -3050,7 +3050,7 @@
               "name": "Clark, David",
               "children": [
                 {
-                  "name": "B07N2X3ST6",
+                  "name": "Broken Open: Mountains, Demons, Treadmills And a Search for Nirvana",
                   "value": 7.671666666666667
                 }
               ]
@@ -3059,7 +3059,7 @@
               "name": "Dobkin, Adin",
               "children": [
                 {
-                  "name": "B08DHSFM4Q",
+                  "name": "Sprinting Through No Man's Land: Endurance, Tragedy, and Rebirth in the 1919 Tour de France",
                   "value": 1.1133333333333335
                 }
               ]
@@ -3068,7 +3068,7 @@
               "name": "Gilkis, Dr. Zeev",
               "children": [
                 {
-                  "name": "B0893YWV5Q",
+                  "name": "Running Back in Time: Discovering the Formula to Beat the Aging Process and Get Younger (Younger Than Ever Book 2)",
                   "value": 12.670000000000002
                 }
               ]
@@ -3077,7 +3077,7 @@
               "name": "Thompson, J. M.",
               "children": [
                 {
-                  "name": "B08RZ4PTSF",
+                  "name": "Running Is a Kind of Dreaming: A Memoir",
                   "value": 481.745
                 }
               ]
@@ -3086,7 +3086,7 @@
               "name": "Reese, Cory ",
               "children": [
                 {
-                  "name": "B0955FXRLM",
+                  "name": "Stronger Than the Dark: Exploring the Intimate Relationship Between Running and Depression",
                   "value": 1.1783333333333332
                 }
               ]
@@ -3095,7 +3095,7 @@
               "name": "Luke, Humphrey",
               "children": [
                 {
-                  "name": "B00JV2H5I8",
+                  "name": "Hansons Half-Marathon Method: Run Your Best Half-Marathon the Hansons Way",
                   "value": 116.79666666666667
                 }
               ]
@@ -3104,7 +3104,7 @@
               "name": "D' Alessandro, Adam",
               "children": [
                 {
-                  "name": "B00HYQEJAK",
+                  "name": "How You Can Run Faster Effortlessly",
                   "value": 10.595
                 }
               ]
@@ -3113,7 +3113,7 @@
               "name": "oluyede, leramo",
               "children": [
                 {
-                  "name": "B09QBBMXCR",
+                  "name": "Trail Runner: How to Build it, How to keep it",
                   "value": 0.6933333333333334
                 }
               ]
@@ -3122,7 +3122,7 @@
               "name": "Maraniss, David",
               "children": [
                 {
-                  "name": "B09JPFYQY2",
+                  "name": "Path Lit by Lightning: The Life of Jim Thorpe",
                   "value": 201.63833333333332
                 }
               ]
@@ -3131,7 +3131,7 @@
               "name": "McMillan, Greg",
               "children": [
                 {
-                  "name": "B0B33PJZJT",
+                  "name": "World's Greatest Running Lessons: 50 Lessons to Elevate Your Running",
                   "value": 66.815
                 }
               ]
@@ -3140,7 +3140,7 @@
               "name": "Lomong, Lopez",
               "children": [
                 {
-                  "name": "B007D1TKAU",
+                  "name": "Running for My Life: One Lost Boy's Journey from the Killing Fields of Sudan to the Olympic Games",
                   "value": 117.40833333333333
                 }
               ]
@@ -3149,7 +3149,7 @@
               "name": "Pierce, Bill",
               "children": [
                 {
-                  "name": "B087BQ7GK3",
+                  "name": "Runner's World Run Less Run Faster: Become a Faster, Stronger Runner with the Revolutionary 3-Runs-a-Week Training Program",
                   "value": 11.338333333333333
                 }
               ]
@@ -3158,7 +3158,7 @@
               "name": "Hudson, John",
               "children": [
                 {
-                  "name": "B08D4QJRY2",
+                  "name": "How to Survive: Self-Reliance in Extreme Circumstances",
                   "value": 80.91666666666666
                 }
               ]
@@ -3167,7 +3167,7 @@
               "name": "Gearhart, Sarah",
               "children": [
                 {
-                  "name": "B0B3Y4RYX6",
+                  "name": "We Share the Sun: The Incredible Journey of Kenya's Legendary Running Coach Patrick Sang and the Fastest Runners on Earth",
                   "value": 2.12
                 }
               ]
@@ -3186,7 +3186,7 @@
               "name": "Oluo, Ijeoma",
               "children": [
                 {
-                  "name": "B07QBNKJTZ",
+                  "name": "So You Want to Talk About Race",
                   "value": 145.57666666666668
                 }
               ]
@@ -3195,7 +3195,7 @@
               "name": "Freeman, Grey",
               "children": [
                 {
-                  "name": "B0764BV94D",
+                  "name": "Practical Stoicism: Exercises for Doing the Right Thing Right Now",
                   "value": 6.85
                 }
               ]
@@ -3214,7 +3214,7 @@
               "name": "Sroufe, Del",
               "children": [
                 {
-                  "name": "B00U27BMT4",
+                  "name": "The China Study Quick & Easy Cookbook: Cook Once, Eat All Week with Whole Food, Plant-Based Recipes",
                   "value": 17.973333333333333
                 }
               ]
@@ -3223,7 +3223,7 @@
               "name": "Frazier, Matt",
               "children": [
                 {
-                  "name": "B08J3YYP2M",
+                  "name": "The Plant-Based Athlete: A Game-Changing Approach to Peak Performance",
                   "value": 14.389999999999999
                 }
               ]
@@ -3242,7 +3242,7 @@
               "name": "Frankl, Viktor E.",
               "children": [
                 {
-                  "name": "B009U9S6FI",
+                  "name": "Man's Search for Meaning",
                   "value": 26.38333333333333
                 }
               ]
@@ -3261,7 +3261,7 @@
               "name": "Ferriss, Timothy",
               "children": [
                 {
-                  "name": "B003EI2EH2",
+                  "name": "The 4-Hour Body: An Uncommon Guide to Rapid Fat-Loss, Incredible Sex, and Becoming Superhuman",
                   "value": 0.8016666666666666
                 }
               ]
@@ -3270,7 +3270,7 @@
               "name": "Attia MD, Peter ",
               "children": [
                 {
-                  "name": "B0B1BTJLJN",
+                  "name": "Outlive: The Science and Art of Longevity",
                   "value": 312.31333333333333
                 }
               ]
@@ -3279,7 +3279,7 @@
               "name": "Asprey, Dave",
               "children": [
                 {
-                  "name": "B0B399L6KP",
+                  "name": "Smarter Not Harder: The Biohacker's Guide to Getting the Body and Mind You Want",
                   "value": 77.79333333333334
                 }
               ]
@@ -3298,7 +3298,7 @@
               "name": "Bechdel, Alison",
               "children": [
                 {
-                  "name": "B08B38JVKY",
+                  "name": "The Secret to Superhuman Strength",
                   "value": 201.58166666666668
                 }
               ]
@@ -3317,7 +3317,7 @@
               "name": "READS, CALEB",
               "children": [
                 {
-                  "name": "B09LM328XY",
+                  "name": "Summary Analysis Of Immune By Philipp Dettmer: A Journey into the Mysterious System That Keeps You Alive",
                   "value": 6.89
                 }
               ]
@@ -3326,7 +3326,7 @@
               "name": "Campbell, Hayley",
               "children": [
                 {
-                  "name": "B09CNFH5WG",
+                  "name": "All the Living and the Dead: From Embalmers to Executioners, an Exploration of the People Who Have Made Death Their Life's Work",
                   "value": 5.001666666666667
                 }
               ]
@@ -3345,7 +3345,7 @@
               "name": "Sheridan, Gina",
               "children": [
                 {
-                  "name": "B0108VD2L4",
+                  "name": "Check These Out: One Librarian's Catalog of the 200 Coolest, Best, and Most Important Books You'll Ever Read",
                   "value": 7.595
                 }
               ]
@@ -3364,7 +3364,7 @@
               "name": "Quinones, Sam",
               "children": [
                 {
-                  "name": "B07TVRR6GR",
+                  "name": "Dreamland (YA edition): The True Tale of America's Opiate Epidemic",
                   "value": 14.353333333333333
                 }
               ]
@@ -3383,7 +3383,7 @@
               "name": "Sancton, Julian",
               "children": [
                 {
-                  "name": "B08FH9BV7N",
+                  "name": "Madhouse at the End of the Earth: The Belgica's Journey into the Dark Antarctic Night",
                   "value": 776.5333333333334
                 }
               ]
@@ -3392,7 +3392,7 @@
               "name": "National Geographic",
               "children": [
                 {
-                  "name": "B016TG0SAK",
+                  "name": "National Geographic Guide to National Parks of the United States, 8th Edition (National Geographic Guide to the National Parks of the United States)",
                   "value": 0.9916666666666667
                 }
               ]
@@ -3411,7 +3411,7 @@
               "name": "Petrow, Steven",
               "children": [
                 {
-                  "name": "B08KL58Q4X",
+                  "name": "Stupid Things I Won't Do When I Get Old: A Highly Judgmental, Unapologetically Honest Accounting of All the Things Our Elders Are Doing Wrong",
                   "value": 28.553333333333335
                 }
               ]
@@ -3420,7 +3420,7 @@
               "name": "Jillette, Penn",
               "children": [
                 {
-                  "name": "B0B2F5J32D",
+                  "name": "Random",
                   "value": 34.79333333333334
                 }
               ]
@@ -3429,7 +3429,7 @@
               "name": "Mortimer, Bob",
               "children": [
                 {
-                  "name": "B0BTZRQHJM",
+                  "name": "The Clementine Complex",
                   "value": 470.41999999999996
                 }
               ]
@@ -3448,7 +3448,7 @@
               "name": "Zevin, Gabrielle",
               "children": [
                 {
-                  "name": "B09JBCGQB8",
+                  "name": "Tomorrow, and Tomorrow, and Tomorrow: A novel",
                   "value": 598.2366666666666
                 }
               ]
@@ -3457,7 +3457,7 @@
               "name": "Sue, Natalie",
               "children": [
                 {
-                  "name": "B0CJ9TSSYB",
+                  "name": "I Hope This Finds You Well: A Novel",
                   "value": 580.2633333333333
                 }
               ]

--- a/src/services/__tests__/genreHierarchy.test.js
+++ b/src/services/__tests__/genreHierarchy.test.js
@@ -4,20 +4,28 @@ import { buildGenreHierarchy } from '../genreHierarchy';
 describe('buildGenreHierarchy', () => {
   it('builds nested tree from flat records', () => {
     const sessions = [
-      { asin: 'A1', title: 'Book One', duration: 30 },
-      { asin: 'A2', title: 'Book Two', duration: 15 },
+      { asin: 'B000OZ0NXA', duration: 30 },
+      { asin: 'B000FC1MBO', duration: 15 },
     ];
     const genres = [
-      { ASIN: 'A1', Genre: 'Fiction' },
-      { ASIN: 'A2', Genre: 'Fiction' },
+      { ASIN: 'B000OZ0NXA', Genre: 'Fiction' },
+      { ASIN: 'B000FC1MBO', Genre: 'Fiction' },
     ];
     const authors = [
-      { ASIN: 'A1', 'Author Name': 'Author A' },
-      { ASIN: 'A2', 'Author Name': 'Author B' },
+      { ASIN: 'B000OZ0NXA', 'Author Name': 'Author A' },
+      { ASIN: 'B000FC1MBO', 'Author Name': 'Author B' },
     ];
     const tags = [
-      { ASIN: 'A1', 'Tag Source Group': 'genre', 'Tag Name': 'Mystery' },
-      { ASIN: 'A2', 'Tag Source Group': 'genre', 'Tag Name': 'Fantasy' },
+      {
+        ASIN: 'B000OZ0NXA',
+        'Tag Source Group': 'genre',
+        'Tag Name': 'Mystery',
+      },
+      {
+        ASIN: 'B000FC1MBO',
+        'Tag Source Group': 'genre',
+        'Tag Name': 'Fantasy',
+      },
     ];
     const root = buildGenreHierarchy(sessions, genres, authors, tags);
     expect(root.name).toBe('root');
@@ -26,6 +34,9 @@ describe('buildGenreHierarchy', () => {
     const mystery = fiction.children.find((c) => c.name === 'Mystery');
     expect(mystery.children[0].name).toBe('Author A');
     const book = mystery.children[0].children[0];
-    expect(book).toEqual({ name: 'Book One', value: 30 });
+    expect(book).toEqual({
+      name: 'Killing Floor (Jack Reacher, Book 1)',
+      value: 30,
+    });
   });
 });

--- a/src/services/genreHierarchy.js
+++ b/src/services/genreHierarchy.js
@@ -1,3 +1,5 @@
+const asinTitleMap = require('../data/kindle/asin-title-map.json');
+
 function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
   const genreByAsin = {};
   for (const g of genres) {
@@ -22,7 +24,7 @@ function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
   for (const s of sessions) {
     const asin = s.asin || s.ASIN;
     if (!asin) continue;
-    const title = s.title || s['Product Name'] || asin;
+    const title = asinTitleMap[asin] || s.title || s['Product Name'] || asin;
     const minutes = Number(s.duration || s.minutes || 0);
     if (!books[asin]) {
       books[asin] = {


### PR DESCRIPTION
## Summary
- map ASINs to human-readable titles when building genre hierarchy
- regenerate genre hierarchy data with book titles
- update tests and helpers to work with title-based hierarchy

## Testing
- `npx vitest run src/services/__tests__/genreHierarchy.test.js src/components/genre/__tests__/GenreSankey.test.jsx src/components/genre/__tests__/GenreIcicle.test.jsx src/components/genre/__tests__/GenreSunburst.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6892b22fe8c0832499b60c518b579921