### PR TITLE
Reset playback when filters change in ReadingMap

### DIFF
--- a/src/components/map/ReadingMap.jsx
+++ b/src/components/map/ReadingMap.jsx
@@ -89,7 +89,7 @@ export default function ReadingMap() {
   useEffect(() => {
     setCurrentIndex(0);
     setPlaying(false);
-  }, [filtered.length]);
+  }, [filtered]);
 
   useEffect(() => {
     if (!playing) return;

--- a/src/components/map/__tests__/ReadingMap.test.jsx
+++ b/src/components/map/__tests__/ReadingMap.test.jsx
@@ -177,6 +177,35 @@ describe('ReadingMap', () => {
     vi.useRealTimers();
   });
 
+  it('resets playback when filters change without altering results', async () => {
+    const { container } = render(<ReadingMap />);
+    await waitFor(() => screen.getByTestId('map'));
+
+    const slider = screen.getByRole('slider');
+    const button = screen.getByRole('button');
+
+    fireEvent.change(slider, { target: { value: 2 } });
+    await waitFor(() =>
+      expect(screen.getAllByTestId('marker')).toHaveLength(3)
+    );
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    expect(button.textContent).toBe('Pause');
+    vi.useRealTimers();
+
+    const [startInput] = container.querySelectorAll('input[type="date"]');
+    fireEvent.change(startInput, { target: { value: '2019-01-01' } });
+
+    await waitFor(() => {
+      const updatedSlider = screen.getByRole('slider');
+      const updatedButton = screen.getByRole('button');
+      expect(updatedSlider.max).toBe('2');
+      expect(updatedSlider.value).toBe('0');
+      expect(updatedButton.textContent).toBe('Play');
+    });
+  });
+
   it('switches map modes', async () => {
     const { container } = render(<ReadingMap />);
     await waitFor(() => screen.getByTestId('map'));


### PR DESCRIPTION
## Summary
- reset playback and index whenever filter criteria change
- add regression test for playback reset when filter results remain constant

## Testing
- `npx vitest run src/components/map/__tests__/ReadingMap.test.jsx`
- `npm test` *(fails: Test timed out in 5000ms and unknown type: mouseover in GenreSankey tests)*

------
https://chatgpt.com/codex/tasks/task_e_689516f642948324af53e94ddc5b56ca