### PR TITLE
Use real Kindle session data for reading metrics

### DIFF
--- a/src/hooks/useReadingHeatmap.ts
+++ b/src/hooks/useReadingHeatmap.ts
@@ -122,7 +122,17 @@ export default function useReadingHeatmap(): HeatmapCell[] | null {
   const [data, setData] = useState<HeatmapCell[] | null>(null)
 
   useEffect(() => {
-    getReadingSessions().then((sessions) => setData(computeReadingHeatmap(sessions)))
+    let active = true
+    getReadingSessions()
+      .then((sessions) => {
+        if (active) setData(computeReadingHeatmap(sessions))
+      })
+      .catch(() => {
+        if (active) setData([])
+      })
+    return () => {
+      active = false
+    }
   }, [])
 
   return data

--- a/src/hooks/useReadingMediumTotals.ts
+++ b/src/hooks/useReadingMediumTotals.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { ReadingMediumTotal } from '@/lib/api'
+import { getReadingMediumTotals, type ReadingMediumTotal } from '@/lib/api'
 
 interface UseReadingMediumTotalsOptions {
   /**
@@ -7,7 +7,7 @@ interface UseReadingMediumTotalsOptions {
    */
   data?: ReadingMediumTotal[]
   /**
-   * Optional fetcher function. Defaults to calling `/api/reading-medium-totals`.
+   * Optional fetcher function. Defaults to `getReadingMediumTotals`.
    */
   fetcher?: () => Promise<ReadingMediumTotal[]>
 }
@@ -19,9 +19,7 @@ interface UseReadingMediumTotalsResult {
 }
 
 async function defaultFetcher(): Promise<ReadingMediumTotal[]> {
-  const res = await fetch('/api/reading-medium-totals')
-  if (!res.ok) throw new Error('Failed to fetch reading medium totals')
-  return res.json()
+  return getReadingMediumTotals()
 }
 
 export default function useReadingMediumTotals(

--- a/src/hooks/useReadingProbability.ts
+++ b/src/hooks/useReadingProbability.ts
@@ -48,9 +48,17 @@ export default function useReadingProbability(): ReadingProbabilityPoint[] | nul
   const [data, setData] = useState<ReadingProbabilityPoint[] | null>(null)
 
   useEffect(() => {
-    getReadingSessions().then((sessions) =>
-      setData(computeReadingProbability(sessions)),
-    )
+    let active = true
+    getReadingSessions()
+      .then((sessions) => {
+        if (active) setData(computeReadingProbability(sessions))
+      })
+      .catch(() => {
+        if (active) setData([])
+      })
+    return () => {
+      active = false
+    }
   }, [])
 
   return data


### PR DESCRIPTION
## Summary
- Load reading sessions from Kindle exports instead of mock generator
- Aggregate medium totals from real Kindle sessions
- Update reading-related hooks to use new session sources and handle fetch failures

## Testing
- `npm test` *(fails: BookChordDiagram, BookNetwork, GenreSankey and others)*

------
https://chatgpt.com/codex/tasks/task_e_68950de7c874832494f4e32dedef0365