### PR TITLE
Add session tooltip to BookProgressSpiral

### DIFF
--- a/src/components/ui/cursor-tooltip.tsx
+++ b/src/components/ui/cursor-tooltip.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface CursorTooltipProps {
+  x: number;
+  y: number;
+  visible: boolean;
+  children: React.ReactNode;
+}
+
+export default function CursorTooltip({ x, y, visible, children }: CursorTooltipProps) {
+  if (!visible) return null;
+  return (
+    <div
+      role="tooltip"
+      className="pointer-events-none fixed z-50 bg-gray-700 text-white text-xs px-2 py-1 rounded shadow"
+      style={{ left: x + 8, top: y + 8 }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/pages/charts/BookProgressSpiral.jsx
+++ b/src/pages/charts/BookProgressSpiral.jsx
@@ -1,13 +1,20 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import { lineRadial, curveCatmullRom } from 'd3-shape';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import useReadingSessions from '@/hooks/useReadingSessions';
+import CursorTooltip from '@/components/ui/cursor-tooltip';
 
 export default function BookProgressSpiral() {
   const { data: sessions, error, isLoading } = useReadingSessions();
   const svgRef = useRef(null);
+  const [tooltip, setTooltip] = useState({
+    visible: false,
+    x: 0,
+    y: 0,
+    session: null,
+  });
 
   const books = useMemo(() => {
     if (!sessions) return [];
@@ -55,21 +62,54 @@ export default function BookProgressSpiral() {
       const start = new Date(arr[0].start);
       const totalDuration = arr.reduce((sum, d) => sum + d.duration, 0);
       let cumulative = 0;
+      let prevPoint = [0, radius(0)];
 
-      const points = arr.map((s) => {
+      arr.forEach((s) => {
         cumulative += s.duration;
         const angle = (2 * Math.PI * cumulative) / totalDuration;
         const r = radius(new Date(s.start) - start);
-        return [angle, r];
-      });
+        const point = [angle, r];
 
-      g
-        .append('path')
-        .attr('d', line(points))
-        .attr('fill', 'none')
-        .attr('stroke', color(title))
-        .attr('stroke-width', 1.5)
-        .attr('opacity', 0.8);
+        g
+          .append('path')
+          .datum({ ...s, title })
+          .attr('d', line([prevPoint, point]))
+          .attr('fill', 'none')
+          .attr('stroke', color(title))
+          .attr('stroke-width', 1.5)
+          .attr('opacity', 0.8)
+          .attr('tabindex', 0)
+          .attr(
+            'aria-label',
+            `${title} session on ${new Date(s.start).toLocaleDateString()} for ${s.duration.toFixed(
+              1,
+            )} min`,
+          )
+          .on('mouseover', (event, d) => {
+            setTooltip({
+              visible: true,
+              x: event.clientX,
+              y: event.clientY,
+              session: d,
+            });
+          })
+          .on('mousemove', (event) => {
+            setTooltip((t) => ({ ...t, x: event.clientX, y: event.clientY }));
+          })
+          .on('mouseout', () => setTooltip((t) => ({ ...t, visible: false })))
+          .on('focus', function (event, d) {
+            const rect = this.getBoundingClientRect();
+            setTooltip({
+              visible: true,
+              x: rect.left + rect.width / 2,
+              y: rect.top,
+              session: d,
+            });
+          })
+          .on('blur', () => setTooltip((t) => ({ ...t, visible: false })));
+
+        prevPoint = point;
+      });
     });
   }, [books, color]);
 
@@ -86,8 +126,21 @@ export default function BookProgressSpiral() {
         different book.
       </p>
       {books.length > 0 ? (
-        <>
+        <> 
           <svg ref={svgRef} className="w-full max-w-[800px] h-[800px]" />
+          <CursorTooltip
+            x={tooltip.x}
+            y={tooltip.y}
+            visible={tooltip.visible}
+          >
+            {tooltip.session && (
+              <div className="space-y-0.5">
+                <div className="font-semibold">{tooltip.session.title}</div>
+                <div>{new Date(tooltip.session.start).toLocaleDateString()}</div>
+                <div>{tooltip.session.duration.toFixed(1)} min</div>
+              </div>
+            )}
+          </CursorTooltip>
           <div className="mt-4 space-y-1">
             {books.map(([title]) => (
               <div key={title} className="flex items-center text-sm">


### PR DESCRIPTION
## Summary
- show reading session details on hover/focus
- add reusable cursor-positioned tooltip component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68955aa640c48324afc24792b2523a58