### PR TITLE
feat: add accordion nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@capacitor/core": "^7.4.2",
         "@capacitor/geolocation": "^7.1.4",
+        "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1239,6 +1240,37 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.11.tgz",
+      "integrity": "sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collapsible": "1.1.11",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@capacitor/core": "^7.4.2",
     "@capacitor/geolocation": "^7.1.4",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -4,6 +4,12 @@ import type { DashboardRouteGroup } from "@/routes";
 import { cn } from "@/lib/utils";
 import { SheetClose } from "@/ui/sheet";
 import { Popover, PopoverTrigger, PopoverContent } from "@/ui/popover";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/ui/accordion";
 
 interface NavItemsProps {
   groups: DashboardRouteGroup[];
@@ -45,19 +51,40 @@ export default function NavItems({
     return vertical ? <SheetClose asChild>{link}</SheetClose> : link;
   };
 
+  if (vertical) {
+    return (
+      <div className={cn("flex flex-col gap-4", className)}>
+        {renderLink("/", "Dashboard")}
+        <Accordion type="multiple" className="w-full">
+          {groups.map((group) => {
+            const Icon = group.icon;
+            return (
+              <AccordionItem key={group.label} value={group.label}>
+                <AccordionTrigger className="group flex w-full items-center gap-2 px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground">
+                  {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
+                  <span>{group.label}</span>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <ul className="flex flex-col gap-2 pl-4">
+                    {group.items.map((item) => (
+                      <li key={item.to}>{renderLink(item.to, item.label)}</li>
+                    ))}
+                  </ul>
+                </AccordionContent>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
+      </div>
+    );
+  }
+
   return (
-    <ul className={cn(vertical ? "flex flex-col gap-4" : "flex gap-4", className)}>
+    <ul className={cn("flex gap-4", className)}>
       <li>{renderLink("/", "Dashboard")}</li>
       {groups.map((group) => {
         const Icon = group.icon;
         const firstItem = group.items[0];
-        if (vertical) {
-          return (
-            <li key={group.label}>
-              {renderLink(firstItem?.to ?? "#", group.label, Icon)}
-            </li>
-          );
-        }
         return (
           <li key={group.label}>
             <Popover>

--- a/src/components/layout/__tests__/navitems.test.tsx
+++ b/src/components/layout/__tests__/navitems.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import NavItems from "../NavItems";
+import type { DashboardRouteGroup } from "@/routes";
+import { vi } from "vitest";
+
+vi.mock("@/ui/sheet", () => ({
+  SheetClose: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const TestIcon = () => <svg data-testid="icon" />;
+
+const groups: DashboardRouteGroup[] = [
+  {
+    label: "Group",
+    icon: TestIcon as any,
+    items: [
+      { to: "/item1", label: "Item 1", icon: TestIcon as any, description: "" },
+      { to: "/item2", label: "Item 2", icon: TestIcon as any, description: "" },
+    ],
+  },
+];
+
+describe("NavItems Accordion", () => {
+  it("toggles group items", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <NavItems groups={groups} orientation="vertical" />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Group" });
+    expect(trigger).toHaveAttribute("aria-controls");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Item 1")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(screen.getByText("Item 1")).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(trigger);
+    expect(screen.queryByText("Item 1")).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item ref={ref} className={cn("border-b", className)} {...props} />
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-2 text-sm font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown
+        className="h-4 w-4 shrink-0 transition-transform duration-200"
+        aria-hidden="true"
+      />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className={cn(
+      "overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+      className,
+    )}
+    {...props}
+  >
+    <div className="pb-4 pt-0">{children}</div>
+  </AccordionPrimitive.Content>
+));
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { default as CommandPalette } from "./CommandPalette"
+export * from "./accordion"
 export * from "./alert"
 export * from "./avatar"
 export * from "./badge"


### PR DESCRIPTION
## Summary
- add Radix-based Accordion component
- switch vertical NavItems to use Accordion
- test accordion rendering and toggle logic

## Testing
- `npm test` *(fails: BookNetwork component highlights shortest path when searching by tag, BookNetwork component renders higher-degree nodes with larger radii, NavItems Accordion toggles group items)*
- `npx vitest run src/components/layout/__tests__/navitems.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6892bfa868808324ba897f97c77cb069