### PR TITLE
Fix constants export for genre charts

### DIFF
--- a/src/config/constants.cjs
+++ b/src/config/constants.cjs
@@ -1,0 +1,4 @@
+const UNCLASSIFIED_GENRE = 'Unclassified';
+
+module.exports = { UNCLASSIFIED_GENRE };
+

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,2 +1,4 @@
-const UNCLASSIFIED_GENRE = 'Unclassified';
-module.exports = { UNCLASSIFIED_GENRE };
+export const UNCLASSIFIED_GENRE = 'Unclassified';
+
+export default { UNCLASSIFIED_GENRE };
+

--- a/src/services/__tests__/genreHierarchy.test.js
+++ b/src/services/__tests__/genreHierarchy.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildGenreHierarchy } from '../genreHierarchy';
-const { UNCLASSIFIED_GENRE } = require('../../config/constants');
+const { UNCLASSIFIED_GENRE } = require('../../config/constants.cjs');
 
 describe('buildGenreHierarchy', () => {
   it('builds nested tree from flat records', () => {

--- a/src/services/genreHierarchy.js
+++ b/src/services/genreHierarchy.js
@@ -2,7 +2,7 @@ const asinTitleMap = require('../data/kindle/asin-title-map.json');
 
 const subgenreOverrides = require('../data/kindle/subgenre-overrides.json');
 const asinSubgenreMap = require('../data/kindle/asin-subgenre-map.json');
-const { UNCLASSIFIED_GENRE } = require('../config/constants');
+const { UNCLASSIFIED_GENRE } = require('../config/constants.cjs');
 
 
 function buildGenreHierarchy(sessions, genres = [], authors = [], tags = []) {


### PR DESCRIPTION
## Summary
- use ES module export for UNCLASSIFIED_GENRE and add CommonJS mirror
- update genre hierarchy service to consume the CJS constants

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68951fac0e6c83248e22ce423dfa4e22