### PR TITLE
Remove navigation components from root layout

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
-import TopNavigation from "@/components/layout/TopNavigation";
-import NavItems from "@/components/layout/NavItems";
 import CommandPalette from "@/ui/CommandPalette";
 import { ChartActionsProvider } from "@/hooks/useChartActions";
 import useRecentViews from "@/hooks/useRecentViews";
-import { dashboardRoutes } from "@/routes";
 
 interface RootLayoutProps {
   children: React.ReactNode;
@@ -24,23 +21,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <ChartActionsProvider>
       <CommandPalette open={commandOpen} setOpen={setCommandOpen} />
       <div className="flex min-h-screen">
-        <aside className="hidden w-64 flex-shrink-0 border-r bg-sidebar p-4 md:block">
-          <NavItems groups={dashboardRoutes} orientation="vertical" className="h-full" />
-        </aside>
         <div className="flex flex-1 flex-col">
-          <header className="sticky top-0 z-50 flex items-center border-b bg-white/80 p-4 backdrop-blur">
-            <TopNavigation />
-            <div className="ml-auto flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => setCommandOpen(true)}
-                className="rounded-md border px-2 py-1 text-sm"
-                aria-label="Open command palette"
-              >
-                Search
-              </button>
-            </div>
-          </header>
           <main className="flex-1 overflow-y-auto p-4">{children}</main>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- simplify `RootLayout` by removing `TopNavigation` and `NavItems`
- drop associated header and sidebar markup so only `<main>` remains for rendering children

## Testing
- `npm test` *(fails: 4 failed, 49 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6893432630a08324b1348694e81dcd85