### PR TITLE
Add timeline zoom instructions and conditional reset visibility

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -215,6 +215,11 @@ export default function ReadingTimeline({ sessions = [] }) {
         ref={ref}
         style={{ width: '100%', height: height + BRUSH_HEIGHT + AXIS_HEIGHT }}
       />
+      <p
+        style={{ fontSize: '0.875rem', color: '#555', margin: '0.5rem 0' }}
+      >
+        Drag across the timeline to zoom; use Reset to return.
+      </p>
       {titles.length > 0 && (
         <ul
           aria-label="Books"
@@ -246,9 +251,11 @@ export default function ReadingTimeline({ sessions = [] }) {
           ))}
         </ul>
       )}
-      <button onClick={reset} disabled={!zoomed} aria-label="Reset zoom">
-        Reset
-      </button>
+      {zoomed && (
+        <button onClick={reset} aria-label="Reset zoom">
+          Reset
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -63,7 +63,7 @@ describe('ReadingTimeline', () => {
   });
 
   it('updates bar widths when brushed and resets via control', () => {
-    const { container, getByRole } = render(<ReadingTimeline sessions={sessions} />);
+    const { container, queryByRole, getByRole } = render(<ReadingTimeline sessions={sessions} />);
     const svg = container.querySelector('svg');
     const brush = svg.__brush;
     const viewWidth = Number(svg.getAttribute('viewBox').split(' ')[2]);
@@ -76,6 +76,9 @@ describe('ReadingTimeline', () => {
     expect(axisLabel.textContent).toBe('Date');
     let tickLines = svg.querySelectorAll('.x-axis .tick line');
     expect(Number(tickLines[0].getAttribute('y2'))).toBeLessThan(0);
+
+    // Reset button should be hidden initially
+    expect(queryByRole('button', { name: /reset/i })).toBeNull();
 
     act(() => {
       select(svg.querySelector('.brush')).call(brush.move, [0, viewWidth / 2]);
@@ -99,7 +102,7 @@ describe('ReadingTimeline', () => {
     rect = svg.querySelector('rect');
     const resetWidth = Number(rect.getAttribute('width'));
     expect(resetWidth).toBeCloseTo(initialWidth);
-    expect(resetBtn).toBeDisabled();
+    expect(queryByRole('button', { name: /reset/i })).toBeNull();
   });
 
   it('renders axis ticks and annotations', () => {


### PR DESCRIPTION
## Summary
- Add instructional text to reading timeline about drag-to-zoom and reset
- Hide Reset button until a zoom is active
- Update timeline tests for new reset behavior

## Testing
- `npm test` (fails: 4 failing tests unrelated to timeline)
- `npx vitest run src/components/timeline/__tests__/ReadingTimeline.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689331287b108324b5bf1f389198047b