### PR TITLE
Handle aborted reading session fetches

### DIFF
--- a/src/hooks/useReadingSessions.js
+++ b/src/hooks/useReadingSessions.js
@@ -8,7 +8,8 @@ export default function useReadingSessions() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const { signal } = controller;
+    const signal = controller.signal;
+    setIsLoading(true);
 
     async function load() {
       try {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1701,7 +1701,9 @@ export async function getKindleSessions(
 ): Promise<KindleSession[]> {
   if (typeof fetch === "function") {
     try {
-      const res = await fetch("/api/kindle/sessions", { signal });
+      const res = await fetch("/api/kindle/sessions", {
+        ...(signal ? { signal } : {}),
+      });
       if (res.ok) {
         return res.json();
       }


### PR DESCRIPTION
## Summary
- Ensure reading sessions hook uses `AbortController` and exposes `isLoading`
- Allow `getKindleSessions` to accept abort signals

## Testing
- `npm test` *(fails: unknown type: mouseover)*

------
https://chatgpt.com/codex/tasks/task_e_6893eee592908324af3f237cbd8c79e6