### PR TITLE
Add home index page and update routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import React, { lazy, Suspense } from "react";
 import RootLayout from "@/layouts/RootLayout";
 import SidebarDemoPage from "@/pages/SidebarDemo";
 import NotFound from "@/pages/NotFound";
+import Home from "@/pages/Home";
+import VisualizationsList from "@/pages/VisualizationsList";
 import { dashboardRoutes } from "@/routes";
 
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
@@ -45,17 +47,14 @@ function App() {
         <SelectionProvider>
           <RootLayout>
             <Routes>
-              <Route
-                path="/"
-                element={<Navigate to="/dashboard/all" replace />}
-              />
+              <Route path="/" element={<Home />} />
               <Route
                 path="/dashboard"
-                element={<Navigate to="/dashboard/all" replace />}
+                element={<Navigate to="/" replace />}
               />
               <Route
                 path="/visualizations"
-                element={<Navigate to="/dashboard/all" replace />}
+                element={<VisualizationsList />}
               />
               <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
               {createDashboardRoutes()}

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -8,6 +8,7 @@ for (const group of dashboardRoutes) {
     routeLabelMap[item.to] = item.label;
   }
 }
+routeLabelMap["/"] = "Dashboard";
 routeLabelMap["/dashboard/all"] = "Dashboard";
 
 interface BreadcrumbsProps {
@@ -41,7 +42,7 @@ export default function Breadcrumbs({ labels = {} }: BreadcrumbsProps) {
   const crumbs = segments.map((segment, index) => {
     let to = "/" + segments.slice(0, index + 1).join("/");
     if (index === 0 && segment === "dashboard") {
-      to = "/dashboard/all";
+      to = "/";
     }
     let label: string | undefined;
 

--- a/src/components/layout/__tests__/breadcrumbs.test.tsx
+++ b/src/components/layout/__tests__/breadcrumbs.test.tsx
@@ -22,7 +22,7 @@ describe("Breadcrumbs", () => {
 
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveTextContent("Dashboard");
-    expect(links[0]).toHaveAttribute("href", "/dashboard/all");
+    expect(links[0]).toHaveAttribute("href", "/");
     expect(links[1]).toHaveTextContent("Charts");
     expect(links[1]).toHaveAttribute("href", "/dashboard/charts");
     expect(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { dashboardRoutes } from "@/routes";
+
+// Build a map of existing page modules so we can filter out
+// routes pointing to non-existent components.
+// Vite's import.meta.glob gives us an object where keys are paths
+// relative to this file's directory (src/pages).
+const pageModules = import.meta.glob("./**/*.{ts,tsx,js,jsx}");
+
+function hasPage(component?: string) {
+  if (!component) return true;
+  // Convert the @/pages/* path to a relative path like ./foo
+  const path = component.replace("@/pages", ".");
+  return (
+    pageModules[`${path}.tsx`] ||
+    pageModules[`${path}.ts`] ||
+    pageModules[`${path}.jsx`] ||
+    pageModules[`${path}.js`]
+  );
+}
+
+export default function Home() {
+  // Filter out routes that don't have an existing page module
+  const groups = dashboardRoutes
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => hasPage(item.component)),
+    }))
+    .filter((group) => group.items.length > 0);
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      {groups.map((group) => (
+        <section key={group.label} className="space-y-2">
+          <h2 className="text-xl font-semibold flex items-center gap-2">
+            {group.label}
+          </h2>
+          <ul className="space-y-1 ml-4 list-disc">
+            {group.items.map(({ to, label, description }) => (
+              <li key={to}>
+                <Link to={to} className="text-blue-600 hover:underline">
+                  {label}
+                </Link>
+                {description && (
+                  <p className="text-sm text-muted-foreground">
+                    {description}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce `Home` page that lists visualization links while ignoring missing components
- route `/` to the new Home page and expose full list at `/visualizations`
- point breadcrumbs to root instead of `/dashboard/all`

## Testing
- `npm test` *(fails: BookNetwork component tests, ReadingTimeline test, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6893bd21edc48324811b92afc9baed4c