### PR TITLE
feat: integrate legend toggles

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -203,12 +203,26 @@ export default function ReadingSpeedViolin() {
       .enter()
       .append('g')
       .attr('transform', (_, i) => `translate(0, ${i * 20})`)
+      .attr('role', 'checkbox')
+      .attr('tabindex', 0)
+      .attr('aria-label', (d) => d.label)
+      .attr('aria-checked', (d) => d.visible)
       .style('cursor', 'pointer')
       .on('click', (_, d) => {
         if (d.key === 'morning') {
           setShowMorning((s) => !s);
         } else {
           setShowEvening((s) => !s);
+        }
+      })
+      .on('keydown', (event, d) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          if (d.key === 'morning') {
+            setShowMorning((s) => !s);
+          } else {
+            setShowEvening((s) => !s);
+          }
         }
       });
 

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -19,8 +19,12 @@ afterEach(() => {
   describe('ReadingSpeedViolin', () => {
     it('renders controls and chart', async () => {
       render(<ReadingSpeedViolin />);
-      expect(screen.getByLabelText('Morning')).toBeInTheDocument();
-      expect(screen.getByLabelText('Evening')).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: 'Morning' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: 'Evening' })
+      ).toBeInTheDocument();
       expect(screen.getByLabelText('Smoothing')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Show All/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Deep reading/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- move morning/evening toggles into SVG legend with accessible checkbox semantics
- update tests to reference legend-based controls

## Testing
- `npm test` *(fails: Error: unknown type: mouseover in GenreSankey tests)*

------
https://chatgpt.com/codex/tasks/task_e_6893e5e22b98832485685d2490f0be42