### PR TITLE
Ensure ReadingMap includes boundary sessions

### DIFF
--- a/src/components/map/ReadingMap.jsx
+++ b/src/components/map/ReadingMap.jsx
@@ -77,8 +77,9 @@ export default function ReadingMap() {
 
   const filtered = useMemo(() => {
     return locations.filter((l) => {
-      if (start && l.start < start) return false;
-      if (end && l.start > end) return false;
+      const date = l.start.slice(0, 10);
+      if (start && date < start) return false;
+      if (end && date > end) return false;
       if (title && !l.title.toLowerCase().includes(title.toLowerCase())) return false;
       return true;
     });

--- a/src/components/map/__tests__/ReadingMap.test.jsx
+++ b/src/components/map/__tests__/ReadingMap.test.jsx
@@ -118,6 +118,26 @@ describe('ReadingMap', () => {
     );
   });
 
+  it('retains sessions on the end date', async () => {
+    const { container } = render(<ReadingMap />);
+    await waitFor(() => screen.getByTestId('map'));
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: 2 } });
+    await waitFor(() =>
+      expect(screen.getAllByTestId('marker')).toHaveLength(3)
+    );
+
+    const dateInputs = container.querySelectorAll('input[type="date"]');
+    const [, endInput] = dateInputs;
+    fireEvent.change(endInput, { target: { value: '2021-06-01' } });
+    fireEvent.change(slider, { target: { value: 1 } });
+    await waitFor(() => {
+      expect(screen.getAllByTestId('marker')).toHaveLength(2);
+      expect(screen.getByText('Beta')).toBeTruthy();
+    });
+  });
+
   it('plays through locations when toggling play', async () => {
     render(<ReadingMap />);
     await waitFor(() => screen.getByTestId('map'));


### PR DESCRIPTION
## Summary
- handle inclusive date filtering by comparing YYYY-MM-DD strings
- test that sessions on the end date remain visible

## Testing
- `npm test` *(fails: unknown type mouseover)*

------
https://chatgpt.com/codex/tasks/task_e_68950c566a3c8324ac479d57c5449adc