### PR TITLE
Attach highlights by ASIN

### DIFF
--- a/data/kindle/highlights.json
+++ b/data/kindle/highlights.json
@@ -1,5 +1,12 @@
-[
-  "the quick brown fox jumps over the lazy dog",
-  "the quick blue hare jumps high",
-  "the slow turtle crawls under the log"
-]
+{
+  "A": [
+    "the quick brown fox jumps over the lazy dog"
+  ],
+  "B": [
+    "the quick blue hare jumps high"
+  ],
+  "C": [
+    "the slow turtle crawls under the log"
+  ]
+}
+

--- a/scripts/build-book-graph.js
+++ b/scripts/build-book-graph.js
@@ -50,8 +50,14 @@ function main() {
     `${base}/Kindle.UnifiedLibraryIndex.CustomerGenres/Kindle.UnifiedLibraryIndex.CustomerGenres.csv`
   );
 
-  const highlightsPath = path.join(__dirname, '..', 'data', 'kindle', 'highlights.json');
-  let highlights = [];
+  const highlightsPath = path.join(
+    __dirname,
+    '..',
+    'data',
+    'kindle',
+    'highlights.json'
+  );
+  let highlights = {};
   if (fs.existsSync(highlightsPath)) {
     highlights = JSON.parse(fs.readFileSync(highlightsPath, 'utf-8'));
   }
@@ -89,11 +95,12 @@ function main() {
     }
   }
 
-  const bookList = Array.from(books.values());
-  highlights.forEach((text, i) => {
-    if (bookList[i]) bookList[i].highlights.push(text);
-  });
+  for (const [asin, texts] of Object.entries(highlights)) {
+    const book = books.get(asin);
+    if (book) book.highlights.push(...texts);
+  }
 
+  const bookList = Array.from(books.values());
   const graph = buildBookGraph(bookList);
   const outPath = path.join(
     __dirname,

--- a/server/services/bookGraphHighlight.test.js
+++ b/server/services/bookGraphHighlight.test.js
@@ -1,0 +1,36 @@
+/* @vitest-environment node */
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+describe('getBookGraph highlight mapping', () => {
+  it('attaches highlights to correct books regardless of order', async () => {
+    const ordersCsv = 'ASIN,Product Name\nB,Title B\nA,Title A';
+    const authorsCsv = 'ASIN,Author Name\nA,Author A\nB,Author B';
+    const genresCsv = 'ASIN,Genre\nA,Genre A\nB,Genre B';
+    const highlightsJson = JSON.stringify({
+      A: ['A highlight'],
+      B: ['B highlight']
+    });
+    vi.spyOn(fs.promises, 'readFile').mockImplementation(async (p) => {
+      if (p.includes('CustomerOrders')) return ordersCsv;
+      if (p.includes('CustomerAuthorNameRelationship')) return authorsCsv;
+      if (p.includes('CustomerGenres')) return genresCsv;
+      if (p.endsWith('highlights.json')) return highlightsJson;
+      return '';
+    });
+    const buildBookGraph = vi.fn((books) => books);
+    const modPath = require.resolve('../../src/services/bookGraph.js');
+    require.cache[modPath] = { exports: { buildBookGraph } };
+    const { getBookGraph } = require('./kindleService');
+    const books = await getBookGraph();
+    expect(buildBookGraph).toHaveBeenCalled();
+    const bookA = books.find((b) => b.asin === 'A');
+    const bookB = books.find((b) => b.asin === 'B');
+    expect(bookA.highlights).toEqual(['A highlight']);
+    expect(bookB.highlights).toEqual(['B highlight']);
+  });
+});

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -233,7 +233,8 @@ async function getHighlightTrie() {
   if (!highlightTrie) {
     const filePath = path.join(__dirname, '..', '..', 'data', 'kindle', 'highlights.json');
     const content = await fs.promises.readFile(filePath, 'utf-8');
-    const texts = JSON.parse(content);
+    const map = JSON.parse(content);
+    const texts = Object.values(map).flat();
     highlightTrie = buildHighlightIndex(texts);
   }
   return highlightTrie;
@@ -322,11 +323,12 @@ async function getBookGraph() {
     if (book && genre && !book.tags.includes(genre)) book.tags.push(genre);
   }
 
-  const bookList = Array.from(books.values());
-  highlights.forEach((text, i) => {
-    if (bookList[i]) bookList[i].highlights.push(text);
-  });
+  for (const [asin, texts] of Object.entries(highlights)) {
+    const book = books.get(asin);
+    if (book) book.highlights.push(...texts);
+  }
 
+  const bookList = Array.from(books.values());
   return buildBookGraph(bookList);
 }
 

--- a/src/components/highlights/WordTree.jsx
+++ b/src/components/highlights/WordTree.jsx
@@ -6,8 +6,10 @@ import { linkHorizontal } from 'd3-shape';
 import { scaleLinear } from 'd3-scale';
 import Sentiment from 'sentiment';
 import nlp from 'compromise';
-import highlights from '@/data/kindle/highlights.json';
+import highlightsMap from '@/data/kindle/highlights.json';
 import { Skeleton } from '@/ui/skeleton';
+
+const highlights = Object.values(highlightsMap).flat();
 
 const sentimentAnalyzer = new Sentiment();
 const sentimentColor = scaleLinear()

--- a/src/data/kindle/highlights.json
+++ b/src/data/kindle/highlights.json
@@ -1,5 +1,12 @@
-[
-  "The first highlight text",
-  "Another highlight from a book",
-  "Last highlight"
-]
+{
+  "A": [
+    "The first highlight text"
+  ],
+  "B": [
+    "Another highlight from a book"
+  ],
+  "C": [
+    "Last highlight"
+  ]
+}
+


### PR DESCRIPTION
## Summary
- parse highlight files into ASIN-keyed maps and flatten for highlight index
- assign highlights to books by matching ASIN instead of index
- update highlight JSON data and WordTree component; add regression test for highlight mapping

## Testing
- `npm test` *(fails: ReadingTimeline.test.jsx etc.)*
- `npx vitest run server/services/bookGraphHighlight.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6893fb508b7c8324a23d53231d53d20f