### PR TITLE
chore: ensure config files end with newline

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ESNext"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,23 +16,13 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@/ui": [
-        "src/components/ui"
-      ],
-      "@/ui/*": [
-        "src/components/ui/*"
-      ],
-      "@/*": [
-        "src/*"
-      ]
+      "@/ui": ["src/components/ui"],
+      "@/ui/*": ["src/components/ui/*"],
+      "@/*": ["src/*"]
     },
-    "types": [
-      "vitest/globals"
-    ]
+    "types": ["vitest/globals"]
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,20 +1,20 @@
-import { defineConfig } from 'vitest/config'
-import path from 'path'
+import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@/ui': path.resolve(__dirname, './src/components/ui'),
-      '@': path.resolve(__dirname, './src'),
+      "@/ui": path.resolve(__dirname, "./src/components/ui"),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: './vitest.setup.ts',
+    setupFiles: "./vitest.setup.ts",
     include: [
-      'src/**/*.{test,spec}.{js,ts,jsx,tsx}',
-      'server/**/*.{test,spec}.js',
+      "src/**/*.{test,spec}.{js,ts,jsx,tsx}",
+      "server/**/*.{test,spec}.js",
     ],
   },
-})
+});


### PR DESCRIPTION
## Summary
- format tsconfig and vitest config
- ensure both config files end with a newline

## Testing
- `npm test` *(fails: getByLabelText is not defined, unknown type: mouseover)*


------
https://chatgpt.com/codex/tasks/task_e_6894fda042b88324a3bb507c7ac99ba2