### PR TITLE
feat: style reading speed gridlines

### DIFF
--- a/src/components/stats/ReadingSpeedViolin.jsx
+++ b/src/components/stats/ReadingSpeedViolin.jsx
@@ -186,7 +186,9 @@ export default function ReadingSpeedViolin() {
           .tickFormat('')
       );
 
-    grid.selectAll('line').attr('stroke', (d) => (d % 250 === 0 ? '#ccc' : '#eee'));
+    grid
+      .selectAll('line')
+      .attr('stroke', (d) => (majorTicks.includes(d) ? '#ccc' : '#eee'));
     grid.select('.domain').remove();
 
     const yAxisGroup = root
@@ -194,8 +196,11 @@ export default function ReadingSpeedViolin() {
       .attr('class', 'y-axis')
       .call(axisLeft(y).tickValues(majorTicks));
 
-    yAxisGroup.selectAll('.tick line').attr('stroke', '#999');
-    yAxisGroup.selectAll('.tick text').attr('fill', '#555');
+    yAxisGroup.selectAll('.tick line').attr('stroke', '#777').attr('stroke-width', 1);
+    yAxisGroup
+      .selectAll('.tick text')
+      .attr('fill', '#333')
+      .style('font-weight', 'bold');
     yAxisGroup.select('.domain').remove();
 
     root


### PR DESCRIPTION
## Summary
- refine violin chart grid to include light gray horizontal lines
- emphasize major ticks at 250 WPM with darker strokes and bold labels

## Testing
- `npm test` *(fails: GET /api/kindle > returns location data, multiple GenreSankey tests, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6893f1f0fac4832490d93bf382b828e1