### PR TITLE
Add dashboard route metadata and empty state

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,27 +8,31 @@ export default function Home() {
   return (
     <div className="p-4 space-y-6">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      {groups.map((group) => (
-        <section key={group.label} className="space-y-2">
-          <h2 className="text-xl font-semibold flex items-center gap-2">
-            {group.label}
-          </h2>
-          <ul className="space-y-1 ml-4 list-disc">
-            {group.items.map(({ to, label, description }) => (
-              <li key={to}>
-                <Link to={to} className="text-blue-600 hover:underline">
-                  {label}
-                </Link>
-                {description && (
-                  <p className="text-sm text-muted-foreground">
-                    {description}
-                  </p>
-                )}
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
+      {groups.length === 0 ? (
+        <p>No dashboards configured.</p>
+      ) : (
+        groups.map((group) => (
+          <section key={group.label} className="space-y-2">
+            <h2 className="text-xl font-semibold flex items-center gap-2">
+              {group.label}
+            </h2>
+            <ul className="space-y-1 ml-4 list-disc">
+              {group.items.map(({ to, label, description }) => (
+                <li key={to}>
+                  <Link to={to} className="text-blue-600 hover:underline">
+                    {label}
+                  </Link>
+                  {description && (
+                    <p className="text-sm text-muted-foreground">
+                      {description}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      )}
     </div>
   );
 }

--- a/src/routes/meta.ts
+++ b/src/routes/meta.ts
@@ -1,5 +1,9 @@
-import type { DashboardRouteGroup } from './types';
+import type { DashboardRouteGroup } from "./types";
+import { analyticsRouteGroup } from "@/features/analytics/routes";
+import { playgroundRouteGroup } from "@/features/playground/routes";
 
-// Placeholder for custom route labels and descriptions.
-// Actual metadata can be filled in as needed.
-export const dashboardRouteMeta: DashboardRouteGroup[] = [];
+// Group metadata for dashboard routes. Add additional groups as needed.
+export const dashboardRouteMeta: DashboardRouteGroup[] = [
+  analyticsRouteGroup,
+  playgroundRouteGroup,
+];


### PR DESCRIPTION
## Summary
- register analytics and playground route groups in dashboard metadata
- display message when no dashboard routes are configured

## Testing
- `npm test` *(fails: unknown type: mouseover in GenreSankey.test and others)*

------
https://chatgpt.com/codex/tasks/task_e_68948e9630508324afee5efde78bf44f