### PR TITLE
Load GenreSunburst data locally

### DIFF
--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
 import GenreIcicle from '@/components/genre/GenreIcicle.jsx';
+import hierarchy from '@/data/kindle/genre-hierarchy.json';
 import { Skeleton } from '@/ui/skeleton';
 import { cn } from '@/lib/utils';
 
@@ -8,30 +9,10 @@ export default function GenreSunburstPage() {
   const [view, setView] = useState('sunburst');
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
 
   useEffect(() => {
-    let isMounted = true;
-    fetch('/api/kindle/genre-hierarchy')
-      .then((res) => {
-        if (!res.ok) throw new Error('Network response was not ok');
-        return res.json();
-      })
-      .then((json) => {
-        if (isMounted) {
-          setData(json);
-          setIsLoading(false);
-        }
-      })
-      .catch(() => {
-        if (isMounted) {
-          setError('Failed to load genre hierarchy');
-          setIsLoading(false);
-        }
-      });
-    return () => {
-      isMounted = false;
-    };
+    setData(hierarchy);
+    setIsLoading(false);
   }, []);
 
   return (
@@ -72,8 +53,6 @@ export default function GenreSunburstPage() {
           className="h-[400px] w-full"
           data-testid="genre-hierarchy-skeleton"
         />
-      ) : error ? (
-        <div role="alert">{error}</div>
       ) : view === 'sunburst' ? (
         <GenreSunburst data={data} />
       ) : (

--- a/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import GenreSunburstPage from '../GenreSunburst.jsx';
 
@@ -13,19 +13,8 @@ vi.mock('@/components/genre/GenreIcicle.jsx', () => ({
   default: () => <div data-testid="icicle-layout" />,
 }));
 
-const mockData = { name: 'root', children: [] };
-
 describe('GenreSunburstPage', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('toggles between sunburst and icicle layouts', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockData),
-    });
-
     const user = userEvent.setup();
     render(<GenreSunburstPage />);
     const sunburstButton = screen.getByRole('button', { name: /sunburst/i });
@@ -57,37 +46,12 @@ describe('GenreSunburstPage', () => {
     expect(icicleButton).not.toHaveClass('text-white');
   });
 
-  it('displays chart description', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(mockData),
-    });
-
+  it('displays chart description', () => {
     render(<GenreSunburstPage />);
     expect(
       screen.getByText(
         /each slice represents time spent reading in that genre/i
       )
-    ).toBeInTheDocument();
-  });
-
-  it('disables view buttons while loading', () => {
-    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}));
-
-    render(<GenreSunburstPage />);
-    const sunburstButton = screen.getByRole('button', { name: /sunburst/i });
-    const icicleButton = screen.getByRole('button', { name: /icicle/i });
-    expect(sunburstButton).toBeDisabled();
-    expect(icicleButton).toBeDisabled();
-  });
-
-  it('renders an error message when the fetch fails', async () => {
-    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('API error'));
-
-    render(<GenreSunburstPage />);
-
-    expect(
-      await screen.findByText(/failed to load genre hierarchy/i)
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- load `GenreSunburst` chart data from bundled JSON instead of backend
- simplify `GenreSunburstPage` tests for synchronous data

## Testing
- `npx vitest run src/pages/charts/__tests__/GenreSunburstPage.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6892baa299e08324a57df439a03a989a