### PR TITLE
feat: add smoothing presets

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -18,7 +18,7 @@ export default function ReadingSpeedViolin() {
   const [error, setError] = useState(null);
   const [showMorning, setShowMorning] = useState(true);
   const [showEvening, setShowEvening] = useState(true);
-  const [bandwidth, setBandwidth] = useState(150);
+  const [bandwidth, setBandwidth] = useState(300);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -282,15 +282,15 @@ export default function ReadingSpeedViolin() {
       />
       <div>
         <label>
-          Bandwidth
-          <input
-            type="range"
-            min="50"
-            max="1000"
-            step="50"
+          Smoothing
+          <select
             value={bandwidth}
             onChange={(e) => setBandwidth(Number(e.target.value))}
-          />
+          >
+            <option value={100}>Low</option>
+            <option value={300}>Medium</option>
+            <option value={600}>High</option>
+          </select>
         </label>
       </div>
     </div>

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -21,20 +21,21 @@ afterEach(() => {
       render(<ReadingSpeedViolin />);
       expect(screen.getByLabelText('Morning')).toBeInTheDocument();
       expect(screen.getByLabelText('Evening')).toBeInTheDocument();
-      expect(screen.getByLabelText('Bandwidth')).toBeInTheDocument();
+      expect(screen.getByLabelText('Smoothing')).toBeInTheDocument();
       await waitFor(() => {
         const paths = document.querySelectorAll('path');
         expect(paths.length).toBeGreaterThan(0);
       });
     });
 
-    it('uses lower default bandwidth and slider range', () => {
+    it('uses preset smoothing options', () => {
       render(<ReadingSpeedViolin />);
-      const slider = screen.getByLabelText('Bandwidth');
-      expect(slider).toHaveValue('150');
-      expect(slider).toHaveAttribute('min', '50');
-      expect(slider).toHaveAttribute('max', '1000');
-      expect(slider).toHaveAttribute('step', '50');
+      const select = screen.getByLabelText('Smoothing');
+      expect(select).toHaveValue('300');
+      const optionValues = Array.from(select.querySelectorAll('option')).map(
+        (o) => o.value
+      );
+      expect(optionValues).toEqual(['100', '300', '600']);
     });
 
     it('applies period-specific colors', async () => {


### PR DESCRIPTION
## Summary
- rename bandwidth control to Smoothing and use discrete presets
- update ReadingSpeedViolin tests for Smoothing selector

## Testing
- `npm test -- --run src/components/stats/__tests__/ReadingSpeedViolin.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_689347bd7720832490ab588f42565744