### PR TITLE
refactor: simplify top navigation

### DIFF
--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { dashboardRoutes } from "@/routes";
-import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent, SheetTrigger } from "@/ui/sheet";
 import NavItems from "./NavItems";
 
@@ -29,19 +28,12 @@ function MobileMenuIcon({ open }: { open: boolean }) {
 
 export default function TopNavigation() {
   const [open, setOpen] = useState(false);
-  const isMobile = useIsMobile();
-
-  useEffect(() => {
-    if (!isMobile) {
-      setOpen(false);
-    }
-  }, [isMobile]);
 
   return (
     <nav className="flex items-center">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
-          <button className="md:hidden p-2" aria-expanded={open}>
+          <button className="p-2" aria-expanded={open}>
             <MobileMenuIcon open={open} />
             <span className="sr-only">Open navigation menu</span>
           </button>
@@ -50,11 +42,6 @@ export default function TopNavigation() {
           <NavItems groups={dashboardRoutes} orientation="vertical" />
         </SheetContent>
       </Sheet>
-      <NavItems
-        groups={dashboardRoutes}
-        orientation="horizontal"
-        className="hidden md:flex"
-      />
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- remove mobile breakpoint logic from TopNavigation and expose menu icon on all screen sizes
- drop desktop nav items, leaving sheet-based vertical navigation

## Testing
- `npm test` *(fails: BookNetwork component > highlights shortest path when searching by tag; BookNetwork component > renders higher-degree nodes with larger radii)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6892bb3ebcf88324a12ae74fef0b1f66