### PR TITLE
Use streamed CSV parsing in Kindle service

### DIFF
--- a/server/services/bookGraphHighlight.test.js
+++ b/server/services/bookGraphHighlight.test.js
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import { Readable } from 'stream';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -15,10 +16,13 @@ describe('getBookGraph highlight mapping', () => {
       A: ['A highlight'],
       B: ['B highlight']
     });
+    vi.spyOn(fs, 'createReadStream').mockImplementation((p) => {
+      if (p.includes('CustomerOrders')) return Readable.from([ordersCsv]);
+      if (p.includes('CustomerAuthorNameRelationship')) return Readable.from([authorsCsv]);
+      if (p.includes('CustomerGenres')) return Readable.from([genresCsv]);
+      throw new Error(`Unexpected path: ${p}`);
+    });
     vi.spyOn(fs.promises, 'readFile').mockImplementation(async (p) => {
-      if (p.includes('CustomerOrders')) return ordersCsv;
-      if (p.includes('CustomerAuthorNameRelationship')) return authorsCsv;
-      if (p.includes('CustomerGenres')) return genresCsv;
       if (p.endsWith('highlights.json')) return highlightsJson;
       return '';
     });

--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -10,17 +10,14 @@ const { calculateGenreTransitions } = require('../../src/services/genreTransitio
 const { buildHighlightIndex, getExpansions } = require('../../src/services/highlightIndex');
 const { buildBookGraph } = require('../../src/services/bookGraph');
 
-async function parseCsv(filePath) {
-  const content = await fs.promises.readFile(filePath, 'utf-8');
+function parseCsv(filePath) {
   return new Promise((resolve, reject) => {
-    parse(
-      content,
-      { columns: true, skip_empty_lines: true, trim: true, bom: true },
-      (err, records) => {
-        if (err) reject(err);
-        else resolve(records);
-      }
-    );
+    const records = [];
+    fs.createReadStream(filePath)
+      .pipe(parse({ columns: true, skip_empty_lines: true, trim: true, bom: true }))
+      .on('data', (record) => records.push(record))
+      .on('end', () => resolve(records))
+      .on('error', reject);
   });
 }
 
@@ -35,7 +32,7 @@ async function getEvents() {
     'Kindle.Devices.KindleNotificationsEventsAndroid',
     'Kindle.Devices.KindleNotificationsEventsAndroid.csv'
   );
-  return parseCsv(filePath);
+  return await parseCsv(filePath);
 }
 
 async function getPoints() {
@@ -68,7 +65,7 @@ async function getAchievements() {
     'Kindle.BookRewards.Achievements.1',
     'Kindle.BookRewards.Achievements.1.csv'
   );
-  return parseCsv(filePath);
+  return await parseCsv(filePath);
 }
 
 async function getDailyStats() {

--- a/server/services/kindleService.test.js
+++ b/server/services/kindleService.test.js
@@ -1,6 +1,7 @@
 /* @vitest-environment node */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import fs from 'fs';
+import { Readable } from 'stream';
 import {
   getEvents,
   getPoints,
@@ -15,7 +16,7 @@ afterEach(() => {
 describe('kindleService', () => {
   it('getEvents parses CSV with quoted commas', async () => {
     const csv = 'Timestamp,Activity\n2025-01-01T00:00:00Z,"OPENED, page 1"';
-    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(csv);
+    vi.spyOn(fs, 'createReadStream').mockReturnValue(Readable.from([csv]));
     const result = await getEvents();
     expect(result).toEqual([
       { Timestamp: '2025-01-01T00:00:00Z', Activity: 'OPENED, page 1' },
@@ -24,7 +25,7 @@ describe('kindleService', () => {
 
   it('getPoints returns first row as object', async () => {
     const csv = 'Available Balance (Points),Marketplace,Pending Balance (Points)\n10,"www.amazon.com,uk",0';
-    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(csv);
+    vi.spyOn(fs, 'createReadStream').mockReturnValue(Readable.from([csv]));
     const result = await getPoints();
     expect(result).toEqual({
       'Available Balance (Points)': '10',
@@ -35,7 +36,7 @@ describe('kindleService', () => {
 
   it('getAchievements parses CSV with quoted fields', async () => {
     const csv = 'AchievementGroupName,AchievementName,EarnDate,Marketplace,Quantity\nGroup,"Gold, Level",2024-01-01Z,"www.amazon.com","1"';
-    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(csv);
+    vi.spyOn(fs, 'createReadStream').mockReturnValue(Readable.from([csv]));
     const result = await getAchievements();
     expect(result).toEqual([
       {


### PR DESCRIPTION
## Summary
- Parse CSV files via `fs.createReadStream` piped into `csv-parse`
- Await streamed parsing when fetching Kindle events and achievements
- Update tests to mock `fs.createReadStream`

## Testing
- `npx vitest run server/services/kindleService.test.js server/services/bookGraphHighlight.test.js server/api/kindle.test.js`
- `npm test` *(fails: `Error: unknown type: mouseover` in UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_6894df8f99dc8324937999e1d7c0fb8e