### PR TITLE
Add labels and clear-filter feature to BookNetwork

### DIFF
--- a/src/components/__tests__/BookNetwork.test.jsx
+++ b/src/components/__tests__/BookNetwork.test.jsx
@@ -22,25 +22,47 @@ describe('BookNetwork component', () => {
     global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
   });
 
-  it('shows sub-genre input and saves override', async () => {
-    const { container } = render(<BookNetwork data={createMockGraph()} />);
+  it('renders labeled inputs and saves sub-genre override', async () => {
+    const { container, getByLabelText, getByText } = render(
+      <BookNetwork data={createMockGraph()} />
+    );
     await waitFor(() => {
       expect(container.querySelectorAll('[data-testid="node"]').length).toBe(3);
     });
+    // label rendering
+    expect(getByLabelText('Filter by tag')).not.toBeNull();
+    expect(getByLabelText('Filter by author')).not.toBeNull();
     fireEvent.click(container.querySelector('[data-id="a"]'));
-    await waitFor(() => {
-      expect(container.querySelector('input[placeholder="Sub-genre"]')).not.toBeNull();
-    });
+    const sgInput = await waitFor(() => getByLabelText('Sub-genre'));
     global.fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ a: 'Mystery' }) });
-    fireEvent.change(container.querySelector('input[placeholder="Sub-genre"]'), {
-      target: { value: 'Mystery' }
-    });
-    fireEvent.click(container.querySelector('button'));
+    fireEvent.change(sgInput, { target: { value: 'Mystery' } });
+    fireEvent.click(getByText('Save'));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         '/api/kindle/subgenre-overrides',
         expect.objectContaining({ method: 'POST' })
       );
+    });
+  });
+
+  it('clears tag, author, and selection', async () => {
+    const { container, getByLabelText, getByText, queryByLabelText } = render(
+      <BookNetwork data={createMockGraph()} />
+    );
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="node"]').length).toBe(3);
+    });
+    fireEvent.click(container.querySelector('[data-id="a"]'));
+    await waitFor(() => getByLabelText('Sub-genre'));
+    fireEvent.change(getByLabelText('Filter by tag'), { target: { value: 'tag1' } });
+    fireEvent.change(getByLabelText('Filter by author'), { target: { value: 'auth1' } });
+
+    fireEvent.click(getByText('Clear filters'));
+
+    expect(getByLabelText('Filter by tag').value).toBe('');
+    expect(getByLabelText('Filter by author').value).toBe('');
+    await waitFor(() => {
+      expect(queryByLabelText('Sub-genre')).toBeNull();
     });
   });
 });

--- a/src/components/network/BookNetwork.jsx
+++ b/src/components/network/BookNetwork.jsx
@@ -312,19 +312,28 @@ export default function BookNetwork({ data = graphData }) {
   return (
     <div>
       <div>
+        <label htmlFor="tag-input">Filter by tag</label>
         <input
+          id="tag-input"
           placeholder="Filter by tag"
           value={tag}
           onChange={(e) => setTag(e.target.value)}
         />
+        <label htmlFor="author-input">Filter by author</label>
         <input
+          id="author-input"
           placeholder="Filter by author"
           value={author}
           onChange={(e) => setAuthor(e.target.value)}
         />
+        <button onClick={() => { setTag(''); setAuthor(''); setSelected(null); }}>
+          Clear filters
+        </button>
         {selected && (
           <div>
+            <label htmlFor="subgenre-input">Sub-genre</label>
             <input
+              id="subgenre-input"
               placeholder="Sub-genre"
               value={subgenre}
               onChange={(e) => setSubgenre(e.target.value)}


### PR DESCRIPTION
## Summary
- add accessible labels and clear filters button to BookNetwork
- test label rendering and filter clearing behavior

## Testing
- `npm test` *(fails: GET /api/kindle > returns genre hierarchy data expected 500 to be 200, asinSubgenreMap is not defined)*
- `npx vitest run src/components/__tests__/BookNetwork.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68932e2b13f483248147a1277bb3b8bb