### PR TITLE
feat: highlight unclassified genres

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,0 +1,2 @@
+const UNCLASSIFIED_GENRE = 'Unclassified';
+module.exports = { UNCLASSIFIED_GENRE };

--- a/src/data/kindle/genre-hierarchy.json
+++ b/src/data/kindle/genre-hierarchy.json
@@ -5,7 +5,7 @@
       "name": "Mystery, Thriller & Suspense",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Moore, Graham",
@@ -753,7 +753,7 @@
       "name": "Science & Math",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "de Grasse Tyson, Neil",
@@ -859,13 +859,13 @@
       ]
     },
     {
-      "name": "Unknown",
+      "name": "Unclassified",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
-              "name": "Unknown",
+              "name": "Unclassified",
               "children": [
                 {
                   "name": "PSNL!KICSGurupaUS!bGlicmFyeS1leHBpcmU_aWQ9QTJTMFYwMEhJUktPR1MmbWFya2V0cGxhY2U9QVRWUERLSUtYMERFUiZhc2luPUIwMU1BV1QyTU8mZW5kdGltZT0xNTE4NTU2MzcwNzk3",
@@ -1657,7 +1657,7 @@
       "name": "Arts & Photography",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Bach, Sebastian",
@@ -1685,7 +1685,7 @@
       "name": "Biographies & Memoirs",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Isaacson, Walter",
@@ -1830,7 +1830,7 @@
       "name": "Children's Books",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Riordan, Rick",
@@ -1858,7 +1858,7 @@
       "name": "History",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Chernow, Ron",
@@ -2025,7 +2025,7 @@
       "name": "Self-Help",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Burns, David D. ",
@@ -2107,7 +2107,7 @@
       "name": "Science Fiction & Fantasy",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Moore, Christopher",
@@ -2274,7 +2274,7 @@
       "name": "Business & Money",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Hall, Chad W. ",
@@ -2302,7 +2302,7 @@
       "name": "Literature & Fiction",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Bernhard, Susan",
@@ -3026,7 +3026,7 @@
       "name": "Sports & Outdoors",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Goldman, Justin",
@@ -3180,7 +3180,7 @@
       "name": "Politics & Social Sciences",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Oluo, Ijeoma",
@@ -3208,7 +3208,7 @@
       "name": "Cookbooks, Food & Wine",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Sroufe, Del",
@@ -3236,7 +3236,7 @@
       "name": "Religion & Spirituality",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Frankl, Viktor E.",
@@ -3255,7 +3255,7 @@
       "name": "Health, Fitness & Dieting",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Ferriss, Timothy",
@@ -3292,7 +3292,7 @@
       "name": "Comics & Graphic Novels",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Bechdel, Alison",
@@ -3311,7 +3311,7 @@
       "name": "Medical Books",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "READS, CALEB",
@@ -3339,7 +3339,7 @@
       "name": "Reference",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Sheridan, Gina",
@@ -3358,7 +3358,7 @@
       "name": "Teen & Young Adult",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Quinones, Sam",
@@ -3377,7 +3377,7 @@
       "name": "Travel",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Sancton, Julian",
@@ -3405,7 +3405,7 @@
       "name": "Humor & Entertainment",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Petrow, Steven",
@@ -3442,7 +3442,7 @@
       "name": "Romance",
       "children": [
         {
-          "name": "Unknown",
+          "name": "Unclassified",
           "children": [
             {
               "name": "Zevin, Gabrielle",

--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -1,19 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import GenreSunburst from '@/components/genre/GenreSunburst.jsx';
 import GenreIcicle from '@/components/genre/GenreIcicle.jsx';
 import hierarchy from '@/data/kindle/genre-hierarchy.json';
 import { Skeleton } from '@/ui/skeleton';
 import { cn } from '@/lib/utils';
+import constants from '@/config/constants';
+
+const { UNCLASSIFIED_GENRE } = constants;
 
 export default function GenreSunburstPage() {
   const [view, setView] = useState('sunburst');
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [showUnclassified, setShowUnclassified] = useState(false);
 
   useEffect(() => {
     setData(hierarchy);
     setIsLoading(false);
   }, []);
+
+  const filteredData = useMemo(() => {
+    if (!data) return null;
+    if (!showUnclassified) return data;
+    const unc = data.children?.find((c) => c.name === UNCLASSIFIED_GENRE);
+    return unc ? { ...data, children: [unc] } : { ...data, children: [] };
+  }, [data, showUnclassified]);
 
   return (
     <div className="p-4">
@@ -47,6 +58,18 @@ export default function GenreSunburstPage() {
         >
           Icicle
         </button>
+        <button
+          type="button"
+          onClick={() => setShowUnclassified((p) => !p)}
+          aria-pressed={showUnclassified}
+          disabled={isLoading}
+          className={cn(
+            'px-2 py-1 border rounded',
+            showUnclassified && 'bg-primary text-white',
+          )}
+        >
+          {showUnclassified ? 'Show All' : `Show ${UNCLASSIFIED_GENRE}`}
+        </button>
       </div>
       {isLoading ? (
         <Skeleton
@@ -54,9 +77,9 @@ export default function GenreSunburstPage() {
           data-testid="genre-hierarchy-skeleton"
         />
       ) : view === 'sunburst' ? (
-        <GenreSunburst data={data} />
+        <GenreSunburst data={filteredData} />
       ) : (
-        <GenreIcicle data={data} />
+        <GenreIcicle data={filteredData} />
       )}
     </div>
   );

--- a/src/services/__tests__/genreHierarchy.test.js
+++ b/src/services/__tests__/genreHierarchy.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildGenreHierarchy } from '../genreHierarchy';
+const { UNCLASSIFIED_GENRE } = require('../../config/constants');
 
 describe('buildGenreHierarchy', () => {
   it('builds nested tree from flat records', () => {
@@ -37,5 +38,16 @@ describe('buildGenreHierarchy', () => {
     const fiction = root.children.find((c) => c.name === 'Fiction');
     const sub = fiction.children.find((c) => c.name === 'Historical Thriller');
     expect(sub).toBeTruthy();
+  });
+
+  it('labels missing data as unclassified', () => {
+    const sessions = [{ asin: 'X1', title: 'Untitled Book', duration: 5 }];
+    const root = buildGenreHierarchy(sessions, [], [], []);
+    const unc = root.children.find((c) => c.name === UNCLASSIFIED_GENRE);
+    expect(unc).toBeTruthy();
+    const sub = unc.children.find((c) => c.name === UNCLASSIFIED_GENRE);
+    expect(sub).toBeTruthy();
+    const author = sub.children.find((c) => c.name === UNCLASSIFIED_GENRE);
+    expect(author.children[0]).toEqual({ name: 'Untitled Book', value: 5 });
   });
 });

--- a/src/services/genreHierarchy.js
+++ b/src/services/genreHierarchy.js
@@ -1,5 +1,6 @@
 const asinTitleMap = require('../data/kindle/asin-title-map.json');
 const asinSubgenreMap = require('../data/kindle/asin-subgenre-map.json');
+const { UNCLASSIFIED_GENRE } = require('../config/constants');
 
 function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
   const genreByAsin = {};
@@ -32,9 +33,9 @@ function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {
       books[asin] = {
         title,
         minutes: 0,
-        genre: genreByAsin[asin] || 'Unknown',
-        subgenre: subgenreByAsin[asin] || 'Unknown',
-        author: authorByAsin[asin] || 'Unknown',
+        genre: genreByAsin[asin] || UNCLASSIFIED_GENRE,
+        subgenre: subgenreByAsin[asin] || UNCLASSIFIED_GENRE,
+        author: authorByAsin[asin] || UNCLASSIFIED_GENRE,
       };
     }
     books[asin].minutes += minutes;


### PR DESCRIPTION
## Summary
- centralize unclassified genre label in shared config
- expose "Show Unclassified" filter on Genre Sunburst page
- update hierarchy builder and tests to use new constant

## Testing
- `npx vitest run src/services/__tests__/genreHierarchy.test.js src/pages/charts/__tests__/GenreSunburstPage.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6892c377bf5c832499310baff71cd37e