### PR TITLE
feat: add genre filter to sankey

### DIFF
--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -62,6 +62,25 @@ describe('GenreSankey', () => {
     expect(container.querySelectorAll('path').length).not.toBe(initialCount);
   });
 
+  it('filters data by genre name', async () => {
+    const { container } = render(<GenreSankey />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    });
+    const initialCount = container.querySelectorAll('path').length;
+    fireEvent.change(screen.getByLabelText('Filter'), {
+      target: { value: 'Self-Help' },
+    });
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBe(4);
+    });
+    expect(container.querySelectorAll('path').length).toBeLessThan(initialCount);
+    fireEvent.click(screen.getByText('Clear Filter'));
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBe(initialCount);
+    });
+  });
+
   it('renders link gradients transitioning between node colors', async () => {
     const { container } = render(<GenreSankey />);
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- add raw and filtered state to GenreSankey and rebuild link/node data based on a genre text filter
- expose a filter input with clear and reset actions to toggle complete diagram
- cover genre filtering with unit tests

## Testing
- `npm test src/components/genre/__tests__/GenreSankey.test.jsx -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6892b59efce08324b5cffbee3c15e902