### PR TITLE
chore: exclude server from ts checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,8 +35,7 @@
     ]
   },
   "include": [
-    "src",
-    "server"
+    "src"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary
- remove `server` from TypeScript `include` to skip type checking for JS server code

## Testing
- `npx tsc --noEmit` *(fails: Property 'env' does not exist on type 'ImportMeta', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689343417ec88324bf86a6dece7f6881