### PR TITLE
Add chart type selector for reading speed chart

### DIFF
--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import ReadingSpeedViolin, { color } from '../ReadingSpeedViolin';
@@ -19,6 +20,7 @@ afterEach(() => {
   describe('ReadingSpeedViolin', () => {
     it('renders controls and chart', async () => {
       render(<ReadingSpeedViolin />);
+      expect(screen.getByLabelText('Chart Type')).toBeInTheDocument();
       expect(screen.getByLabelText('Morning')).toBeInTheDocument();
       expect(screen.getByLabelText('Evening')).toBeInTheDocument();
       expect(screen.getByLabelText('Bandwidth')).toBeInTheDocument();
@@ -80,5 +82,26 @@ afterEach(() => {
     });
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('switches to box plot when selected', async () => {
+    const { container } = render(<ReadingSpeedViolin />);
+
+    await waitFor(() => {
+      const paths = Array.from(container.querySelectorAll('path')).filter((p) =>
+        p.getAttribute('fill') && p.getAttribute('fill') !== 'none'
+      );
+      expect(paths.length).toBeGreaterThan(0);
+    });
+
+    await userEvent.selectOptions(screen.getByLabelText('Chart Type'), 'box');
+
+    await waitFor(() => {
+      const violinPaths = Array.from(container.querySelectorAll('path')).filter(
+        (p) => p.getAttribute('fill') && p.getAttribute('fill') !== 'none'
+      );
+      expect(violinPaths.length).toBe(0);
+      expect(container.querySelectorAll('rect').length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- allow choosing between violin and box plots for reading speed data
- reuse computed scales while conditionally calculating violin densities
- expand unit tests to cover chart type toggle

## Testing
- `npm test` *(fails: 3 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689347c471c48324b48c9ffdfa576ead