### PR TITLE
fix: load book covers via title endpoint

### DIFF
--- a/src/components/bookshelf/BookshelfByYear.tsx
+++ b/src/components/bookshelf/BookshelfByYear.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import type { KindleSession } from "@/lib/api";
 
 interface BookshelfByYearProps {
@@ -15,37 +15,23 @@ interface BookInfo {
 }
 
 function BookCover({ title }: { title: string }) {
-  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const url = `https://covers.openlibrary.org/b/title/${encodeURIComponent(
+    title
+  )}-M.jpg?default=false`;
 
-  useEffect(() => {
-    const controller = new AbortController();
-    async function fetchCover() {
-      try {
-        const res = await fetch(
-          `https://openlibrary.org/search.json?title=${encodeURIComponent(title)}&limit=1`,
-          { signal: controller.signal }
-        );
-        const data = await res.json();
-        const coverId = data?.docs?.[0]?.cover_i;
-        if (coverId) {
-          setUrl(`https://covers.openlibrary.org/b/id/${coverId}-M.jpg`);
-        }
-      } catch {
-        // ignore
-      }
-    }
-    fetchCover();
-    return () => {
-      controller.abort();
-    };
-  }, [title]);
-
-  return url ? (
-    <img src={url} alt={title} className="w-full h-full object-cover" />
-  ) : (
+  return failed ? (
     <div className="w-full h-full bg-muted flex items-center justify-center text-[10px] p-1 text-center">
       {title}
     </div>
+  ) : (
+    <img
+      src={url}
+      alt={title}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className="w-full h-full object-cover"
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- use Open Library title-based cover endpoint instead of two-step search
- gracefully fall back to title text if cover fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689534a5a5cc8324bdbbebc3c251d23f