### PR TITLE
Add generator for Kindle reading locations

### DIFF
--- a/scripts/generate-locations.js
+++ b/scripts/generate-locations.js
@@ -1,0 +1,62 @@
+import { promises as fs } from 'fs';
+
+const sessionsPath = 'src/data/kindle/sessions.json';
+const asinTitleMapPath = 'src/data/kindle/asin-title-map.json';
+const outputPath = 'src/data/kindle/locations.json';
+
+const cities = [
+  { latitude: 37.7749, longitude: -122.4194 }, // San Francisco
+  { latitude: 40.7128, longitude: -74.006 }, // New York
+  { latitude: 34.0522, longitude: -118.2437 }, // Los Angeles
+  { latitude: 51.5074, longitude: -0.1278 }, // London
+  { latitude: 48.8566, longitude: 2.3522 }, // Paris
+  { latitude: 35.6895, longitude: 139.6917 }, // Tokyo
+  { latitude: 52.52, longitude: 13.405 }, // Berlin
+  { latitude: -33.8688, longitude: 151.2093 }, // Sydney
+  { latitude: 55.7558, longitude: 37.6173 }, // Moscow
+  { latitude: -23.5505, longitude: -46.6333 }, // São Paulo
+];
+
+function hash(str) {
+  let h = 0;
+  for (const ch of str) h = (h + ch.charCodeAt(0)) % 2147483647;
+  return h;
+}
+
+async function main() {
+  const sessions = JSON.parse(await fs.readFile(sessionsPath, 'utf8'));
+  const asinTitleMap = JSON.parse(await fs.readFile(asinTitleMapPath, 'utf8'));
+  const validAsins = new Set(Object.keys(asinTitleMap));
+
+  const asinStart = new Map();
+  for (const s of sessions) {
+    if (!s.asin || !s.start || !validAsins.has(s.asin)) continue;
+    const t = new Date(s.start);
+    if (Number.isNaN(t.getTime())) continue;
+    const prev = asinStart.get(s.asin);
+    if (!prev || t < prev) {
+      asinStart.set(s.asin, t);
+    }
+  }
+
+  const entries = [];
+  const cityCount = cities.length;
+  for (const [asin, date] of asinStart) {
+    const city = cities[hash(asin) % cityCount];
+    entries.push({
+      start: date.toISOString(),
+      title: asin,
+      latitude: city.latitude,
+      longitude: city.longitude,
+    });
+  }
+
+  entries.sort((a, b) => new Date(a.start) - new Date(b.start));
+
+  await fs.writeFile(outputPath, JSON.stringify(entries, null, 2) + '\n');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/data/kindle/locations.json
+++ b/src/data/kindle/locations.json
@@ -1,5 +1,2306 @@
 [
-  { "start": "2018-01-13T03:49:45Z", "title": "B01A4AXM3W", "latitude": 37.7749, "longitude": -122.4194 },
-  { "start": "2018-03-25T22:21:24Z", "title": "B071Y385Q1", "latitude": 40.7128, "longitude": -74.0060 },
-  { "start": "2018-03-26T13:49:01Z", "title": "B071Y385Q1", "latitude": 34.0522, "longitude": -118.2437 }
+  {
+    "start": "2018-01-09T22:49:43.000Z",
+    "title": "B01A4AXM3W",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2018-02-01T22:40:29.000Z",
+    "title": "B01MAWT2MO",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2018-02-19T03:15:33.000Z",
+    "title": "B00NLLYN4Y",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2018-02-20T18:56:09.000Z",
+    "title": "B01KE61LPW",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2018-03-18T03:28:10.000Z",
+    "title": "B01LXZZ1L5",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2018-03-21T02:06:48.000Z",
+    "title": "B079ZLBXV6",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2018-03-21T02:08:32.000Z",
+    "title": "B074ST9DGK",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2018-03-22T02:28:54.000Z",
+    "title": "B071Y385Q1",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2018-03-25T21:15:09.000Z",
+    "title": "B07B2L77BJ",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2018-03-25T21:23:12.000Z",
+    "title": "B07B6W7GRQ",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2018-03-25T21:43:03.000Z",
+    "title": "B07B6NPXHV",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2018-03-25T21:49:43.000Z",
+    "title": "B079ZQBV4H",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2018-03-25T21:50:38.000Z",
+    "title": "B07B9GK76Z",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2018-04-12T02:07:11.000Z",
+    "title": "B00280LYIM",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2018-04-18T03:07:41.000Z",
+    "title": "B06W2J89PV",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2018-06-13T03:23:30.000Z",
+    "title": "B009UW5X4C",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2018-09-21T15:29:25.000Z",
+    "title": "B07192GP7F",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2018-09-25T22:01:28.000Z",
+    "title": "B00BBPVYUS",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2018-11-04T03:49:20.000Z",
+    "title": "B0143V938Q",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2018-11-05T04:00:36.000Z",
+    "title": "B00KFEK0I8",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2018-11-05T04:07:23.000Z",
+    "title": "B07BDKJVWS",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2019-01-06T13:42:41.000Z",
+    "title": "B00O2RPEE4",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2019-02-07T15:52:12.000Z",
+    "title": "B074ZDRGBC",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2019-02-28T20:15:16.000Z",
+    "title": "B078W5XGZD",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2019-11-13T15:16:36.000Z",
+    "title": "B07BZ4F75T",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2020-01-10T19:56:27.000Z",
+    "title": "B000OZ0NXA",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2020-01-24T23:39:36.000Z",
+    "title": "B00II6SY4W",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-02-07T02:51:12.000Z",
+    "title": "B000QCS932",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2020-02-07T21:08:16.000Z",
+    "title": "B001FXK8XU",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-02-16T02:38:13.000Z",
+    "title": "B004DI7JNG",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-03-04T03:51:00.000Z",
+    "title": "B077WWXZ41",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-03-19T06:59:11.000Z",
+    "title": "B000FBJDF2",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2020-03-25T21:46:59.000Z",
+    "title": "B000FC1MBO",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2020-04-13T03:05:23.000Z",
+    "title": "B000FCK5PI",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2020-04-15T19:51:41.000Z",
+    "title": "B07L2J8P4S",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2020-04-20T03:14:00.000Z",
+    "title": "B000GCFG7E",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-05-10T23:47:57.000Z",
+    "title": "B07TRVW6VX",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2020-05-15T00:26:11.000Z",
+    "title": "B000QCQ8Y4",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2020-05-22T20:35:42.000Z",
+    "title": "B000YJ54DU",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2020-05-29T22:44:38.000Z",
+    "title": "B001NLL8LA",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2020-06-06T15:17:58.000Z",
+    "title": "B07QBNKJTZ",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-06-15T03:11:33.000Z",
+    "title": "B0036S4CWA",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2020-06-17T19:59:05.000Z",
+    "title": "B003EY7IWC",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-06-18T11:18:20.000Z",
+    "title": "B07THBZ4VD",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-06-19T11:09:16.000Z",
+    "title": "B004P8JPS6",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2020-08-04T03:15:11.000Z",
+    "title": "B07NCNVZ5P",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2020-08-22T03:34:44.000Z",
+    "title": "B07GNX99VJ",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2020-09-12T19:55:52.000Z",
+    "title": "B00U27BMT4",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2020-09-16T16:36:40.000Z",
+    "title": "B086JN68M6",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-09-17T02:06:28.000Z",
+    "title": "B003ODIZL6",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-09-21T02:42:45.000Z",
+    "title": "B0084B57VO",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2020-09-21T02:46:12.000Z",
+    "title": "B085GKR5BL",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2020-09-28T14:42:24.000Z",
+    "title": "B07ZN51NL3",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2020-10-11T03:58:36.000Z",
+    "title": "B07N2X3ST6",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-10-11T04:03:13.000Z",
+    "title": "B081NHX6LN",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2020-10-14T03:55:27.000Z",
+    "title": "B07ZG57WBH",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-10-14T04:42:45.000Z",
+    "title": "B081Y4J7LD",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-10-28T04:46:44.000Z",
+    "title": "B089T77W63",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-10-28T05:04:56.000Z",
+    "title": "B07THQLGBT",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2020-11-18T05:39:56.000Z",
+    "title": "B00AHC9PZW",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2020-11-18T05:58:15.000Z",
+    "title": "B08NHG3PKK",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2020-11-30T04:35:47.000Z",
+    "title": "B081ZXQB52",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-11-30T20:33:09.000Z",
+    "title": "B07RL58ZDG",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2020-12-05T05:49:03.000Z",
+    "title": "B0764BV94D",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2020-12-05T06:45:49.000Z",
+    "title": "B07YRWHGYD",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2020-12-06T01:44:26.000Z",
+    "title": "B07YXS82KD",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2020-12-08T04:46:56.000Z",
+    "title": "B07YXSLVX7",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2020-12-25T06:24:26.000Z",
+    "title": "B00CH3DBNQ",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2021-02-14T12:28:33.000Z",
+    "title": "B08478T2CK",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2021-02-28T04:57:07.000Z",
+    "title": "B07R5KC59C",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-03-01T03:44:56.000Z",
+    "title": "B07ZTTH5VD",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-03-03T04:52:52.000Z",
+    "title": "B083JKGK15",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2021-03-10T22:40:45.000Z",
+    "title": "B084V823SR",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-03-18T15:20:13.000Z",
+    "title": "B07TPFTG1S",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-04-20T14:42:00.000Z",
+    "title": "B086HB336Y",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2021-05-19T03:12:22.000Z",
+    "title": "B07ZC6W6SV",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-06-02T13:00:39.000Z",
+    "title": "B08DHSFM4Q",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-07-17T03:59:09.000Z",
+    "title": "B00C8S9VKM",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-07-18T19:32:56.000Z",
+    "title": "B009U9S6FI",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2021-07-19T03:26:44.000Z",
+    "title": "B008TY8BQ4",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-07-20T23:11:27.000Z",
+    "title": "B08BLMJ576",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2021-07-24T00:44:53.000Z",
+    "title": "B07CL5ZLHX",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2021-07-24T03:34:16.000Z",
+    "title": "B003EI2EH2",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-07-24T23:51:26.000Z",
+    "title": "B098GBS3BH",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-07-24T23:57:18.000Z",
+    "title": "B095YHMBSL",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2021-07-30T03:43:29.000Z",
+    "title": "B07MYXB26N",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2021-07-31T03:30:16.000Z",
+    "title": "B07SKWFVYW",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-08-02T04:20:06.000Z",
+    "title": "B0987XFGZF",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2021-08-03T03:58:39.000Z",
+    "title": "B07P9DC6TY",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2021-08-03T22:52:19.000Z",
+    "title": "B08681BNKV",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2021-08-04T22:04:50.000Z",
+    "title": "B07C3XLBHG",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-08-22T04:06:26.000Z",
+    "title": "B0893YWV5Q",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2021-08-23T04:01:34.000Z",
+    "title": "B09D3K2MCY",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2021-08-25T02:46:43.000Z",
+    "title": "B083SN8RF7",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2021-08-25T03:27:08.000Z",
+    "title": "B072KZWHW4",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2021-08-25T20:32:44.000Z",
+    "title": "B08LDL3PJ3",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-08-26T01:48:09.000Z",
+    "title": "B07FKB3V5S",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-09-05T14:24:42.000Z",
+    "title": "B000FC0R7O",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2021-09-05T22:56:29.000Z",
+    "title": "B09F8RV343",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2021-09-11T02:05:55.000Z",
+    "title": "B0865TSTWM",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2021-09-29T02:56:05.000Z",
+    "title": "B08PK59474",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2021-09-29T20:59:53.000Z",
+    "title": "B08XP24KR8",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-10-07T03:47:23.000Z",
+    "title": "B08RZ4PTSF",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2021-10-07T22:41:56.000Z",
+    "title": "B005NY4QGM",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-11-01T01:59:01.000Z",
+    "title": "B09KKPHDHC",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-11-03T04:39:06.000Z",
+    "title": "B0955FXRLM",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-11-03T04:45:08.000Z",
+    "title": "B08WC6VC8S",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-11-03T16:19:17.000Z",
+    "title": "B08SJQSWYM",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2021-11-04T03:34:25.000Z",
+    "title": "B0865Z9S5L",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-11-06T13:51:36.000Z",
+    "title": "B00MYEQGFI",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2021-11-07T05:24:35.000Z",
+    "title": "B09GYVRQWF",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2021-11-07T05:45:07.000Z",
+    "title": "B07LGLF1JG",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2021-12-10T00:09:37.000Z",
+    "title": "B08N8Z99MK",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2021-12-10T22:58:01.000Z",
+    "title": "B09887KBTZ",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2021-12-30T05:36:46.000Z",
+    "title": "B08SBMCSQQ",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-01-02T03:27:43.000Z",
+    "title": "B08TRMSR3Z",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-01-14T05:40:32.000Z",
+    "title": "B08PF965W9",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-01-21T05:15:12.000Z",
+    "title": "B093B4BGRK",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-01-21T05:42:11.000Z",
+    "title": "B013X9F1IK",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-01-21T05:48:03.000Z",
+    "title": "B08VRP55V1",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-01-23T16:01:33.000Z",
+    "title": "B00JV2H5I8",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-01-31T04:23:51.000Z",
+    "title": "B087PL8YVQ",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-02-04T04:50:05.000Z",
+    "title": "B08B38JVKY",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-02-04T05:31:47.000Z",
+    "title": "B0814JSV96",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2022-02-04T05:34:50.000Z",
+    "title": "B001NXK1XO",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-02-06T06:00:37.000Z",
+    "title": "B08PY1XTB8",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2022-02-08T05:49:44.000Z",
+    "title": "B08XTNHRR5",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-02-08T06:09:09.000Z",
+    "title": "B08WRH53MY",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-02-16T06:05:25.000Z",
+    "title": "B08478YC6V",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-02-16T22:47:21.000Z",
+    "title": "B08L3P3VGQ",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-02-22T19:26:05.000Z",
+    "title": "B07PK5RMPM",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-02-25T00:58:04.000Z",
+    "title": "B093ZQCS29",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-02-28T22:28:16.000Z",
+    "title": "B09LM328XY",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-03-03T02:22:38.000Z",
+    "title": "B09T9H87RB",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-03-04T05:50:12.000Z",
+    "title": "B00HYQEJAK",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-03-04T06:01:47.000Z",
+    "title": "B0108VD2L4",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-03-04T06:15:11.000Z",
+    "title": "B094GQBBPQ",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-03-04T22:13:46.000Z",
+    "title": "B098TZ17NC",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-03-05T05:11:46.000Z",
+    "title": "B07TZYFR71",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-03-12T06:08:06.000Z",
+    "title": "B08QM8VHRT",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-03-16T18:51:15.000Z",
+    "title": "B07TVRR6GR",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-03-26T03:28:53.000Z",
+    "title": "B08FH9BV7N",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-04-09T03:55:14.000Z",
+    "title": "B08G1NJK2R",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-04-14T02:45:17.000Z",
+    "title": "B098PXP11K",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-04-19T05:03:20.000Z",
+    "title": "B08JKC299M",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-04-20T03:34:16.000Z",
+    "title": "B08FLLBBP9",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-04-24T20:16:02.000Z",
+    "title": "B0018ND8B6",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-04-25T02:43:28.000Z",
+    "title": "B01LWWK7WR",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2022-04-28T04:30:27.000Z",
+    "title": "B099DRHTLX",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-04-29T08:15:38.000Z",
+    "title": "B091Y4KGFH",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-05-09T19:21:06.000Z",
+    "title": "B09Z1Y1MG9",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-05-13T01:35:00.000Z",
+    "title": "B01NBJMMRR",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-05-15T02:58:30.000Z",
+    "title": "B0756J4NRG",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-05-17T01:41:52.000Z",
+    "title": "B07GVCBVYC",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-05-20T02:25:07.000Z",
+    "title": "B07WYSF921",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-05-21T04:23:01.000Z",
+    "title": "B095MMJYSR",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-05-23T03:07:26.000Z",
+    "title": "B07D2C6J4K",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-05-27T03:00:38.000Z",
+    "title": "B09BTJNJCX",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2022-06-03T20:33:32.000Z",
+    "title": "B09Q1SQ567",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-06-03T20:33:45.000Z",
+    "title": "B09QCX4JK7",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-06-07T04:32:02.000Z",
+    "title": "B00JX43A0G",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-06-08T03:15:27.000Z",
+    "title": "B096DH95W8",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-06-08T03:32:53.000Z",
+    "title": "B098QS47D3",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-06-09T01:44:02.000Z",
+    "title": "B09P37M6P3",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-06-19T05:06:44.000Z",
+    "title": "B08KL58Q4X",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-06-21T01:38:15.000Z",
+    "title": "B09QBBMXCR",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-06-21T01:46:55.000Z",
+    "title": "B08J3YYP2M",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-06-22T04:46:44.000Z",
+    "title": "B08P98PVY2",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-06-26T00:33:54.000Z",
+    "title": "B0151YQYYU",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-06-29T01:26:48.000Z",
+    "title": "B00AEBETU2",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-07-09T03:54:21.000Z",
+    "title": "B0B5GC1ZR5",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2022-07-11T22:02:30.000Z",
+    "title": "B095MPSYWY",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-07-25T03:42:12.000Z",
+    "title": "B097T5JR84",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-07-29T03:25:32.000Z",
+    "title": "B09HCD24DJ",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2022-07-31T03:17:29.000Z",
+    "title": "B08HL86V91",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-08-02T02:50:10.000Z",
+    "title": "B084M663VB",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-08-12T03:36:34.000Z",
+    "title": "B08YRM9NBM",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-08-15T03:12:27.000Z",
+    "title": "B01MSICPW3",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-08-15T03:22:13.000Z",
+    "title": "B00OICLVBI",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2022-08-29T03:07:27.000Z",
+    "title": "B09JPFYQY2",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-09-02T03:46:30.000Z",
+    "title": "B08THH7R49",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-09-13T04:18:02.000Z",
+    "title": "B09841WSGD",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-09-16T02:47:44.000Z",
+    "title": "B09G9C2WRT",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-09-18T02:48:24.000Z",
+    "title": "B0BCPF7HGJ",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-09-20T03:19:38.000Z",
+    "title": "B08PC3SZHX",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-09-20T22:29:46.000Z",
+    "title": "B09NTJPTKN",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-09-23T19:14:03.000Z",
+    "title": "B09NLPTNQ2",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2022-09-25T03:32:57.000Z",
+    "title": "B09QKTFZGR",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-09-26T02:25:09.000Z",
+    "title": "B097769VDM",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-09-28T19:46:22.000Z",
+    "title": "B000FC0QBQ",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-10-23T03:23:30.000Z",
+    "title": "B0B193DJYK",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2022-10-27T03:46:45.000Z",
+    "title": "B003BRBCFG",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2022-10-31T23:01:02.000Z",
+    "title": "B0BKPPPQNV",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-11-03T03:36:35.000Z",
+    "title": "B09QPJKSXM",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2022-11-11T05:38:56.000Z",
+    "title": "B09285Y1V4",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-11-13T06:18:23.000Z",
+    "title": "B0BH8GTQYX",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-11-17T04:54:49.000Z",
+    "title": "B07WK8JZ9N",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2022-11-18T04:05:56.000Z",
+    "title": "B09NH4DJBP",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2022-12-02T20:56:25.000Z",
+    "title": "B08KH4LZDM",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2022-12-13T03:50:44.000Z",
+    "title": "B0B33PJZJT",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-12-15T04:11:35.000Z",
+    "title": "B09RX45W14",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-12-16T04:21:26.000Z",
+    "title": "B09RX2WQ3M",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2022-12-16T05:17:24.000Z",
+    "title": "B097XBXQ1T",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2022-12-20T03:42:33.000Z",
+    "title": "B08BYBNGMW",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2022-12-27T04:21:07.000Z",
+    "title": "B09T9D8QY7",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-01-01T04:42:59.000Z",
+    "title": "B01HNJIJ3U",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-01-03T05:08:22.000Z",
+    "title": "B09QMHZ53K",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-01-12T05:37:12.000Z",
+    "title": "B0BQVLNL73",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-01-17T04:44:15.000Z",
+    "title": "B003L77UKC",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-01-25T00:55:25.000Z",
+    "title": "B09R21YVLM",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-01-31T04:34:25.000Z",
+    "title": "B09NTK9WDQ",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-02-09T04:25:13.000Z",
+    "title": "B00PSSG4MM",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-02-15T22:06:48.000Z",
+    "title": "B01COJUEZ0",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-02-20T03:04:42.000Z",
+    "title": "B07VDJBKNJ",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-02-20T22:36:59.000Z",
+    "title": "B0B2F5J32D",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-02-21T05:09:36.000Z",
+    "title": "B08NT2VSWF",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-02-23T19:38:52.000Z",
+    "title": "B08KQ4W18H",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2023-02-24T03:57:36.000Z",
+    "title": "B08QXTPXPH",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-02-27T23:51:19.000Z",
+    "title": "B0BWMMN631",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-03-02T04:42:47.000Z",
+    "title": "B01HLY0Z0W",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-03-03T04:17:47.000Z",
+    "title": "B09NW4FN2R",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-03-07T03:39:34.000Z",
+    "title": "B07TYBQJBM",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-03-07T04:03:23.000Z",
+    "title": "B09RTYQW2S",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-03-08T06:26:27.000Z",
+    "title": "B09N6VX4K7",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-03-08T19:51:31.000Z",
+    "title": "B09JBCGQB8",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2023-03-11T22:08:16.000Z",
+    "title": "B007D1TKAU",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-03-17T02:58:53.000Z",
+    "title": "B0B3Y8DJFJ",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2023-03-18T04:26:09.000Z",
+    "title": "B006CUDDUG",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-03-25T18:14:28.000Z",
+    "title": "B07MXCRB2F",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-03-29T02:38:32.000Z",
+    "title": "B0B3989NDF",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-03-31T04:29:37.000Z",
+    "title": "B0B1Y1ZKFX",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-03-31T16:16:32.000Z",
+    "title": "B075SPBQDV",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-04-04T02:03:48.000Z",
+    "title": "B07HB5DKQX",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2023-04-09T04:09:48.000Z",
+    "title": "B004HW7DZ2",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-04-09T23:14:17.000Z",
+    "title": "B000U913EI",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-04-10T02:51:20.000Z",
+    "title": "B0B3HPSFJ7",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-04-10T23:44:25.000Z",
+    "title": "B087BQ7GK3",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-04-13T18:30:05.000Z",
+    "title": "B0B1BTJLJN",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-04-24T03:22:01.000Z",
+    "title": "B0B6Z3LN2D",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-04-28T03:38:29.000Z",
+    "title": "B0B6Z4SVTH",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-04-28T19:54:15.000Z",
+    "title": "B0C3QHMLGL",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-05-01T20:46:45.000Z",
+    "title": "B09CNFH5WG",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-05-02T01:20:28.000Z",
+    "title": "B084357H23",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-05-09T03:14:09.000Z",
+    "title": "B0BBCB6PFC",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-05-11T02:51:11.000Z",
+    "title": "B09GW3P1KJ",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-05-12T02:43:51.000Z",
+    "title": "B09XL59MJX",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-05-15T20:39:00.000Z",
+    "title": "B09Y46DSD7",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-05-16T20:44:17.000Z",
+    "title": "B08D4QJRY2",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-05-17T03:52:53.000Z",
+    "title": "B00AG8GXVQ",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-05-20T03:56:26.000Z",
+    "title": "B08PG6CKZJ",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-05-27T18:04:31.000Z",
+    "title": "B0B3Y4RYX6",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-05-27T18:07:06.000Z",
+    "title": "B098433CGQ",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-06-03T03:25:42.000Z",
+    "title": "B0B5SR4KBR",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-06-03T03:45:52.000Z",
+    "title": "B0B6JSJQLH",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-06-07T02:55:54.000Z",
+    "title": "B09XBGYWSR",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-06-08T21:37:46.000Z",
+    "title": "B000GCFX6S",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-06-14T20:07:14.000Z",
+    "title": "B0BHCXVWGT",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-06-21T17:27:26.000Z",
+    "title": "B0BHTN6TL6",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2023-06-28T04:03:45.000Z",
+    "title": "B0B7NDZNDV",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-07-05T02:07:01.000Z",
+    "title": "B016TG0SAK",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-07-05T02:16:56.000Z",
+    "title": "B09Y94K74X",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-07-16T03:20:01.000Z",
+    "title": "B07GD51NCJ",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-07-18T03:01:54.000Z",
+    "title": "B07GJBCLHN",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-07-19T02:08:55.000Z",
+    "title": "B0BH4QWM85",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-07-23T03:38:50.000Z",
+    "title": "B084G9Z5C3",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-08-05T04:45:24.000Z",
+    "title": "B0BG13PH57",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-08-09T02:25:24.000Z",
+    "title": "B0BL126WSH",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-08-11T20:36:07.000Z",
+    "title": "B08T6CL58V",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-08-19T03:37:38.000Z",
+    "title": "B0BHY38ZPH",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-08-23T03:15:38.000Z",
+    "title": "B0BGJ3W5D3",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-08-26T04:03:36.000Z",
+    "title": "B0B7NGCGHG",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-08-27T03:12:01.000Z",
+    "title": "B092T947PJ",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2023-08-28T17:49:55.000Z",
+    "title": "B093R2CP2V",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-09-02T03:43:03.000Z",
+    "title": "B0BLY7J9DC",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-09-02T03:47:20.000Z",
+    "title": "B0BBC769LV",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-09-04T16:22:06.000Z",
+    "title": "B0BKKVQPLB",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-09-06T16:52:19.000Z",
+    "title": "B0BT82YGGF",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-09-09T02:53:16.000Z",
+    "title": "B0BP2HWMP6",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-09-14T03:28:34.000Z",
+    "title": "B09721CTG1",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-09-16T03:12:16.000Z",
+    "title": "B0BTVBH6G3",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-09-22T03:14:47.000Z",
+    "title": "B0BQLKNTYR",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-09-25T02:55:55.000Z",
+    "title": "B0BJNKTFGH",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-10-03T02:42:31.000Z",
+    "title": "B0BP66G6B7",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-10-07T01:15:45.000Z",
+    "title": "B0BBC9K8C3",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-10-11T00:42:54.000Z",
+    "title": "B0CBW58P3J",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-10-11T21:15:15.000Z",
+    "title": "B09RMQJCZJ",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-10-12T16:53:35.000Z",
+    "title": "B09BV2JNWV",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-10-19T04:13:01.000Z",
+    "title": "B08SMFSLVQ",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-10-22T03:50:53.000Z",
+    "title": "B0BKH7G2X8",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-10-24T03:06:09.000Z",
+    "title": "B0BP6S1S57",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2023-11-01T00:21:48.000Z",
+    "title": "B0B9KVXCQ6",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-11-01T00:22:08.000Z",
+    "title": "B0CHWJCN94",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-11-01T03:59:16.000Z",
+    "title": "B0BQGHJM5L",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-11-01T17:38:58.000Z",
+    "title": "B07CWDMQ45",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2023-11-03T03:19:55.000Z",
+    "title": "B0BPX7SF89",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2023-11-11T03:47:51.000Z",
+    "title": "B0BR511292",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-11-22T03:30:59.000Z",
+    "title": "B09YRR8DB6",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-12-01T04:09:33.000Z",
+    "title": "B0B6B4WPSF",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2023-12-01T21:28:35.000Z",
+    "title": "B0C5LRCM2F",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2023-12-13T05:23:32.000Z",
+    "title": "B0B9SN8K6H",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2023-12-17T04:44:55.000Z",
+    "title": "B08FGV64B1",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2023-12-19T04:48:09.000Z",
+    "title": "B0B399L6KP",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-12-21T06:14:42.000Z",
+    "title": "B09Y467GZY",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-12-23T18:20:08.000Z",
+    "title": "B09S3WWY98",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2023-12-27T00:54:35.000Z",
+    "title": "B09Q2F1X14",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2023-12-29T04:53:08.000Z",
+    "title": "B003XT60E0",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2024-01-01T04:07:38.000Z",
+    "title": "B0B7R4Q5DJ",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-01-05T02:03:44.000Z",
+    "title": "B07LF64DZ2",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-01-07T21:09:52.000Z",
+    "title": "B0BST5X6GS",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-01-08T04:17:34.000Z",
+    "title": "B000JMKNV0",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2024-01-10T17:04:47.000Z",
+    "title": "B0927NRBFB",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2024-01-12T05:33:59.000Z",
+    "title": "B08TF1VTGX",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-01-15T04:16:04.000Z",
+    "title": "B07WG8L7WC",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2024-01-16T02:18:11.000Z",
+    "title": "B0BJSGV831",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2024-01-19T05:06:00.000Z",
+    "title": "B0BL6271NP",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-01-25T20:33:06.000Z",
+    "title": "B0C3C886FY",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2024-01-25T20:33:58.000Z",
+    "title": "B0C7RK8P8K",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2024-01-26T19:05:31.000Z",
+    "title": "B0C592RHNC",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2024-02-06T22:01:26.000Z",
+    "title": "B09LHBX5KV",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2024-02-08T21:24:38.000Z",
+    "title": "B0B72HGHW8",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2024-02-11T17:55:11.000Z",
+    "title": "B0BDMPQ2FC",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2024-02-13T21:40:42.000Z",
+    "title": "B0044781ZQ",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2024-02-15T02:36:01.000Z",
+    "title": "B07HDT9JFX",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-02-20T04:59:58.000Z",
+    "title": "B0CLQVQSVL",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2024-02-27T23:40:57.000Z",
+    "title": "B0C1YCKNK1",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2024-03-01T02:26:58.000Z",
+    "title": "B0C7RPT9B3",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-03-01T02:30:13.000Z",
+    "title": "B0C6KMGND1",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2024-03-01T04:19:14.000Z",
+    "title": "B0BPNP7YQB",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-03-08T22:29:59.000Z",
+    "title": "B0BJP5QFFM",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-03-18T03:52:49.000Z",
+    "title": "B0BWGKNK7G",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-03-18T04:10:16.000Z",
+    "title": "B00BUP18U0",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2024-03-19T19:54:50.000Z",
+    "title": "B008J2G5Y6",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-03-26T02:51:10.000Z",
+    "title": "B0BTZRQHJM",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2024-04-01T03:41:08.000Z",
+    "title": "B007RMYE9M",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2024-04-03T03:18:02.000Z",
+    "title": "B0BXTB6HSN",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-04-10T03:48:39.000Z",
+    "title": "B092T8QDYW",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-04-11T22:37:10.000Z",
+    "title": "B0BQGJVCMT",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2024-04-15T20:36:29.000Z",
+    "title": "B003B4IW2U",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-04-22T21:45:17.000Z",
+    "title": "B0C772ZLMQ",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-05-01T03:47:25.000Z",
+    "title": "B0C4PX8RD7",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-05-04T17:47:16.000Z",
+    "title": "B0CDKLBD2W",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2024-05-10T21:28:03.000Z",
+    "title": "B0C97G1ZR6",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-05-15T03:45:31.000Z",
+    "title": "B081914PR7",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2024-05-22T22:06:42.000Z",
+    "title": "B07QN87LQB",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-05-25T04:08:39.000Z",
+    "title": "B0CJ9TSSYB",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2024-05-30T03:47:27.000Z",
+    "title": "B0B8GZ58DK",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-05-31T04:04:00.000Z",
+    "title": "B09X34KMRM",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2024-06-06T21:55:56.000Z",
+    "title": "B0B3Y9JVMK",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-06-11T02:38:22.000Z",
+    "title": "B0CL5G23ZF",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-06-11T02:39:47.000Z",
+    "title": "B002C7Z57C",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2024-06-11T03:33:26.000Z",
+    "title": "B0CGTHLBT9",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2024-07-15T22:12:42.000Z",
+    "title": "B0CH1NHWNW",
+    "latitude": 48.8566,
+    "longitude": 2.3522
+  },
+  {
+    "start": "2024-07-18T03:31:28.000Z",
+    "title": "B0C7729CF8",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2024-07-29T03:49:26.000Z",
+    "title": "B078R46LCY",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-08-01T03:30:58.000Z",
+    "title": "B0CQ38FNR9",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-08-04T17:19:14.000Z",
+    "title": "B0CL3FMNKJ",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-09-19T23:43:23.000Z",
+    "title": "B0CQJHF3HQ",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2024-09-22T01:44:48.000Z",
+    "title": "B0CQFXKTPW",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-10-02T02:49:42.000Z",
+    "title": "B0CGZFPKTZ",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2024-10-02T20:04:59.000Z",
+    "title": "B0CQHM2KL5",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-10-09T02:25:08.000Z",
+    "title": "B0CW1J3Y5G",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  },
+  {
+    "start": "2024-11-23T04:05:49.000Z",
+    "title": "B0CDWDLCNS",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2024-12-03T04:50:07.000Z",
+    "title": "B0BZ5Y513V",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2024-12-26T05:47:01.000Z",
+    "title": "B0CN8TPKSP",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2024-12-30T20:06:47.000Z",
+    "title": "B0CZXNTCFX",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2024-12-30T20:38:23.000Z",
+    "title": "B0BQGDMFH6",
+    "latitude": 51.5074,
+    "longitude": -0.1278
+  },
+  {
+    "start": "2025-01-05T18:22:35.000Z",
+    "title": "B0CH9KQYHS",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2025-01-20T18:54:17.000Z",
+    "title": "B0CC1J32NG",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2025-01-21T04:02:10.000Z",
+    "title": "B0DMDYK6Y6",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2025-01-27T04:23:42.000Z",
+    "title": "B0BL6YQ61Y",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2025-02-05T05:29:28.000Z",
+    "title": "B000JML2Z6",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2025-02-07T05:12:19.000Z",
+    "title": "B0CQHL1XV7",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2025-02-16T04:34:09.000Z",
+    "title": "B003K15IF8",
+    "latitude": -23.5505,
+    "longitude": -46.6333
+  },
+  {
+    "start": "2025-02-19T21:32:19.000Z",
+    "title": "B081M4F8GH",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2025-04-03T02:28:14.000Z",
+    "title": "B0D57LWBM6",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2025-04-21T22:11:34.000Z",
+    "title": "B0D3CBLLPH",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  {
+    "start": "2025-05-03T20:38:42.000Z",
+    "title": "B0DLLGPNMQ",
+    "latitude": 40.7128,
+    "longitude": -74.006
+  },
+  {
+    "start": "2025-05-06T03:10:17.000Z",
+    "title": "B0DY9TZD8Z",
+    "latitude": 52.52,
+    "longitude": 13.405
+  },
+  {
+    "start": "2025-05-06T03:27:16.000Z",
+    "title": "B09SKWT6SF",
+    "latitude": -33.8688,
+    "longitude": 151.2093
+  },
+  {
+    "start": "2025-05-11T03:30:49.000Z",
+    "title": "B0CWFMT5SC",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2025-06-09T04:31:14.000Z",
+    "title": "B0D9F3KFPM",
+    "latitude": 34.0522,
+    "longitude": -118.2437
+  },
+  {
+    "start": "2025-06-19T23:18:14.000Z",
+    "title": "B0DHDF2RDL",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2025-06-23T23:53:42.000Z",
+    "title": "B0DJ7XG2MQ",
+    "latitude": 55.7558,
+    "longitude": 37.6173
+  },
+  {
+    "start": "2025-07-11T05:44:38.000Z",
+    "title": "B0DJM99D77",
+    "latitude": 35.6895,
+    "longitude": 139.6917
+  }
 ]


### PR DESCRIPTION
## Summary
- add script to generate reading location entries from Kindle sessions
- populate `src/data/kindle/locations.json` with auto-generated coordinates for mapped ASINs

## Testing
- `npm test` *(fails: 2 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68950a74f5288324b7d6e4704550a882