### PR TITLE
Map ASINs to book titles for Kindle sessions

### DIFF
--- a/src/lib/__tests__/kindleSessions.test.ts
+++ b/src/lib/__tests__/kindleSessions.test.ts
@@ -8,16 +8,28 @@ afterEach(() => {
 })
 
 describe('getKindleSessions', () => {
-  it('returns sessions on successful fetch', async () => {
+  it('maps titles on successful fetch', async () => {
     const sessions = [
-      { start: '2025-07-30T10:00:00Z', end: '2025-07-30T10:10:00Z', asin: 'A', title: 'Book A', duration: 10, highlights: 0 },
+      {
+        start: '2025-07-30T10:00:00Z',
+        end: '2025-07-30T10:10:00Z',
+        asin: 'B01A4AXM3W',
+        title: 'B01A4AXM3W',
+        duration: 10,
+        highlights: 0,
+      },
     ]
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(sessions),
     }))
     const result = await getKindleSessions()
-    expect(result).toEqual(sessions)
+    expect(result).toEqual([
+      {
+        ...sessions[0],
+        title: (asinTitleMap as Record<string, string>)[sessions[0].asin],
+      },
+    ])
   })
 
   it('returns local data when fetch rejects', async () => {


### PR DESCRIPTION
## Summary
- map Kindle session ASINs to real book titles even when sessions come from the network
- update tests for Kindle session mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689536e659f883249ddd8a9fee5a5b8d