### PR TITLE
chore: proxy api requests during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,13 @@ Unit tests (Vitest + Testing Library) should live alongside components in a `__t
 ## Development
 
 ```bash
-npm run dev
+npm run server    # start Express API on :3000
+npm run dev       # start Vite dev server on :5173
 npm run build
 npm test
 ```
+
+The Vite dev server is configured to proxy `/api` requests to the Express backend. With both commands running, pages like `/dashboard/charts/book-progress-spiral` can fetch Kindle data during local development.
 
 ## Spotify integration
 The Run Soundtrack card uses the Spotify Web API. Set the following environment variables so the helpers can obtain an access token:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,12 @@ export default defineConfig({
       events: 'events',
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- proxy `/api` requests to local Express server in Vite dev setup
- document starting API server and dev proxy in README

## Testing
- `npm test -- --run` *(fails: ReadingSpeedViolin tests unable to find "Smoothing" label)*

------
https://chatgpt.com/codex/tasks/task_e_6895285646988324b50dfb7f434723b3