### PR TITLE
Enable zoom and pan on book network

### DIFF
--- a/src/components/network/BookNetwork.jsx
+++ b/src/components/network/BookNetwork.jsx
@@ -4,6 +4,7 @@ import { transition } from 'd3-transition';
 import { forceSimulation, forceLink, forceManyBody, forceCenter } from 'd3-force';
 import { drag } from 'd3-drag';
 import { scaleOrdinal, scaleLinear } from 'd3-scale';
+import { zoom } from 'd3-zoom';
 import graphData from '@/data/kindle/book-graph.json';
 
 export default function BookNetwork({ data = graphData }) {
@@ -183,7 +184,21 @@ export default function BookNetwork({ data = graphData }) {
 
     const t = transition().duration(400);
 
-    const linkGroup = svg
+    const g = svg
+      .selectAll('g.zoom-container')
+      .data([null])
+      .join('g')
+      .attr('class', 'zoom-container');
+
+    const zoomBehavior = zoom()
+      .scaleExtent([0.5, 5])
+      .on('zoom', (event) => {
+        g.attr('transform', event.transform);
+      });
+
+    svg.call(zoomBehavior);
+
+    const linkGroup = g
       .selectAll('g.links')
       .data([null])
       .join('g')
@@ -215,7 +230,7 @@ export default function BookNetwork({ data = graphData }) {
         (exit) => exit.transition(t).attr('stroke-opacity', 0).remove()
       );
 
-    const nodeGroup = svg
+    const nodeGroup = g
       .selectAll('g.nodes')
       .data([null])
       .join('g')

--- a/src/pages/charts/BookNetwork.jsx
+++ b/src/pages/charts/BookNetwork.jsx
@@ -21,8 +21,9 @@ export default function BookNetworkPage() {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Related Books Network</h1>
       <p className="mb-4 text-sm text-muted-foreground">
-        Click a book to expand its neighbors, drag nodes to reposition and use
-        the switch below to view a chord diagram.
+        Click a book to expand its neighbors, drag nodes to reposition,
+        scroll or pinch to zoom, drag the background to pan and use the switch
+        below to view a chord diagram.
       </p>
       {data ? (
         <div>


### PR DESCRIPTION
## Summary
- add d3-zoom to BookNetwork so users can zoom and pan the network
- explain the new zoom and pan controls on the book network page

## Testing
- `npm test` *(fails: server/api/kindle, genreHierarchy)*

------
https://chatgpt.com/codex/tasks/task_e_6893311053508324aebe0ecf04cdb611