### PR TITLE
feat: improve timeline palette

### DIFF
--- a/docs/reading-timeline-colors.md
+++ b/docs/reading-timeline-colors.md
@@ -1,0 +1,17 @@
+# Reading Timeline Palette
+
+The `ReadingTimeline` component uses the accessible `schemeTableau10` palette from
+[d3-scale-chromatic](https://github.com/d3/d3-scale-chromatic). The palette provides ten
+color-blind friendly hues which are assigned to book titles in the order they appear.
+If more than ten titles are supplied, the colors repeat.
+
+For additional accessibility the component exposes a `colorBlindFriendly` prop. When enabled,
+legend swatches receive alternating stripe patterns to help distinguish titles even when colors
+repeat or are hard to perceive. Use it like:
+
+```jsx
+<ReadingTimeline sessions={sessions} colorBlindFriendly />
+```
+
+Patterns are implemented with CSS `repeating-linear-gradient` backgrounds and cycle through a
+set of diagonal and horizontal stripes.

--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useMemo, useState } from 'react';
 import { select } from 'd3-selection';
 import { scaleTime, scaleOrdinal, scaleLinear } from 'd3-scale';
+import { schemeTableau10 } from 'd3-scale-chromatic';
 import { brushX } from 'd3-brush';
 import { axisBottom } from 'd3-axis';
 import { timeMonth } from 'd3-time';
@@ -14,8 +15,19 @@ const BRUSH_HEIGHT = 10;
 const AXIS_HEIGHT = 40;
 const MIN_HEIGHT = 120;
 
+const PATTERN_STYLES = [
+  'repeating-linear-gradient(45deg, rgba(0,0,0,0.4) 0, rgba(0,0,0,0.4) 2px, transparent 2px, transparent 4px)',
+  'repeating-linear-gradient(-45deg, rgba(0,0,0,0.4) 0, rgba(0,0,0,0.4) 2px, transparent 2px, transparent 4px)',
+  'repeating-linear-gradient(0deg, rgba(0,0,0,0.4) 0, rgba(0,0,0,0.4) 2px, transparent 2px, transparent 4px)',
+  'repeating-linear-gradient(90deg, rgba(0,0,0,0.4) 0, rgba(0,0,0,0.4) 2px, transparent 2px, transparent 4px)',
+  'repeating-linear-gradient(45deg, rgba(0,0,0,0.4) 0, rgba(0,0,0,0.4) 1px, transparent 1px, transparent 2px)',
+  'repeating-linear-gradient(-45deg, rgba(0,0,0,0.4) 0, rgba(0,0,0,0.4) 1px, transparent 1px, transparent 2px)',
+];
 
-export default function ReadingTimeline({ sessions = [] }) {
+export default function ReadingTimeline({
+  sessions = [],
+  colorBlindFriendly = false,
+}) {
   const ref = useRef(null);
   const containerRef = useRef(null);
   const brushRef = useRef(null);
@@ -53,7 +65,9 @@ export default function ReadingTimeline({ sessions = [] }) {
     [sessions],
   );
   const colorScale = useMemo(() => {
-    const colors = Array.from({ length: 10 }, (_, i) => `hsl(var(--chart-${i + 1}))`);
+    const colors = titles.map(
+      (_, i) => schemeTableau10[i % schemeTableau10.length],
+    );
     return scaleOrdinal().domain(titles).range(colors);
   }, [titles]);
 
@@ -227,7 +241,7 @@ export default function ReadingTimeline({ sessions = [] }) {
             margin: '0.5rem 0',
           }}
         >
-          {titles.map((t) => (
+          {titles.map((t, idx) => (
             <li
               key={t}
               style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}
@@ -238,6 +252,9 @@ export default function ReadingTimeline({ sessions = [] }) {
                   width: 12,
                   height: 12,
                   backgroundColor: colorScale(t),
+                  backgroundImage: colorBlindFriendly
+                    ? PATTERN_STYLES[idx % PATTERN_STYLES.length]
+                    : 'none',
                   display: 'inline-block',
                 }}
               />

--- a/src/components/timeline/__tests__/ReadingTimeline.test.jsx
+++ b/src/components/timeline/__tests__/ReadingTimeline.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { select } from 'd3-selection';
 import { act } from 'react';
 import ReadingTimeline from '../ReadingTimeline.jsx';
+import { schemeTableau10 } from 'd3-scale-chromatic';
 
 class ResizeObserver {
   observe() {}
@@ -146,8 +147,8 @@ describe('ReadingTimeline', () => {
     const { container } = render(<ReadingTimeline sessions={sessions} />);
     const svg = container.querySelector('svg');
     const rects = svg.querySelectorAll('rect[height="30"]');
-    expect(rects[0].getAttribute('fill')).toBe('hsl(var(--chart-1))');
-    expect(rects[1].getAttribute('fill')).toBe('hsl(var(--chart-2))');
+    expect(rects[0].getAttribute('fill')).toBe(schemeTableau10[0]);
+    expect(rects[1].getAttribute('fill')).toBe(schemeTableau10[1]);
   });
 
   it('encodes duration using opacity', () => {
@@ -174,7 +175,7 @@ describe('ReadingTimeline', () => {
     expect(items).toHaveLength(2);
     expect(items[0].textContent).toContain('Test Book 1');
     const swatch = items[0].querySelector('span[aria-hidden="true"]');
-    expect(swatch).toHaveStyle({ backgroundColor: 'hsl(var(--chart-1))' });
+    expect(swatch).toHaveStyle({ backgroundColor: schemeTableau10[0] });
   });
 
   it('displays titles in bar tooltips and legend labels', () => {
@@ -186,5 +187,17 @@ describe('ReadingTimeline', () => {
     expect(rects[0].querySelector('title')?.textContent).toContain('Test Book 1');
     const list = getByRole('list', { name: /books/i });
     expect(within(list).getByText('Test Book 1')).toBeInTheDocument();
+  });
+
+  it('can show patterned legend swatches for color-blind users', () => {
+    const { getByRole } = render(
+      <ReadingTimeline sessions={sessions} colorBlindFriendly />,
+    );
+    const list = getByRole('list', { name: /books/i });
+    const items = within(list).getAllByRole('listitem');
+    const swatch = items[0].querySelector('span[aria-hidden="true"]');
+    expect(swatch).toHaveStyle({
+      backgroundImage: expect.stringContaining('repeating-linear-gradient'),
+    });
   });
 });


### PR DESCRIPTION
## Summary
- use d3's schemeTableau10 for ReadingTimeline colors and add optional patterns for color-blind users
- document the palette and color-blind options for maintainers

## Testing
- `npm test` *(fails: expected 500 to be 200; ReferenceError: asinSubgenreMap is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68933127cfd08324a0e2e2e514c6b2cf