### PR TITLE
feat(calendar): skip loading when data prop present

### DIFF
--- a/src/components/calendar/CalendarHeatmap.jsx
+++ b/src/components/calendar/CalendarHeatmap.jsx
@@ -323,8 +323,14 @@ export default function CalendarHeatmap({
   multiYear,
   buckets = defaultBuckets,
 }) {
-  const { data: hookData, isLoading, error } = useDailyReading();
+  const {
+    data: hookData,
+    isLoading: hookIsLoading,
+    error: hookError,
+  } = useDailyReading(!propData);
   const data = propData || hookData;
+  const isLoading = !propData && hookIsLoading;
+  const error = !propData && hookError;
   if (isLoading) {
     return <Skeleton className="h-64" data-testid="calendar-heatmap-skeleton" />;
   }

--- a/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
+++ b/src/components/calendar/__tests__/CalendarHeatmap.test.jsx
@@ -38,6 +38,17 @@ describe('CalendarHeatmap', () => {
     expect(screen.getByTestId('calendar-heatmap-skeleton')).not.toBeNull();
   });
 
+  it('skips loading state when prop data is provided', () => {
+    useDailyReading.mockReturnValueOnce({
+      data: null,
+      error: null,
+      isLoading: true,
+    });
+    render(<CalendarHeatmap data={mockData} />);
+    expect(screen.queryByTestId('calendar-heatmap-skeleton')).toBeNull();
+    expect(useDailyReading).toHaveBeenCalledWith(false);
+  });
+
   it('renders an error message when data fails to load', () => {
     useDailyReading.mockReturnValueOnce({
       data: null,

--- a/src/hooks/useDailyReading.js
+++ b/src/hooks/useDailyReading.js
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
 import { getDailyReadingStats } from '@/lib/api';
 
-export default function useDailyReading() {
+export default function useDailyReading(enabled = true) {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (!enabled) return;
     getDailyReadingStats()
       .then(setData)
       .catch(setError);
-  }, []);
+  }, [enabled]);
 
-  return { data, error, isLoading: !data && !error };
+  return { data, error, isLoading: enabled && !data && !error };
 }


### PR DESCRIPTION
## Summary
- pass `enabled` flag to `useDailyReading` to prevent fetching when external data provided
- gate CalendarHeatmap skeleton behind prop data check
- add test ensuring skeleton is skipped when prop data exists

## Testing
- `npm test` *(fails: Test Files 6 failed | 48 passed | 2 skipped (96))*

------
https://chatgpt.com/codex/tasks/task_e_68950ec149308324bfbc0f10c617395b