### PR TITLE
refactor: remove unused numpy import

### DIFF
--- a/ml/train_models.py
+++ b/ml/train_models.py
@@ -1,4 +1,4 @@
-import json, time, os, numpy as np, pandas as pd
+import json, time, os, pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 from hmmlearn.hmm import GaussianHMM


### PR DESCRIPTION
## Summary
- remove unused numpy alias from training script

## Testing
- `python ml/train_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68934310c0c483249cd81ab9f1693b8d