### PR TITLE
feat: enhance sidebar navigation

### DIFF
--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -10,6 +10,7 @@ import {
   AccordionTrigger,
   AccordionContent,
 } from "@/ui/accordion";
+import { LayoutDashboard, Search } from "lucide-react";
 
 interface NavItemsProps {
   groups: DashboardRouteGroup[];
@@ -23,29 +24,65 @@ export default function NavItems({
   className,
 }: NavItemsProps) {
   const vertical = orientation === "vertical";
+  const [query, setQuery] = React.useState("");
+  const linkRefs = React.useRef<Array<HTMLAnchorElement | null>>([]);
 
+  const filteredGroups = React.useMemo(() => {
+    if (!query) return groups;
+    const lower = query.toLowerCase();
+    return groups
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) =>
+          item.label.toLowerCase().includes(lower),
+        ),
+      }))
+      .filter(
+        (group) =>
+          group.items.length > 0 || group.label.toLowerCase().includes(lower),
+      );
+  }, [groups, query]);
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLAnchorElement>,
+    index: number,
+  ) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      linkRefs.current[index + 1]?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      linkRefs.current[index - 1]?.focus();
+    }
+  };
+
+  let linkIndex = 0;
   const renderLink = (
     to: string,
     label: string,
     Icon?: React.ComponentType<{ className?: string }> ,
   ) => {
+    const currentIndex = linkIndex++;
+    const ref = (el: HTMLAnchorElement | null) => {
+      if (vertical) linkRefs.current[currentIndex] = el;
+    };
     const link = (
       <NavLink
         to={to}
+        ref={ref}
+        onKeyDown={(e) => vertical && handleKeyDown(e, currentIndex)}
         className={({ isActive }) =>
           cn(
-            "group relative flex items-center gap-2 px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground after:absolute after:left-0 after:bottom-0 after:h-0.5 after:w-full after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-300 hover:after:scale-x-100",
-            isActive && "active text-foreground after:scale-x-100",
+            "group relative flex items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+            vertical &&
+              "before:absolute before:left-0 before:top-0 before:h-full before:w-1 before:origin-top before:scale-y-0 before:bg-sidebar-ring before:transition-transform before:duration-300 group-hover:before:scale-y-100",
+            isActive &&
+              "bg-sidebar-accent text-foreground before:scale-y-100",
           )
         }
       >
-        {Icon && (
-          <Icon
-            className="h-4 w-4 transition-transform group-hover:scale-110"
-            aria-hidden="true"
-          />
-        )}
-        <span className="transition-colors group-hover:text-foreground">{label}</span>
+        {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
+        <span>{label}</span>
       </NavLink>
     );
     return vertical ? <SheetClose asChild>{link}</SheetClose> : link;
@@ -54,14 +91,34 @@ export default function NavItems({
   if (vertical) {
     return (
       <div className={cn("flex flex-col gap-4", className)}>
-        {renderLink("/", "Dashboard")}
-        <Accordion type="multiple" className="w-full">
-          {groups.map((group) => {
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <input
+            type="text"
+            className="w-full rounded-md border bg-sidebar px-7 py-1 text-sm text-sidebar-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+            placeholder="Jump to..."
+            aria-label="Search navigation"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                linkRefs.current[0]?.focus();
+              }
+            }}
+          />
+        </div>
+        {renderLink("/", "Dashboard", LayoutDashboard)}
+        <Accordion type="single" collapsible className="w-full">
+          {filteredGroups.map((group) => {
             const Icon = group.icon;
             return (
               <AccordionItem key={group.label} value={group.label}>
-                <AccordionTrigger className="group flex w-full items-center gap-2 px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground">
-                  {Icon && <Icon className="h-4 w-4" aria-hidden="true" />}
+                <AccordionTrigger className="group flex w-full items-center gap-2 px-2 py-1 text-base font-medium text-sidebar-foreground transition-colors hover:text-foreground">
+                  {Icon && <Icon className="h-5 w-5" aria-hidden="true" />}
                   <span>{group.label}</span>
                 </AccordionTrigger>
                 <AccordionContent>
@@ -81,7 +138,7 @@ export default function NavItems({
 
   return (
     <ul className={cn("flex gap-4", className)}>
-      <li>{renderLink("/", "Dashboard")}</li>
+      <li>{renderLink("/", "Dashboard", LayoutDashboard)}</li>
       {groups.map((group) => {
         const Icon = group.icon;
         const firstItem = group.items[0];

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -30,7 +30,7 @@ export default function TopNavigation() {
   const [open, setOpen] = useState(false);
 
   return (
-    <nav className="flex items-center">
+    <nav className="flex items-center md:hidden">
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetTrigger asChild>
           <button className="p-2" aria-expanded={open}>

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 import TopNavigation from "@/components/layout/TopNavigation";
+import NavItems from "@/components/layout/NavItems";
 import CommandPalette from "@/ui/CommandPalette";
 import { ChartActionsProvider } from "@/hooks/useChartActions";
 import useRecentViews from "@/hooks/useRecentViews";
+import { dashboardRoutes } from "@/routes";
 
 interface RootLayoutProps {
   children: React.ReactNode;
@@ -21,21 +23,26 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ChartActionsProvider>
       <CommandPalette open={commandOpen} setOpen={setCommandOpen} />
-      <div className="flex min-h-screen flex-col">
-        <header className="sticky top-0 z-50 flex items-center border-b bg-white/80 p-4 backdrop-blur">
-          <TopNavigation />
-          <div className="ml-auto flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setCommandOpen(true)}
-              className="rounded-md border px-2 py-1 text-sm"
-              aria-label="Open command palette"
-            >
-              Search
-            </button>
-          </div>
-        </header>
-        <main className="flex-1 p-4">{children}</main>
+      <div className="flex min-h-screen">
+        <aside className="hidden w-64 flex-shrink-0 border-r bg-sidebar p-4 md:block">
+          <NavItems groups={dashboardRoutes} orientation="vertical" className="h-full" />
+        </aside>
+        <div className="flex flex-1 flex-col">
+          <header className="sticky top-0 z-50 flex items-center border-b bg-white/80 p-4 backdrop-blur">
+            <TopNavigation />
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setCommandOpen(true)}
+                className="rounded-md border px-2 py-1 text-sm"
+                aria-label="Open command palette"
+              >
+                Search
+              </button>
+            </div>
+          </header>
+          <main className="flex-1 overflow-y-auto p-4">{children}</main>
+        </div>
       </div>
     </ChartActionsProvider>
   );

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import {
   List,
   BookOpen,
   FlaskConical,
+  MoreHorizontal,
 } from "lucide-react";
 import {
   withIcon,
@@ -287,12 +288,6 @@ export const demoRoutes = withIcon(FlaskConical, [
   },
 ]);
 
-const demoRouteGroup: DashboardRouteGroup = {
-  label: "Component Demos",
-  icon: FlaskConical,
-  items: demoRoutes,
-};
-
 export const kindleRoutes = withIcon(BookOpen, [
   {
     to: "/dashboard/kindle/calendar-heatmap",
@@ -412,21 +407,20 @@ export const privacyRoutes = withIcon(Shield, [
   },
 ]);
 
-const privacyRouteGroup: DashboardRouteGroup = {
-  label: "Privacy & Settings",
-  icon: Shield,
-  items: privacyRoutes,
+const otherRouteGroup: DashboardRouteGroup = {
+  label: "Other",
+  icon: MoreHorizontal,
+  items: [...demoRoutes, ...privacyRoutes],
 };
 
 export const dashboardRoutes: DashboardRouteGroup[] = [
+  kindleRouteGroup,
   allRouteGroup,
   mapsRouteGroup,
   trendsRouteGroup,
   analyticalRouteGroup,
-  demoRouteGroup,
-  kindleRouteGroup,
   goalsRouteGroup,
-  privacyRouteGroup,
+  otherRouteGroup,
 ];
 
 export type { DashboardRoute, DashboardRouteGroup } from "./types";


### PR DESCRIPTION
## Summary
- prioritize Kindle Insights and consolidate rarely-used tools in an "Other" navigation group
- add searchable, keyboard-friendly sidebar with animated accent bar for active links
- show a persistent sidebar on desktop while keeping mobile navigation via a slide-out drawer

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689335139a2483248d710419631885b7