### PR TITLE
Use live Kindle data for Kindle charts

### DIFF
--- a/src/components/network/BookChordDiagram.jsx
+++ b/src/components/network/BookChordDiagram.jsx
@@ -3,10 +3,9 @@ import { select } from 'd3-selection';
 import { chord, ribbon } from 'd3-chord';
 import { arc } from 'd3-shape';
 import { scaleOrdinal } from 'd3-scale';
-import graphData from '@/data/kindle/book-graph.json';
 import buildChordMatrix from '@/services/chordMatrix.js';
 
-export default function BookChordDiagram({ data = graphData }) {
+export default function BookChordDiagram({ data = { nodes: [], links: [] } }) {
   const svgRef = useRef(null);
   const containerRef = useRef(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });

--- a/src/components/network/BookNetwork.jsx
+++ b/src/components/network/BookNetwork.jsx
@@ -5,9 +5,7 @@ import { forceSimulation, forceLink, forceManyBody, forceCenter } from 'd3-force
 import { drag } from 'd3-drag';
 import { scaleOrdinal, scaleLinear } from 'd3-scale';
 import { zoom } from 'd3-zoom';
-import graphData from '@/data/kindle/book-graph.json';
-
-export default function BookNetwork({ data = graphData }) {
+export default function BookNetwork({ data = { nodes: [], links: [] } }) {
   const svgRef = useRef(null);
   const containerRef = useRef(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });

--- a/src/hooks/__tests__/useDailyReading.test.ts
+++ b/src/hooks/__tests__/useDailyReading.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import useDailyReading from '../useDailyReading'
 
 const sample = [
@@ -9,6 +9,14 @@ const sample = [
 ]
 
 describe('useDailyReading', () => {
+  const originalFetch = global.fetch
+  beforeEach(() => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('no server'))
+  })
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
   it('fetches daily reading data', async () => {
     const { result } = renderHook(() => useDailyReading())
     await waitFor(() => expect(result.current.isLoading).toBe(false))

--- a/src/pages/charts/BookNetwork.jsx
+++ b/src/pages/charts/BookNetwork.jsx
@@ -8,9 +8,26 @@ export default function BookNetworkPage() {
   const [view, setView] = useState('network');
 
   useEffect(() => {
-    import('@/data/kindle/book-graph.json').then((mod) => {
-      setData(mod.default);
-    });
+    let active = true;
+    const load = async () => {
+      try {
+        const res = await fetch('/api/kindle/book-graph');
+        if (!res.ok) throw new Error('Failed to fetch book graph');
+        const json = await res.json();
+        if (active) setData(json);
+      } catch {
+        try {
+          const mod = await import('@/data/kindle/book-graph.json');
+          if (active) setData(mod.default);
+        } catch {
+          // ignore
+        }
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
   }, []);
 
   const toggleView = () => {

--- a/src/pages/charts/GenreSunburst.jsx
+++ b/src/pages/charts/GenreSunburst.jsx
@@ -17,20 +17,20 @@ export default function GenreSunburstPage() {
     let isMounted = true;
     const loadData = async () => {
       try {
-        const module = await import('@/data/kindle/genre-hierarchy.json');
-        const hierarchy = module.default || module;
-        if (isMounted) {
-          setData(hierarchy);
-        }
+        const res = await fetch('/api/kindle/genre-hierarchy');
+        if (!res.ok) throw new Error('Failed to fetch genre data');
+        const hierarchy = await res.json();
+        if (isMounted) setData(hierarchy);
       } catch (err) {
-        console.error(err);
-        if (isMounted) {
-          setError('Failed to load genre data');
+        try {
+          const module = await import('@/data/kindle/genre-hierarchy.json');
+          const hierarchy = module.default || module;
+          if (isMounted) setData(hierarchy);
+        } catch {
+          if (isMounted) setError('Failed to load genre data');
         }
       } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
+        if (isMounted) setIsLoading(false);
       }
     };
     loadData();

--- a/src/pages/charts/__tests__/BookNetworkPage.test.jsx
+++ b/src/pages/charts/__tests__/BookNetworkPage.test.jsx
@@ -13,6 +13,20 @@ vi.mock('@/components/network/BookChordDiagram.jsx', () => ({
   default: () => <div data-testid="book-chord" />,
 }));
 
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ nodes: [], links: [] }),
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
 describe('BookNetworkPage', () => {
   it('displays a skeleton before data resolves', async () => {
     render(<BookNetworkPage />);

--- a/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
+++ b/src/pages/charts/__tests__/GenreSunburstPage.test.jsx
@@ -21,15 +21,27 @@ vi.mock('@/components/genre/GenreIcicle.jsx', () => ({
   ),
 }));
 
-vi.mock('@/data/kindle/genre-hierarchy.json', () => ({
-  default: {
-    name: 'root',
-    children: [
-      { name: 'Fiction', children: [{ name: 'Book A', value: 1 }] },
-      { name: 'Unclassified', children: [{ name: 'Book B', value: 2 }] },
-    ],
-  },
-}), { virtual: true });
+const hierarchy = {
+  name: 'root',
+  children: [
+    { name: 'Fiction', children: [{ name: 'Book A', value: 1 }] },
+    { name: 'Unclassified', children: [{ name: 'Book B', value: 2 }] },
+  ],
+};
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(hierarchy),
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
 
 import GenreSunburstPage from '../GenreSunburst.jsx';
 


### PR DESCRIPTION
## Summary
- fetch genre hierarchy, book graph, and genre transitions from `/api/kindle` with JSON fallbacks
- load highlight expansions and daily reading stats from live Kindle exports
- expand API to source reading speed and locations from Kindle data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68951d9a1ed88324b116e16e95bfba04