### PR TITLE
feat(calendar): improve heatmap accessibility

### DIFF
--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -224,6 +224,30 @@ describe('CalendarHeatmap', () => {
     within(tooltip).getByText('10 min');
   });
 
+  it('provides grid roles and navigation instructions', () => {
+    const { container } = render(<CalendarHeatmap />);
+    const grid = container.querySelector('[role="grid"]');
+    expect(grid).not.toBeNull();
+    expect(grid.getAttribute('aria-label')).toBeTruthy();
+    const instructions = within(grid).getByText(
+      /use arrow keys to navigate/i
+    );
+    expect(instructions).toHaveClass('sr-only');
+    const cell = container.querySelector('rect[data-date="2024-01-01"]');
+    expect(cell?.getAttribute('role')).toBe('gridcell');
+  });
+
+  it('moves focus with arrow keys', async () => {
+    const user = userEvent.setup();
+    render(<CalendarHeatmap />);
+    const firstCell = screen.getByLabelText('Jan 1, 2024: 5 minutes');
+    firstCell.focus();
+    expect(firstCell).toHaveFocus();
+    await user.keyboard('{ArrowRight}');
+    const secondCell = screen.getByLabelText('Jan 2, 2024: 10 minutes');
+    expect(secondCell).toHaveFocus();
+  });
+
   it('renders separate heatmaps for each year', () => {
     const twoYearData = [
       { date: '2023-12-31', minutes: 30, pages: 10 },


### PR DESCRIPTION
## Summary
- add grid and gridcell roles to calendar heatmap
- support arrow-key navigation between days
- document navigation with screen-reader-only instructions

## Testing
- `npx vitest run src/components/calendar/__tests__/CalendarHeatmap.test.jsx`
- `npm test` *(fails: Transform failed with 4 errors in ReadingTimeline.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68933f4098b88324b62845169ac0fa3e