### PR TITLE
Add ML requirements and setup instructions

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,21 @@
+# Machine Learning Models
+
+This directory contains training scripts and data for the project's machine learning models.
+
+## Installation
+
+To install the Python dependencies required by `train_models.py`, run:
+
+```bash
+pip install -r requirements.txt
+```
+
+This installs the following packages used in the training script:
+
+- numpy
+- pandas
+- scikit-learn
+- hmmlearn
+- sklearn-crfsuite
+- tensorflow
+- tensorflowjs

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+pandas
+scikit-learn
+hmmlearn
+sklearn-crfsuite
+tensorflow
+tensorflowjs


### PR DESCRIPTION
## Summary
- add Python requirements for ML training
- document installation steps for ML scripts

## Testing
- `npm test` *(fails: symbol "colorScale" already declared in ReadingTimeline.jsx; ReferenceError in BookChordDiagram/BookNetwork tests)*

------
https://chatgpt.com/codex/tasks/task_e_6893430eb9f08324a15eab7dc4e7ba2e