### PR TITLE
feat: use server-friendly location data

### DIFF
--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const { pathToFileURL } = require('url');
 const { parse } = require('csv-parse');
+const { getSessionLocations } = require('./locationData.cjs');
 const { aggregateDailyReading } = require('../../src/services/readingStats');
 const { aggregateReadingSessions } = require('../../src/services/readingSessions');
 const { calculateReadingSpeeds } = require('../../src/services/readingSpeed');
@@ -245,10 +245,6 @@ async function getHighlightExpansions(keyword) {
 }
 
 async function getLocations() {
-  const moduleUrl = pathToFileURL(
-    path.join(__dirname, '../../src/services/locationData.js')
-  ).href;
-  const { getSessionLocations } = await import(moduleUrl);
   return getSessionLocations();
 }
 

--- a/server/services/locationData.cjs
+++ b/server/services/locationData.cjs
@@ -1,0 +1,15 @@
+const sessionLocations = require('../../src/data/kindle/locations.json');
+const asinTitleMap = require('../../src/data/kindle/asin-title-map.json');
+
+function mapTitles(data) {
+  return data.map((l) => ({
+    ...l,
+    title: asinTitleMap[l.title] ?? l.title,
+  }));
+}
+
+function getSessionLocations() {
+  return mapTitles(sessionLocations);
+}
+
+module.exports = { getSessionLocations };


### PR DESCRIPTION
## Summary
- provide server-side locationData module without browser APIs
- replace dynamic import with CommonJS require in Kindle service

## Testing
- `vitest server/api/kindle.test.js`
- `node server/app.js & curl -s http://localhost:3000/api/kindle/locations | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6893fb4b43f08324a3e00e9493b575ae