### PR TITLE
refactor: remove nested ResponsiveContainer

### DIFF
--- a/src/components/dashboard/ReadingStackSplit.tsx
+++ b/src/components/dashboard/ReadingStackSplit.tsx
@@ -7,7 +7,6 @@ import {
   ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,
-  ResponsiveContainer,
 } from "@/ui/chart";
 import { Cell, Label, type TooltipProps } from "recharts";
 import { useState } from "react";
@@ -101,8 +100,7 @@ export default function ReadingStackSplit() {
   return (
     <ChartCard title="Reading Stack Split" description="Time by device">
       <ChartContainer config={config} className="h-64 md:h-80 lg:h-96">
-        <ResponsiveContainer>
-          <PieChart>
+        <PieChart>
             <defs>
               {filtered.map((_, idx) => (
                 <linearGradient
@@ -174,8 +172,7 @@ export default function ReadingStackSplit() {
                 }}
               />
             </Pie>
-          </PieChart>
-        </ResponsiveContainer>
+        </PieChart>
       </ChartContainer>
     </ChartCard>
   );


### PR DESCRIPTION
## Summary
- avoid double ResponsiveContainer in ReadingStackSplit so ChartContainer manages responsiveness

## Testing
- `npm test` *(fails: 6 failed, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68950ec344bc8324a0225168fb545572