### PR TITLE
Add choropleth tooltips to ReadingMap

### DIFF
--- a/src/components/map/ReadingMap.jsx
+++ b/src/components/map/ReadingMap.jsx
@@ -245,6 +245,13 @@ export default function ReadingMap() {
     return 'markers';
   }, [mode, zoom]);
 
+  function handleFeature(feature, layer) {
+    const count = feature.properties.count || 0;
+    layer.bindTooltip(
+      `${feature.properties.name}: ${count} title${count === 1 ? '' : 's'}`
+    );
+  }
+
   if (loading)
     return <Skeleton className="h-[480px] w-full" data-testid="loading" />;
 
@@ -376,6 +383,7 @@ export default function ReadingMap() {
             color: 'hsl(var(--background))',
             fillOpacity: 0.7,
           })}
+          onEachFeature={handleFeature}
         />
         <Legend colorScale={colorScale} maxCount={maxCount} />
         {computedMode === 'heatmap' && <HeatmapLayer points={points} />}


### PR DESCRIPTION
## Summary
- add onEachFeature callback binding region name and title count to tooltips
- pass callback to GeoJSON so countries and states show counts on hover

## Testing
- `npm test` *(fails: expected 500 to be 200 for GET /api/kindle)*

------
https://chatgpt.com/codex/tasks/task_e_6893e5dc7cd483248c60d8d8e80c9477