### PR TITLE
Handle Kindle session fetch errors

### DIFF
--- a/src/hooks/__tests__/useReadingSessions.test.ts
+++ b/src/hooks/__tests__/useReadingSessions.test.ts
@@ -1,0 +1,31 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import useReadingSessions from '../useReadingSessions'
+import { getKindleSessions } from '@/lib/api'
+
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  getKindleSessions: vi.fn(),
+}))
+
+describe('useReadingSessions', () => {
+  it('returns sessions on success', async () => {
+    const sessions = [
+      { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:10:00Z', asin: 'A', title: 'Book A', duration: 10, highlights: 0 },
+    ]
+    ;(getKindleSessions as any).mockResolvedValue(sessions)
+    const { result } = renderHook(() => useReadingSessions())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual(sessions)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets error when request fails', async () => {
+    const err = new Error('fail')
+    ;(getKindleSessions as any).mockRejectedValue(err)
+    const { result } = renderHook(() => useReadingSessions())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBe(err)
+    expect(result.current.data).toBeNull()
+  })
+})

--- a/src/hooks/useReadingSessions.js
+++ b/src/hooks/useReadingSessions.js
@@ -10,14 +10,18 @@ export default function useReadingSessions() {
     const controller = new AbortController();
     const signal = controller.signal;
     setIsLoading(true);
+    setError(null);
 
     async function load() {
       try {
         const d = await getKindleSessions(signal);
-        if (!signal.aborted) setData(d);
+        if (!signal.aborted) {
+          setData(d);
+        }
       } catch (err) {
         if (err.name !== 'AbortError' && !signal.aborted) {
           setError(err);
+          setData(null);
         }
       } finally {
         if (!signal.aborted) setIsLoading(false);

--- a/src/lib/__tests__/kindleSessions.test.ts
+++ b/src/lib/__tests__/kindleSessions.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getKindleSessions } from '../api'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getKindleSessions', () => {
+  it('returns sessions on successful fetch', async () => {
+    const sessions = [
+      { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:10:00Z', asin: 'A', title: 'Book A', duration: 10, highlights: 0 },
+    ]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sessions),
+    }))
+    const result = await getKindleSessions()
+    expect(result).toEqual(sessions)
+  })
+
+  it('throws when fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+    await expect(getKindleSessions()).rejects.toThrow('network')
+  })
+
+  it('throws when response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+    }))
+    await expect(getKindleSessions()).rejects.toThrow(/Failed to fetch Kindle sessions/)
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1704,11 +1704,13 @@ export async function getKindleSessions(
       const res = await fetch("/api/kindle/sessions", {
         ...(signal ? { signal } : {}),
       });
-      if (res.ok) {
-        return res.json();
+      if (!res.ok) {
+        throw new Error(`Failed to fetch Kindle sessions: ${res.status} ${res.statusText}`);
       }
+      return res.json();
     } catch (err: any) {
       if (err.name === "AbortError") throw err;
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- Throw an error if fetching Kindle sessions fails or returns a bad response
- Reset and report errors in `useReadingSessions`
- Test successful and failing Kindle session fetches

## Testing
- `npm test src/lib/__tests__/kindleSessions.test.ts src/hooks/__tests__/useReadingSessions.test.ts`
- `npm test -- --run` *(fails: expected 0 to be greater than 0 in GenreSankey tests)*

------
https://chatgpt.com/codex/tasks/task_e_6894e2e24ec88324ad41fbbd088788dc