### PR TITLE
chore: hide sparkline from screen readers

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -49,6 +49,7 @@ const Sparkline = ({ series }) => {
       height={height}
       viewBox={`0 0 ${width} ${height}`}
       data-testid="sparkline"
+      aria-hidden="true"
     >
       <polyline
         points={points}

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -133,6 +133,22 @@ describe('CalendarHeatmap', () => {
     within(tooltip).getByTestId('sparkline');
   });
 
+  it('hides sparkline from assistive technologies', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<CalendarHeatmap />);
+    const day = container.querySelector('rect[data-date="2024-01-02"]');
+    expect(day).not.toBeNull();
+    await user.hover(day);
+    const tooltip = await screen.findByRole('tooltip');
+    const sparkline = within(tooltip).getByTestId('sparkline');
+    expect(sparkline.getAttribute('aria-hidden')).toBe('true');
+    const otherAria = sparkline
+      .getAttributeNames()
+      .filter((name) => name.startsWith('aria-') && name !== 'aria-hidden');
+    expect(otherAria.length).toBe(0);
+    expect(sparkline.hasAttribute('role')).toBe(false);
+  });
+
   it('shows tooltip when interacting with days that have month labels and totals', async () => {
     const user = userEvent.setup();
     const { container, getByText } = render(<CalendarHeatmap />);


### PR DESCRIPTION
## Summary
- ensure sparkline SVG is hidden from assistive tech
- test sparkline accessibility attributes

## Testing
- `npx vitest run src/components/calendar/__tests__/CalendarHeatmap.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68933101b32083248ba17e69c0cc69d0