### PR TITLE
feat: add subgenre mapping support

### DIFF
--- a/scripts/fetch-subgenres.ts
+++ b/scripts/fetch-subgenres.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+
+// Basic script to fetch sub-genre information from Open Library
+// Usage: ts-node scripts/fetch-subgenres.ts <ASIN|Title> [...]
+// The script looks up titles in the existing asin-title map and queries
+// the Open Library API for subject data. The first returned subject is
+// stored as the sub-genre in a mapping file under src/data/kindle.
+
+const asinTitleMap: Record<string, string> = require('../src/data/kindle/asin-title-map.json');
+
+const subgenrePath = path.join(__dirname, '../src/data/kindle/asin-subgenre-map.json');
+let existing: Record<string, string> = {};
+try {
+  existing = require(subgenrePath);
+} catch {
+  existing = {};
+}
+
+async function lookupSubjects(title: string): Promise<string[]> {
+  const url = `https://openlibrary.org/search.json?title=${encodeURIComponent(title)}&limit=1`;
+  const res = await fetch(url);
+  if (!res.ok) return [];
+  const data = await res.json();
+  const doc = data.docs && data.docs[0];
+  return (doc && doc.subject) || [];
+}
+
+async function processQuery(query: string) {
+  const title = asinTitleMap[query] || query;
+  const subjects = await lookupSubjects(title);
+  if (subjects.length > 0) {
+    existing[query] = subjects[0];
+    console.log(`Found sub-genre for ${query}: ${subjects[0]}`);
+  } else {
+    console.log(`No sub-genre found for ${query}`);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.log('Usage: ts-node scripts/fetch-subgenres.ts <ASIN|Title> [...]');
+    return;
+  }
+  for (const a of args) {
+    await processQuery(a);
+  }
+  fs.writeFileSync(subgenrePath, JSON.stringify(existing, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/data/kindle/asin-subgenre-map.json
+++ b/src/data/kindle/asin-subgenre-map.json
@@ -1,0 +1,3 @@
+{
+  "B01A4AXM3W": "Historical Thriller"
+}

--- a/src/services/__tests__/genreHierarchy.test.js
+++ b/src/services/__tests__/genreHierarchy.test.js
@@ -28,4 +28,14 @@ describe('buildGenreHierarchy', () => {
     const book = mystery.children[0].children[0];
     expect(book).toEqual({ name: 'Book One', value: 30 });
   });
+
+  it('uses asin-subgenre mapping when tags are missing', () => {
+    const sessions = [{ asin: 'B01A4AXM3W', title: 'The Last Days of Night: A Novel', duration: 10 }];
+    const genres = [{ ASIN: 'B01A4AXM3W', Genre: 'Fiction' }];
+    const authors = [{ ASIN: 'B01A4AXM3W', 'Author Name': 'Graham Moore' }];
+    const root = buildGenreHierarchy(sessions, genres, authors, []);
+    const fiction = root.children.find((c) => c.name === 'Fiction');
+    const sub = fiction.children.find((c) => c.name === 'Historical Thriller');
+    expect(sub).toBeTruthy();
+  });
 });

--- a/src/services/genreHierarchy.js
+++ b/src/services/genreHierarchy.js
@@ -1,4 +1,5 @@
 const asinTitleMap = require('../data/kindle/asin-title-map.json');
+const asinSubgenreMap = require('../data/kindle/asin-subgenre-map.json');
 
 function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
   const genreByAsin = {};
@@ -7,7 +8,7 @@ function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
     const genre = g.Genre;
     if (asin && genre && !genreByAsin[asin]) genreByAsin[asin] = genre;
   }
-  const subgenreByAsin = {};
+  const subgenreByAsin = { ...asinSubgenreMap };
   for (const t of tags) {
     if (t['Tag Source Group'] !== 'genre') continue;
     const asin = t.ASIN;


### PR DESCRIPTION
## Summary
- add script to fetch book sub-genres from Open Library
- store ASIN-to-subgenre map and load it when building genre hierarchy
- test that hierarchy uses sub-genre mapping

## Testing
- `npm test` *(fails: BookNetwork.test.jsx)*
- `npx vitest run src/services/__tests__/genreHierarchy.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6892bff52fa48324835b2dddcc2261de