### PR TITLE
Map ASINs to titles across services

### DIFF
--- a/server/services/kindleService.js
+++ b/server/services/kindleService.js
@@ -9,6 +9,7 @@ const { buildGenreHierarchy } = require('../../src/services/genreHierarchy');
 const { calculateGenreTransitions } = require('../../src/services/genreTransitions');
 const { buildHighlightIndex, getExpansions } = require('../../src/services/highlightIndex');
 const { buildBookGraph } = require('../../src/services/bookGraph');
+const asinTitleMap = require('../../src/data/kindle/asin-title-map.json');
 
 function parseCsv(filePath) {
   return new Promise((resolve, reject) => {
@@ -299,7 +300,7 @@ async function getBookGraph() {
     if (!books.has(asin)) {
       books.set(asin, {
         asin,
-        title: o['Product Name'] || asin,
+        title: asinTitleMap[asin] || o['Product Name'] || asin,
         authors: [],
         tags: [],
         highlights: [],

--- a/src/services/__tests__/readingSpeed.test.js
+++ b/src/services/__tests__/readingSpeed.test.js
@@ -20,12 +20,14 @@ describe('calculateReadingSpeeds', () => {
       {
         start: '2024-01-01T08:00:00Z',
         asin: undefined,
+        title: undefined,
         wpm: 2500 / 10, // 10 pages * 250 words / 10 minutes
         period: 'morning',
       },
       {
         start: '2024-01-01T20:00:00Z',
         asin: undefined,
+        title: undefined,
         wpm: 1250 / 5, // 5 pages * 250 words / 5 minutes
         period: 'evening',
       },

--- a/src/services/readingSessions.js
+++ b/src/services/readingSessions.js
@@ -1,3 +1,5 @@
+const asinTitleMap = require('../data/kindle/asin-title-map.json');
+
 function aggregateReadingSessions(sessions, highlights = [], orders = []) {
   const titleByAsin = {};
   for (const o of orders) {
@@ -32,7 +34,7 @@ function aggregateReadingSessions(sessions, highlights = [], orders = []) {
           ? s.end_timestamp
           : s.start_timestamp;
       const asin = s.ASIN;
-      const title = titleByAsin[asin] || asin;
+      const title = asinTitleMap[asin] || titleByAsin[asin] || asin;
       const duration = Number(s.total_reading_millis || 0) / 60000;
       const list = highlightsByAsin[asin] || [];
       const highlightsCount = list.filter((ts) => ts >= start && ts <= end).length;

--- a/src/services/readingSpeed.js
+++ b/src/services/readingSpeed.js
@@ -1,5 +1,6 @@
 const MAX_WPM = 2000;
 const MIN_DURATION_MILLIS = 60 * 1000;
+const asinTitleMap = require('../data/kindle/asin-title-map.json');
 
 function calculateReadingSpeeds(sessions) {
   return sessions
@@ -19,9 +20,11 @@ function calculateReadingSpeeds(sessions) {
       const wpm = minutes > 0 ? Math.min(words / minutes, MAX_WPM) : 0;
       const hour = new Date(start).getHours();
       const period = hour < 12 ? 'morning' : 'evening';
+      const asin = s.ASIN;
       return {
         start,
-        asin: s.ASIN,
+        asin,
+        title: asinTitleMap[asin] || asin,
         wpm,
         period,
       };


### PR DESCRIPTION
## Summary
- map ASINs to titles when aggregating Kindle sessions
- include book titles with reading speed data
- apply title mapping to server book graph builder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68953769f1b48324900fdaea525e1ad1