### PR TITLE
fix: stabilize heatmap hooks and unique keys

### DIFF
--- a/src/components/genre/GenreSunburst.jsx
+++ b/src/components/genre/GenreSunburst.jsx
@@ -115,7 +115,7 @@ export default function GenreSunburst({ data }) {
     <div>
       <div>
         {ancestors.map((node, i) => (
-          <span key={node.data.name}>
+          <span key={`${node.data.name}-${i}`}>
             {i > 0 && ' / '}
             <button
               type="button"


### PR DESCRIPTION
## Summary
- ensure ancestor breadcrumb items have unique keys in GenreSunburst
- call hooks consistently in CalendarHeatmap and reset selected year on data change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68955a70866883248c708a87f1cd6888