### PR TITLE
Split Kindle dashboard routes for Bookshelf and Progress Spiral

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -351,12 +351,13 @@ export const kindleRoutes = withIcon(BookOpen, [
     label: "Bookshelf by Year",
     description: "Book covers organized chronologically",
     component: "@/pages/charts/BookshelfByYear",
-
+    tags: ["kindle"],
+  },
+  {
     to: "/dashboard/kindle/book-progress-spiral",
     label: "Book Progress Spirals",
     description: "Spiral chart of book progress over time",
     component: "@/pages/charts/BookProgressSpiral",
-
     tags: ["kindle"],
   },
 ]);


### PR DESCRIPTION
## Summary
- separate Kindle dashboard route entries for Bookshelf and Book Progress Spirals

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: 6 failed, 87 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6893e5bb660083248873c9319f1abeb8