### PR TITLE
feat: add keyboard tooltip support

### DIFF
--- a/src/components/genre/GenreSankey.jsx
+++ b/src/components/genre/GenreSankey.jsx
@@ -207,11 +207,21 @@ export default function GenreSankey() {
             `From ${d.source.name} to ${d.target.name}: ${d.value} sessions`,
           );
       })
-      .on('mouseover', (event, d) => {
+      .on('mouseover focus', (event, d) => {
         const tooltip = tooltipRef.current;
         if (!tooltip) return;
-        const x = event.pageX || event.clientX;
-        const y = event.pageY || event.clientY;
+        let x = event.pageX ?? event.clientX;
+        let y = event.pageY ?? event.clientY;
+        if (x == null || y == null) {
+          const rect = event.target?.getBoundingClientRect();
+          if (rect) {
+            x = rect.left + rect.width / 2 + window.scrollX;
+            y = rect.top + rect.height / 2 + window.scrollY;
+          } else {
+            x = 0;
+            y = 0;
+          }
+        }
         tooltip.style.display = 'block';
         tooltip.style.left = `${x + 10}px`;
         tooltip.style.top = `${y + 10}px`;
@@ -231,7 +241,7 @@ export default function GenreSankey() {
           .join('');
         tooltip.innerHTML = `<div>${text}</div><svg width="${counts.length * barWidth}" height="${barHeight}">${bars}</svg>`;
       })
-      .on('mouseout', () => {
+      .on('mouseout blur', () => {
         const tooltip = tooltipRef.current;
         if (tooltip) tooltip.style.display = 'none';
       });

--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -151,4 +151,30 @@ describe('GenreSankey', () => {
       expect(tooltip).toHaveStyle({ display: 'none' });
     });
   });
+
+  it('shows a tooltip on link focus', async () => {
+    const { container } = render(<GenreSankey />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    });
+    const link = container.querySelector('path');
+    // jsdom provides a rect of zeros; ensure presence of method
+    link.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 10,
+      height: 10,
+      right: 10,
+      bottom: 10,
+    });
+    fireEvent.focus(link);
+    const tooltip = screen.getByTestId('tooltip');
+    await waitFor(() => {
+      expect(tooltip).toHaveStyle({ display: 'block' });
+    });
+    fireEvent.blur(link);
+    await waitFor(() => {
+      expect(tooltip).toHaveStyle({ display: 'none' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- support keyboard focus for Sankey link tooltips
- fall back to bounding boxes when mouse coordinates missing
- test tooltip display on link focus

## Testing
- `npm test` *(fails: GET /api/kindle returns 500; ReferenceError: asinSubgenreMap is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6893311ac3b4832493d25d40caf1af85