### PR TITLE
Add year selector to CalendarHeatmap with optional multi-year toggle

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import Heatmap from 'react-calendar-heatmap';
 import 'react-calendar-heatmap/dist/styles.css';
 import useDailyReading from '@/hooks/useDailyReading';
@@ -9,6 +9,8 @@ import {
   TooltipProvider,
 } from '@/ui/tooltip';
 import { Skeleton } from '@/ui/skeleton';
+import { SimpleSelect } from '@/ui/select';
+import { Button } from '@/ui/button';
 import {
   getISOWeek,
   getISOWeekYear,
@@ -285,22 +287,56 @@ export default function CalendarHeatmap({ data: propData, multiYear }) {
     return acc;
   }, {});
 
-  const years = Object.keys(dataByYear).sort();
-  const isMultiYear = multiYear ?? years.length > 1;
+  const years = Object.keys(dataByYear)
+    .map(Number)
+    .sort((a, b) => a - b);
 
-  if (!isMultiYear) {
-    const year = years[0];
-    return <YearlyHeatmap data={dataByYear[year]} />;
+  const [selectedYear, setSelectedYear] = useState(
+    String(years[years.length - 1])
+  );
+  const [showAll, setShowAll] = useState(multiYear ?? false);
+
+  if (years.length === 1 && !showAll) {
+    return <YearlyHeatmap data={dataByYear[years[0]]} />;
   }
 
   return (
     <div>
-      {years.map((year) => (
-        <div key={year} className="mb-8">
-          <div className="mb-2 font-semibold">{year}</div>
-          <YearlyHeatmap data={dataByYear[year]} />
+      {years.length > 1 && (
+        <div className="flex items-center gap-2 mb-4">
+          {!showAll && (
+            <SimpleSelect
+              value={selectedYear}
+              onValueChange={setSelectedYear}
+              options={years.map((y) => ({
+                value: String(y),
+                label: String(y),
+              }))}
+              label="Year"
+            />
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowAll((prev) => !prev)}
+          >
+            {showAll ? 'Show selected year' : 'Show all years'}
+          </Button>
         </div>
-      ))}
+      )}
+      {showAll
+        ? years.map((year) => (
+            <div key={year} className="mb-8">
+              <div className="mb-2 font-semibold">{year}</div>
+              <YearlyHeatmap data={dataByYear[year]} />
+            </div>
+          ))
+        : (
+            <div>
+              <div className="mb-2 font-semibold">{selectedYear}</div>
+              <YearlyHeatmap data={dataByYear[selectedYear]} />
+            </div>
+          )}
     </div>
   );
 }

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -189,30 +189,43 @@ describe('CalendarHeatmap', () => {
       { date: '2023-12-31', minutes: 30, pages: 10 },
       { date: '2024-01-01', minutes: 5, pages: 2 },
     ];
-    const { container, getByText } = render(
+    const { container, getByRole } = render(
       <CalendarHeatmap data={twoYearData} />
     );
     const svgs = container.querySelectorAll('svg.react-calendar-heatmap');
-    expect(svgs.length).toBe(2);
-    getByText('2023');
-    getByText('2024');
-
-    const [svg2023, svg2024] = svgs;
-      expect(svg2023.querySelector('rect.reading-scale-3')).not.toBeNull();
-      expect(svg2024.querySelector('rect.reading-scale-1')).not.toBeNull();
+    expect(svgs.length).toBe(1);
+    getByRole('combobox', { name: /year/i });
   });
 
-  it('can render a single heatmap when multiYear is false', () => {
+  it('can toggle to show all years', async () => {
+    const user = userEvent.setup();
     const twoYearData = [
       { date: '2023-12-31', minutes: 30, pages: 10 },
       { date: '2024-01-01', minutes: 5, pages: 2 },
     ];
-    const { container, queryByText } = render(
-      <CalendarHeatmap data={twoYearData} multiYear={false} />
+    const { container, getByText } = render(
+      <CalendarHeatmap data={twoYearData} />
+    );
+    await user.click(screen.getByRole('button', { name: /show all years/i }));
+    const svgs = container.querySelectorAll('svg.react-calendar-heatmap');
+    expect(svgs.length).toBe(2);
+    getByText('2023');
+    getByText('2024');
+    const [svg2023, svg2024] = svgs;
+    expect(svg2023.querySelector('rect.reading-scale-3')).not.toBeNull();
+    expect(svg2024.querySelector('rect.reading-scale-1')).not.toBeNull();
+  });
+
+  it('defaults to multi-year view when multiYear is true', () => {
+    const twoYearData = [
+      { date: '2023-12-31', minutes: 30, pages: 10 },
+      { date: '2024-01-01', minutes: 5, pages: 2 },
+    ];
+    const { container, getByRole } = render(
+      <CalendarHeatmap data={twoYearData} multiYear />
     );
     const svgs = container.querySelectorAll('svg.react-calendar-heatmap');
-    expect(svgs.length).toBe(1);
-    expect(queryByText('2023')).toBeNull();
-    expect(queryByText('2024')).toBeNull();
+    expect(svgs.length).toBe(2);
+    getByRole('button', { name: /show selected year/i });
   });
 });


### PR DESCRIPTION
## Summary
- allow picking a year in CalendarHeatmap when multiple years are present
- add optional toggle to switch between single-year and all-years views
- update CalendarHeatmap tests for selector and toggle

## Testing
- `npm test` *(fails: asinSubgenreMap is not defined in genreHierarchy tests)*
- `npx vitest run src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68933102f6e4832481c56f3a458ada48