### PR TITLE
feat: annotate reading speed medians

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -158,6 +158,20 @@ export default function ReadingSpeedViolin() {
       .append('g')
       .attr('transform', `translate(${margin.left},${margin.top})`);
 
+    const defs = svg.append('defs');
+    defs
+      .append('marker')
+      .attr('id', 'arrow')
+      .attr('viewBox', '0 -5 10 10')
+      .attr('refX', 5)
+      .attr('refY', 0)
+      .attr('markerWidth', 6)
+      .attr('markerHeight', 6)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('d', 'M0,-5L10,0L0,5')
+      .attr('fill', '#555');
+
     const yTicks = y.ticks();
     const majorTicks = yTicks.filter((d) => d % 250 === 0);
 
@@ -387,6 +401,39 @@ export default function ReadingSpeedViolin() {
           .on('mouseout', () => tooltip.style('opacity', 0));
       });
     });
+
+    if (showMorning && showEvening && stats.morning && stats.evening) {
+      const morningMedian = stats.morning.median;
+      const eveningMedian = stats.evening.median;
+      const annotationY = -10;
+      const annotation = root.append('g').attr('class', 'median-annotation');
+      annotation
+        .append('text')
+        .attr('x', innerWidth / 2)
+        .attr('y', annotationY)
+        .attr('text-anchor', 'middle')
+        .text(
+          `Evening median ≈${Math.round(eveningMedian)} WPM vs. Morning ≈${Math.round(
+            morningMedian
+          )} WPM`
+        );
+      annotation
+        .append('line')
+        .attr('x1', innerWidth / 2)
+        .attr('y1', annotationY + 5)
+        .attr('x2', xCat('morning') + catWidth / 2)
+        .attr('y2', y(morningMedian))
+        .attr('stroke', color.morning)
+        .attr('marker-end', 'url(#arrow)');
+      annotation
+        .append('line')
+        .attr('x1', innerWidth / 2)
+        .attr('y1', annotationY + 5)
+        .attr('x2', xCat('evening') + catWidth / 2)
+        .attr('y2', y(eveningMedian))
+        .attr('stroke', color.evening)
+        .attr('marker-end', 'url(#arrow)');
+    }
   }, [
     filteredData,
     showMorning,

--- a/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
+++ b/src/components/stats/__tests__/ReadingSpeedViolin.test.jsx
@@ -178,4 +178,16 @@ afterEach(() => {
 
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
-});
+
+    it('annotates median comparison', async () => {
+      render(<ReadingSpeedViolin />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Evening median/)).toBeInTheDocument();
+      });
+
+      const annotation = document.querySelector('.median-annotation');
+      expect(annotation).toBeInTheDocument();
+      expect(annotation.querySelectorAll('line').length).toBe(2);
+    });
+  });


### PR DESCRIPTION
## Summary
- draw annotation comparing morning and evening median reading speeds
- render arrow markers pointing from annotation to each median line
- test median annotations appear with lines

## Testing
- `npm test` *(fails: GET /api/kindle returns location data 18ms → expected 500 to be 200 // Object.is equality)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef10c2ac8324ad2f6b774efccf93