### PR TITLE
Add error handling to calendar heatmap

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -271,12 +271,17 @@ function YearlyHeatmap({ data }) {
 }
 
 export default function CalendarHeatmap({ data: propData, multiYear }) {
-  const { data: hookData, isLoading } = useDailyReading();
+  const { data: hookData, isLoading, error } = useDailyReading();
   const data = propData || hookData;
   if (isLoading) {
     return <Skeleton className="h-64" data-testid="calendar-heatmap-skeleton" />;
   }
-  if (!data || data.length === 0) return null;
+  if (error) {
+    return <div role="alert">Unable to load reading data.</div>;
+  }
+  if (!data || data.length === 0) {
+    return <div>No reading data available</div>;
+  }
 
   const dataByYear = data.reduce((acc, d) => {
     const year = new Date(d.date).getFullYear();

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, within, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
@@ -35,6 +36,28 @@ describe('CalendarHeatmap', () => {
     });
     render(<CalendarHeatmap />);
     expect(screen.getByTestId('calendar-heatmap-skeleton')).not.toBeNull();
+  });
+
+  it('renders an error message when data fails to load', () => {
+    useDailyReading.mockReturnValueOnce({
+      data: null,
+      error: new Error('oops'),
+      isLoading: false,
+    });
+    render(<CalendarHeatmap />);
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Unable to load reading data.'
+    );
+  });
+
+  it('renders a message when no reading data is available', () => {
+    useDailyReading.mockReturnValueOnce({
+      data: [],
+      error: null,
+      isLoading: false,
+    });
+    render(<CalendarHeatmap />);
+    expect(screen.getByText('No reading data available')).not.toBeNull();
   });
 
   it('renders heatmap cells', () => {


### PR DESCRIPTION
## Summary
- show a friendly alert if reading data fails to load
- display message when no reading data exists
- add tests for error and empty states

## Testing
- `npx vitest run src/components/calendar/__tests__/CalendarHeatmap.test.jsx`
- `npm test` *(fails: expected 500 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_689330fee3308324a980fcace4544035