### PR TITLE
Fix BookNetwork container height

### DIFF
--- a/src/components/network/BookNetwork.jsx
+++ b/src/components/network/BookNetwork.jsx
@@ -371,7 +371,7 @@ export default function BookNetwork({ data = { nodes: [], links: [] } }) {
           </div>
         )}
       </div>
-      <div ref={containerRef}>
+      <div ref={containerRef} className="h-96 w-full">
         <svg ref={svgRef} width={dimensions.width} height={dimensions.height}></svg>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- give BookNetwork svg container a fixed height so ResizeObserver measures dimensions

## Testing
- `npx vitest run` *(fails: Unable to find a label with the text of: Smoothing)*

------
https://chatgpt.com/codex/tasks/task_e_68952cc488c0832495ada194bff48ce7