### PR TITLE
feat: add fallback for missing chart colors

### DIFF
--- a/src/components/genre/GenreSunburst.jsx
+++ b/src/components/genre/GenreSunburst.jsx
@@ -49,10 +49,13 @@ export default function GenreSunburst({ data }) {
 
     const style = getComputedStyle(document.documentElement);
     const chartColors = Array.from({ length: 10 }, (_, i) => {
-      const val = style
-        .getPropertyValue(`--chart-${i + 1}`)
-        .trim()
-        .replace(/\s+/g, ',');
+      const prop = `--chart-${i + 1}`;
+      const raw = style.getPropertyValue(prop).trim();
+      if (!raw) {
+        console.warn(`Missing CSS variable ${prop}, using fallback color`);
+        return 'hsl(0,0%,50%)';
+      }
+      const val = raw.replace(/\s+/g, ',');
       return `hsl(${val})`;
     });
     const color = scaleOrdinal().range(chartColors);

--- a/src/components/genre/__tests__/GenreSunburst.test.jsx
+++ b/src/components/genre/__tests__/GenreSunburst.test.jsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import GenreSunburst from '../GenreSunburst';
 import { hsl as d3hsl } from 'd3-color';
+import { vi } from 'vitest';
 
   describe('GenreSunburst', () => {
   const data = {
@@ -92,6 +93,18 @@ import { hsl as d3hsl } from 'd3-color';
       await user.click(pathA);
       await new Promise((r) => setTimeout(r, 800));
       expect(pathA.getAttribute('fill')).toBe(initialA);
+    });
+
+    it('falls back to default color when CSS variable is missing', () => {
+      document.documentElement.style.removeProperty('--chart-2');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { container } = render(<GenreSunburst data={data} />);
+      const pathB = container.querySelector('path[data-name="B"]');
+      const colorB = d3hsl(pathB.getAttribute('fill'));
+      expect(colorB.s).toBe(0);
+      expect(colorB.l).toBeCloseTo(0.5, 1);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- warn and fallback to gray when genre chart CSS variables are missing
- test GenreSunburst color fallbacks

## Testing
- `npm test` *(fails: server/api/kindle.test.js, genreHierarchy.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689330ea5a088324a1c02cd35ffd2ee2