### PR TITLE
Reorder dashboard route groups

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -429,12 +429,12 @@ const otherRouteGroup: DashboardRouteGroup = {
 };
 
 export const dashboardRoutes: DashboardRouteGroup[] = [
-  kindleRouteGroup,
   allRouteGroup,
   mapsRouteGroup,
   trendsRouteGroup,
   analyticalRouteGroup,
   goalsRouteGroup,
+  kindleRouteGroup,
   otherRouteGroup,
 ];
 


### PR DESCRIPTION
## Summary
- reorganize dashboard route groups so Kindle links follow main categories

## Testing
- `npm test` *(fails: unknown type mouseover in GenreSankey tests)*
- `npm run build` *(fails: default is not exported by src/config/constants.js)*

------
https://chatgpt.com/codex/tasks/task_e_6893f235eb3883249c41bfce7bfbdb16