### PR TITLE
feat: make NavItems link closing optional

### DIFF
--- a/src/components/layout/NavItems.tsx
+++ b/src/components/layout/NavItems.tsx
@@ -16,12 +16,14 @@ interface NavItemsProps {
   groups: DashboardRouteGroup[];
   orientation?: "vertical" | "horizontal";
   className?: string;
+  closeOnLinkClick?: boolean;
 }
 
 export default function NavItems({
   groups,
   orientation = "vertical",
   className,
+  closeOnLinkClick = false,
 }: NavItemsProps) {
   const vertical = orientation === "vertical";
   const [query, setQuery] = React.useState("");
@@ -85,7 +87,7 @@ export default function NavItems({
         <span>{label}</span>
       </NavLink>
     );
-    return vertical ? <SheetClose asChild>{link}</SheetClose> : link;
+    return closeOnLinkClick ? <SheetClose asChild>{link}</SheetClose> : link;
   };
 
   if (vertical) {

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -39,7 +39,11 @@ export default function TopNavigation() {
           </button>
         </SheetTrigger>
         <SheetContent side="left" className="p-4">
-          <NavItems groups={dashboardRoutes} orientation="vertical" />
+          <NavItems
+            groups={dashboardRoutes}
+            orientation="vertical"
+            closeOnLinkClick
+          />
         </SheetContent>
       </Sheet>
     </nav>


### PR DESCRIPTION
## Summary
- make sheet closing optional via `closeOnLinkClick`
- enable closing for mobile menu

## Testing
- `npm test src/components/layout/__tests__/navitems.test.tsx`
- `npm test` *(fails: ReadingTimeline.test.jsx, BookNetwork.test.jsx)*
- `npm run build` *(fails: ReadingTimeline.jsx build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68933ec87a948324bb2ba06f3882afe9