### PR TITLE
refactor: use list semantics for heatmap legend

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -238,21 +238,22 @@ function YearlyHeatmap({ data }) {
           className="w-full h-auto"
           style={{ width: '100%', overflow: 'visible' }}
         />
-        <div
+        <ul
+          role="list"
           className="flex flex-wrap items-center gap-2 md:gap-3 mt-2 text-xs md:text-sm"
           data-testid="reading-legend"
         >
-          <div className="flex items-center gap-1" data-no-data>
+          <li className="flex items-center gap-1" data-no-data>
             <div className="w-3 h-3 border" />
             <span>No data</span>
-          </div>
+          </li>
           {categories.map((cat, idx) => {
             const rangeLabel =
               cat.max === Infinity
                 ? `${cat.min}+`
                 : `${cat.min}-${cat.max}`;
             return (
-              <div
+              <li
                 key={idx}
                 className="flex items-center gap-1"
                 data-legend-level
@@ -261,10 +262,10 @@ function YearlyHeatmap({ data }) {
                 <span>
                   {rangeLabel} min ({cat.label})
                 </span>
-              </div>
+              </li>
             );
           })}
-        </div>
+        </ul>
       </div>
     </TooltipProvider>
   );

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -47,9 +47,10 @@ describe('CalendarHeatmap', () => {
     const { container, getByTestId } = render(<CalendarHeatmap />);
     const legend = getByTestId('reading-legend');
     expect(legend).not.toBeNull();
+    expect(legend.tagName).toBe('UL');
 
     expect(container.querySelector('rect.reading-scale-1')).not.toBeNull();
-    const swatches = legend.querySelectorAll('[data-legend-level]');
+    const swatches = legend.querySelectorAll('li[data-legend-level]');
     expect(swatches.length).toBe(4);
     expect(
       swatches[0].querySelector('div').classList.contains('reading-scale-1')
@@ -57,7 +58,7 @@ describe('CalendarHeatmap', () => {
     expect(
       swatches[3].querySelector('div').classList.contains('reading-scale-4')
     ).toBe(true);
-    expect(legend.querySelector('[data-no-data]')).not.toBeNull();
+    expect(legend.querySelector('li[data-no-data]')).not.toBeNull();
   });
 
   it('renders month and quarter boundaries', () => {


### PR DESCRIPTION
## Summary
- improve accessibility in CalendarHeatmap legend by using `<ul>` and `<li>`
- update CalendarHeatmap legend tests for new list semantics

## Testing
- `npx vitest run` *(fails: server/api/kindle.test.js > GET /api/kindle > returns genre hierarchy data; src/services/__tests__/genreHierarchy.test.js > buildGenreHierarchy > builds nested tree from flat records; src/services/__tests__/genreHierarchy.test.js > buildGenreHierarchy > uses asin-subgenre mapping when tags are missing; src/services/__tests__/genreHierarchy.test.js > buildGenreHierarchy > labels missing data as unclassified)*

------
https://chatgpt.com/codex/tasks/task_e_689330ffa7f8832497e0f30c3d22fa95