### PR TITLE
feat: add accessibility attrs for full screen

### DIFF
--- a/src/pages/charts/GenreSankey.jsx
+++ b/src/pages/charts/GenreSankey.jsx
@@ -35,6 +35,10 @@ export default function GenreSankeyPage() {
         <button
           onClick={toggleFullscreen}
           className="px-2 py-1 border rounded"
+          aria-pressed={isFullscreen}
+          aria-label={
+            isFullscreen ? 'Exit full screen' : 'Enter full screen'
+          }
         >
           {isFullscreen ? 'Exit Full Screen' : 'Full Screen'}
         </button>

--- a/src/pages/charts/__tests__/GenreSankeyPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSankeyPage.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import GenreSankeyPage from '../GenreSankey.jsx';
+
+vi.mock('@/components/genre/GenreSankey.jsx', () => ({
+  default: () => <div data-testid="genre-sankey" />,
+}));
+
+describe('GenreSankeyPage', () => {
+  beforeEach(() => {
+    Element.prototype.requestFullscreen = vi.fn(function () {
+      document.fullscreenElement = this;
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+    document.exitFullscreen = vi.fn(() => {
+      document.fullscreenElement = null;
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+  });
+
+  it('toggles aria attributes on fullscreen button', async () => {
+    const user = userEvent.setup();
+    render(<GenreSankeyPage />);
+
+    const button = screen.getByRole('button', { name: 'Enter full screen' });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(button);
+    const exitButton = await screen.findByRole('button', {
+      name: 'Exit full screen',
+    });
+    expect(exitButton).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(exitButton);
+    const enterButton = await screen.findByRole('button', {
+      name: 'Enter full screen',
+    });
+    expect(enterButton).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+


### PR DESCRIPTION
## Summary
- improve GenreSankey fullscreen button with `aria-pressed` and dynamic `aria-label`
- add tests for fullscreen button accessibility toggling

## Testing
- `npm test -- --run`
- `npx vitest run src/pages/charts/__tests__/GenreSankeyPage.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_689330e183988324950c1c22348da4d1