### PR TITLE
feat: fallback reading medium totals

### DIFF
--- a/src/hooks/__tests__/useReadingMediumTotals.test.ts
+++ b/src/hooks/__tests__/useReadingMediumTotals.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react"
 import { describe, it, expect, vi } from "vitest"
 import useReadingMediumTotals from "../useReadingMediumTotals"
+import * as api from "@/lib/api"
 import type { ReadingMediumTotal } from "@/lib/api"
 
 describe("useReadingMediumTotals", () => {
@@ -24,5 +25,22 @@ describe("useReadingMediumTotals", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.error).toBeTruthy()
     expect(result.current.data).toBeNull()
+  })
+
+  it("falls back to mock data when fetch fails", async () => {
+    const mockData: ReadingMediumTotal[] = [
+      { medium: "tablet", minutes: 45 },
+    ]
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("fail")))
+    const spy = vi
+      .spyOn(api, "getReadingMediumTotals")
+      .mockResolvedValue(mockData)
+    const { result } = renderHook(() => useReadingMediumTotals())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual(mockData)
+    expect(result.current.error).toBeNull()
+    expect(spy).toHaveBeenCalled()
+    vi.unstubAllGlobals()
+    spy.mockRestore()
   })
 })

--- a/src/hooks/useReadingMediumTotals.ts
+++ b/src/hooks/useReadingMediumTotals.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { ReadingMediumTotal } from '@/lib/api'
+import { getReadingMediumTotals } from '@/lib/api'
 
 interface UseReadingMediumTotalsOptions {
   /**
@@ -7,7 +8,9 @@ interface UseReadingMediumTotalsOptions {
    */
   data?: ReadingMediumTotal[]
   /**
-   * Optional fetcher function. Defaults to calling `/api/reading-medium-totals`.
+   * Optional fetcher function. By default the hook attempts to call
+   * `/api/reading-medium-totals` and falls back to mock data if the endpoint
+   * is unavailable.
    */
   fetcher?: () => Promise<ReadingMediumTotal[]>
 }
@@ -19,11 +22,20 @@ interface UseReadingMediumTotalsResult {
 }
 
 async function defaultFetcher(): Promise<ReadingMediumTotal[]> {
-  const res = await fetch('/api/reading-medium-totals')
-  if (!res.ok) throw new Error('Failed to fetch reading medium totals')
-  return res.json()
+  try {
+    const res = await fetch('/api/reading-medium-totals')
+    if (!res.ok) throw new Error('Failed to fetch reading medium totals')
+    return res.json()
+  } catch {
+    return getReadingMediumTotals()
+  }
 }
 
+/**
+ * Retrieves total reading time by medium. Attempts to fetch from the
+ * `/api/reading-medium-totals` endpoint and falls back to locally generated
+ * mock data when the API is absent.
+ */
 export default function useReadingMediumTotals(
   options: UseReadingMediumTotalsOptions = {},
 ): UseReadingMediumTotalsResult {


### PR DESCRIPTION
## Summary
- try `/api/reading-medium-totals` and fall back to mock data for useReadingMediumTotals
- document the fallback behaviour and allow custom fetchers
- cover API fallback in useReadingMediumTotals tests

## Testing
- `npm test` *(fails: GenreSankey filters data when dates are applied; ReadingTimeline filters by minimum duration and highlights)*

------
https://chatgpt.com/codex/tasks/task_e_68950ec7ce708324949d787d450f38cc