### PR TITLE
feat: toggle fullscreen for Genre Sankey chart

### DIFF
--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -260,7 +260,10 @@ export default function GenreSankey() {
   }, [data, dimensions]);
 
   return (
-    <div ref={containerRef} style={{ position: 'relative' }}>
+    <div
+      ref={containerRef}
+      style={{ position: 'relative', width: '100%', height: '100%' }}
+    >
       <div>
         <label>
           Start

--- a/src/pages/charts/GenreSankey.jsx
+++ b/src/pages/charts/GenreSankey.jsx
@@ -1,11 +1,47 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import GenreSankey from '@/components/genre/GenreSankey.jsx';
 
 export default function GenreSankeyPage() {
+  const containerRef = useRef(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement && containerRef.current) {
+      containerRef.current.requestFullscreen();
+    } else if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+  };
+
+  useEffect(() => {
+    const handler = () => {
+      setIsFullscreen(document.fullscreenElement === containerRef.current);
+    };
+    document.addEventListener('fullscreenchange', handler);
+    return () => document.removeEventListener('fullscreenchange', handler);
+  }, []);
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Genre Transition Sankey</h1>
-      <GenreSankey />
+    <div
+      ref={containerRef}
+      className={
+        isFullscreen
+          ? 'fixed inset-0 z-50 bg-white p-4 flex flex-col'
+          : 'p-4'
+      }
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold">Genre Transition Sankey</h1>
+        <button
+          onClick={toggleFullscreen}
+          className="px-2 py-1 border rounded"
+        >
+          {isFullscreen ? 'Exit Full Screen' : 'Full Screen'}
+        </button>
+      </div>
+      <div className="flex-1">
+        <GenreSankey />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add fullscreen toggle and container styling for Genre Sankey page
- expand GenreSankey component to fill parent dimensions

## Testing
- `npm test` *(fails: BookNetwork, GenreSankey tests)*


------
https://chatgpt.com/codex/tasks/task_e_6892b01670f48324b954762a2bb984ea