### PR TITLE
Show legend by default for color blind mode

### DIFF
--- a/src/components/timeline/ReadingTimeline.jsx
+++ b/src/components/timeline/ReadingTimeline.jsx
@@ -39,11 +39,19 @@ export default function ReadingTimeline({
   const adjustingRef = useRef(false);
   const [zoomed, setZoomed] = useState(false);
   const [width, setWidth] = useState(DEFAULT_WIDTH);
-  const [showLegend, setShowLegend] = useState(false);
+  const [showLegend, setShowLegend] = useState(colorBlindFriendly);
   const [search, setSearch] = useState('');
   const [colorBy, setColorBy] = useState('title');
   const [minDuration, setMinDuration] = useState(0);
   const [minHighlights, setMinHighlights] = useState(0);
+
+  const prevColorBlindRef = useRef(colorBlindFriendly);
+  useEffect(() => {
+    if (prevColorBlindRef.current !== colorBlindFriendly) {
+      setShowLegend(colorBlindFriendly);
+      prevColorBlindRef.current = colorBlindFriendly;
+    }
+  }, [colorBlindFriendly]);
 
   const filteredSessions = useMemo(() => {
     const term = search.toLowerCase();


### PR DESCRIPTION
## Summary
- initialize ReadingTimeline legend visibility from the `colorBlindFriendly` prop
- sync legend visibility when `colorBlindFriendly` changes after mount

## Testing
- `npm test -- run src/components/timeline/__tests__/ReadingTimeline.test.jsx` *(fails: ReadingTimeline > filters by minimum duration and highlights: expected to have a length of 1 but got 0)*

------
https://chatgpt.com/codex/tasks/task_e_6894bbba28bc83249cd3c24bfd1485ab