### PR TITLE
refactor: centralize route lazy loader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,21 @@
-import React, { lazy, Suspense } from "react";
+import React, { Suspense } from "react";
 import RootLayout from "@/layouts/RootLayout";
 import SidebarDemoPage from "@/pages/SidebarDemo";
 import NotFound from "@/pages/NotFound";
 import Home from "@/pages/Home";
 import VisualizationsList from "@/pages/VisualizationsList";
 import { dashboardRoutes } from "@/routes";
+import { getLazyComponent } from "@/lib/routeLoader";
 
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { DashboardFiltersProvider } from "@/hooks/useDashboardFilters";
 import { SelectionProvider } from "@/hooks/useSelection";
 
-const MissingComponent = () => <div>Component not found</div>;
-
-const pageModules = import.meta.glob("./pages/**/*.{ts,tsx,js,jsx}");
-
 function createDashboardRoutes() {
   return dashboardRoutes.flatMap(({ items }) =>
     items.map(({ to, component }) => {
       if (!component) return [];
-      const path = component.replace("@/", "./");
-      const importer =
-        pageModules[`${path}.tsx`] ||
-        pageModules[`${path}.ts`] ||
-        pageModules[`${path}.jsx`] ||
-        pageModules[`${path}.js`];
-      const LazyComp = importer ? lazy(importer as any) : MissingComponent;
+      const LazyComp = getLazyComponent(component);
       return (
         <Route
           key={to}

--- a/src/lib/routeLoader.ts
+++ b/src/lib/routeLoader.ts
@@ -1,0 +1,18 @@
+import React, { lazy } from 'react'
+
+const pageModules = import.meta.glob('../pages/**/*.{ts,tsx,js,jsx}')
+
+const MissingComponent = () => <div>Component not found</div>
+
+export function getLazyComponent(path: string) {
+  const cleaned = path.replace(/^@\//, '../')
+  const importer =
+    pageModules[`${cleaned}.tsx`] ||
+    pageModules[`${cleaned}.ts`] ||
+    pageModules[`${cleaned}.jsx`] ||
+    pageModules[`${cleaned}.js`]
+
+  return importer ? lazy(importer as any) : MissingComponent
+}
+
+export { MissingComponent }


### PR DESCRIPTION
## Summary
- add `getLazyComponent` to load dashboard routes lazily with fallback
- use new lazy loader in `createDashboardRoutes`

## Testing
- `npm test` *(fails: GenreSankey tests)*

------
https://chatgpt.com/codex/tasks/task_e_68940a612e308324a4991793a2061a24