### PR TITLE
Abort stale weather requests in useCurrentWeather

### DIFF
--- a/src/hooks/useCurrentWeather.ts
+++ b/src/hooks/useCurrentWeather.ts
@@ -4,9 +4,15 @@ import { getCurrentWeather, type CurrentWeather } from '@/lib/weather'
 export function useCurrentWeather(lat: number, lon: number): CurrentWeather | null {
   const [data, setData] = useState<CurrentWeather | null>(null)
   useEffect(() => {
-    getCurrentWeather(lat, lon)
+    const controller = new AbortController()
+    getCurrentWeather(lat, lon, controller.signal)
       .then(setData)
-      .catch(() => {})
+      .catch((err) => {
+        if (err.name !== 'AbortError') {
+          console.error('Failed to fetch current weather', err)
+        }
+      })
+    return () => controller.abort()
   }, [lat, lon])
   return data
 }

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -18,9 +18,10 @@ export function mapWeatherCode(code: number): string {
 export async function getCurrentWeather(
   lat: number,
   lon: number,
+  signal?: AbortSignal,
 ): Promise<CurrentWeather> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true`
-  const res = await fetch(url)
+  const res = await fetch(url, { signal })
   if (!res.ok) {
     throw new Error('Failed to fetch weather')
   }


### PR DESCRIPTION
## Summary
- add `AbortController` to `useCurrentWeather` and cancel pending fetches
- plumb `AbortSignal` through `getCurrentWeather`
- log weather fetch errors instead of swallowing them

## Testing
- `npm test` *(fails: Error: unknown type: mouseover)*

------
https://chatgpt.com/codex/tasks/task_e_6893fb4ddd608324afe7d564079dce88