### PR TITLE
refactor: stabilize genre sankey resize

### DIFF
--- a/src/components/genre/__tests__/GenreSankey.test.jsx
+++ b/src/components/genre/__tests__/GenreSankey.test.jsx
@@ -181,4 +181,26 @@ describe('GenreSankey', () => {
       expect(tooltip).toHaveStyle({ display: 'none' });
     });
   });
+
+  it('does not change svg dimensions on re-render when container size is stable', async () => {
+    const { container } = render(<GenreSankey />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    });
+    const svg = container.querySelector('svg');
+    const initialWidth = svg.getAttribute('width');
+    const initialHeight = svg.getAttribute('height');
+
+    // Trigger a re-render that does not affect container size
+    fireEvent.change(screen.getByLabelText('Filter'), {
+      target: { value: 'Self-Help' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: '' } });
+
+    await waitFor(() => {
+      const svg2 = container.querySelector('svg');
+      expect(svg2.getAttribute('width')).toBe(initialWidth);
+      expect(svg2.getAttribute('height')).toBe(initialHeight);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- avoid ResizeObserver loops by measuring only a stable parent container
- update dimensions only when size actually changes
- add regression test to ensure svg dimensions remain stable across re-renders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68933a2fdce483248e629927b6ded19c