### PR TITLE
Refactor base routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,7 @@
-import React, { Suspense } from "react";
+import { Suspense } from "react";
 import RootLayout from "@/layouts/RootLayout";
-import SidebarDemoPage from "@/pages/SidebarDemo";
-import NotFound from "@/pages/NotFound";
-import Home from "@/pages/Home";
-import VisualizationsList from "@/pages/VisualizationsList";
 import { dashboardRoutes } from "@/routes";
+import { baseRoutes } from "@/routes/baseRoutes";
 import { getLazyComponent } from "@/lib/routeLoader";
 
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
@@ -38,18 +35,14 @@ function App() {
         <SelectionProvider>
           <RootLayout>
             <Routes>
-              <Route path="/" element={<Home />} />
+              {baseRoutes.map(({ path, element }) => (
+                <Route key={path} path={path} element={element} />
+              ))}
               <Route
                 path="/dashboard"
                 element={<Navigate to="/" replace />}
               />
-              <Route
-                path="/visualizations"
-                element={<VisualizationsList />}
-              />
-              <Route path="/sidebar-demo" element={<SidebarDemoPage />} />
               {createDashboardRoutes()}
-              <Route path="*" element={<NotFound />} />
             </Routes>
           </RootLayout>
         </SelectionProvider>

--- a/src/routes/baseRoutes.ts
+++ b/src/routes/baseRoutes.ts
@@ -1,0 +1,16 @@
+import Home from "@/pages/Home";
+import VisualizationsList from "@/pages/VisualizationsList";
+import SidebarDemoPage from "@/pages/SidebarDemo";
+import NotFound from "@/pages/NotFound";
+
+interface BaseRoute {
+  path: string;
+  element: JSX.Element;
+}
+
+export const baseRoutes: BaseRoute[] = [
+  { path: "/", element: <Home /> },
+  { path: "/visualizations", element: <VisualizationsList /> },
+  { path: "/sidebar-demo", element: <SidebarDemoPage /> },
+  { path: "*", element: <NotFound /> },
+];


### PR DESCRIPTION
## Summary
- centralize static routes in new `baseRoutes` config
- consume `baseRoutes` in `App` before dashboard routes

## Testing
- `npm test` *(fails: unknown type: mouseover)*

------
https://chatgpt.com/codex/tasks/task_e_68940c1b51a88324a941008932ce73eb