### PR TITLE
feat: add standalone home page and adjust routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import RootLayout from "@/layouts/RootLayout";
 import DashboardLanding from "@/pages/DashboardLanding";
 import SidebarDemoPage from "@/pages/SidebarDemo";
 import NotFound from "@/pages/NotFound";
+import Home from "@/pages/Home";
 import { dashboardRoutes } from "@/routes";
 
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
@@ -46,7 +47,8 @@ function App() {
         <SelectionProvider>
           <RootLayout>
             <Routes>
-              <Route path="/" element={<DashboardLanding />} />
+              <Route path="/" element={<Home />} />
+              <Route path="/dashboard" element={<DashboardLanding />} />
               <Route
                 path="/visualizations"
                 element={<Navigate to="/dashboard/all" replace />}

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -8,7 +8,7 @@ for (const group of dashboardRoutes) {
     routeLabelMap[item.to] = item.label;
   }
 }
-routeLabelMap["/"] = "Dashboard";
+routeLabelMap["/dashboard"] = "Dashboard";
 
 interface BreadcrumbsProps {
   /**
@@ -37,7 +37,7 @@ export default function Breadcrumbs({ labels = {} }: BreadcrumbsProps) {
   const crumbs = segments.map((segment, index) => {
     let to = "/" + segments.slice(0, index + 1).join("/");
     if (index === 0 && segment === "dashboard") {
-      to = "/";
+      to = "/dashboard";
     }
     let label: string | undefined;
 

--- a/src/components/layout/__tests__/breadcrumbs.test.tsx
+++ b/src/components/layout/__tests__/breadcrumbs.test.tsx
@@ -22,7 +22,7 @@ describe("Breadcrumbs", () => {
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveTextContent("Dashboard");
-    expect(links[0]).toHaveAttribute("href", "/");
+    expect(links[0]).toHaveAttribute("href", "/dashboard");
     expect(links[1]).toHaveTextContent("Charts");
     expect(links[1]).toHaveAttribute("href", "/dashboard/charts");
     expect(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+
+export default function Home() {
+  return (
+    <div className="space-y-6 p-6">
+      {dashboardRoutes.map((group) => (
+        <div key={group.label} className="space-y-2">
+          <h2 className="text-xl font-semibold">{group.label}</h2>
+          <ul className="ml-4 list-disc space-y-1">
+            {group.items.map((item) => (
+              <li key={item.to}>
+                <Link to={item.to} className="text-blue-600 hover:underline">
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- list dashboard groups and links on a new home page
- route `/` to `Home` and move `DashboardLanding` to `/dashboard`
- update breadcrumbs and tests for new dashboard path

## Testing
- `npx vitest run src/components/layout/__tests__/breadcrumbs.test.tsx src/pages/__tests__/Dashboard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689343358d5c8324bf528fb23cee0f42