### PR TITLE
feat: add reset button for timeline zoom

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -403,6 +403,17 @@ export default function ReadingTimeline({
           Drag the brush below the chart to zoom into a specific time range.
         </desc>
       </svg>
+      {zoomed && (
+        <button
+          onClick={() => {
+            reset();
+            setZoomed(false);
+          }}
+          style={{ marginTop: '0.5rem' }}
+        >
+          Reset
+        </button>
+      )}
 
       {legendKeys.length > 0 && showLegend && (
         <ul


### PR DESCRIPTION
## Summary
- show a Reset button when the timeline is zoomed
- hook Reset to clear brush selection and exit zoom

## Testing
- `npm test` *(fails: unknown type: mouseover)*

------
https://chatgpt.com/codex/tasks/task_e_6894b68bf8b083248c12a5a54b1036d2