### PR TITLE
Fix dialog root children rendering

### DIFF
--- a/src/components/ui/__tests__/dialog.test.tsx
+++ b/src/components/ui/__tests__/dialog.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
 
 import { Dialog, DialogContentFullscreen, DialogTrigger } from "../dialog";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
@@ -86,5 +87,22 @@ describe("Dialog", () => {
     await user.click(screen.getByText("open"));
 
     expect(screen.getByText("content")).toBeInTheDocument();
+  });
+
+  it("allows interacting with links when closed", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <>
+        <UncontrolledDialog />
+        <a href="#" onClick={handleClick}>
+          link
+        </a>
+      </>
+    );
+
+    await user.click(screen.getByText("link"));
+
+    expect(handleClick).toHaveBeenCalled();
   });
 });

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 interface DialogProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {}
 
-function Dialog({ open, onOpenChange, ...props }: DialogProps) {
+function Dialog({ open, onOpenChange, children, ...props }: DialogProps) {
   const [internalOpen, setInternalOpen] = React.useState(false);
 
   const handleOpenChange = (next: boolean) => {
@@ -20,7 +20,9 @@ function Dialog({ open, onOpenChange, ...props }: DialogProps) {
       open={open === undefined ? internalOpen : open}
       onOpenChange={handleOpenChange}
       {...props}
-    />
+    >
+      {children}
+    </DialogPrimitive.Root>
   );
 }
 const DialogTrigger = DialogPrimitive.Trigger;


### PR DESCRIPTION
## Summary
- render `Dialog` children inside `DialogPrimitive.Root`
- add test ensuring links remain clickable when dialog is closed

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: Error: unknown type: mouseover)*

------
https://chatgpt.com/codex/tasks/task_e_6893e32b29e4832487137fe210f5538b